### PR TITLE
Change JobHost contract for async support.

### DIFF
--- a/src/Microsoft.Azure.Jobs.Host/WebjobsShutdownWatcher.cs
+++ b/src/Microsoft.Azure.Jobs.Host/WebjobsShutdownWatcher.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Azure.Jobs
     public sealed class WebJobsShutdownWatcher : IDisposable
     {
         private readonly string _shutdownFile;
+        private readonly bool _ownsCancellationTokenSource;
 
         private CancellationTokenSource _cts;
         private FileSystemWatcher _watcher;
@@ -21,6 +22,11 @@ namespace Microsoft.Azure.Jobs
         /// Begin watching for a shutdown notification from Antares.
         /// </summary>
         public WebJobsShutdownWatcher()
+            : this(new CancellationTokenSource(), ownsCancellationTokenSource: true)
+        {
+        }
+
+        private WebJobsShutdownWatcher(CancellationTokenSource cancellationTokenSource, bool ownsCancellationTokenSource)
         {
             // http://blog.amitapple.com/post/2014/05/webjobs-graceful-shutdown/#.U3aIXRFOVaQ
             // Antares will set this file to signify shutdown
@@ -40,7 +46,7 @@ namespace Microsoft.Azure.Jobs
                 // the directory name does not exist
                 _watcher = new FileSystemWatcher(directoryName);
             }
-            catch(ArgumentException)
+            catch (ArgumentException)
             {
                 // The path is invalid
                 return;
@@ -52,7 +58,8 @@ namespace Microsoft.Azure.Jobs
             _watcher.IncludeSubdirectories = false;
             _watcher.EnableRaisingEvents = true;
 
-            _cts = new CancellationTokenSource();
+            _cts = cancellationTokenSource;
+            _ownsCancellationTokenSource = ownsCancellationTokenSource;
         }
 
         private void OnChanged(object sender, FileSystemEventArgs e)
@@ -88,7 +95,7 @@ namespace Microsoft.Azure.Jobs
             {
                 CancellationTokenSource cts = _cts;
 
-                if (cts != null)
+                if (cts != null && _ownsCancellationTokenSource)
                 {
                     // Null out the field to prevent a race condition in OnChanged above.
                     _cts = null;
@@ -98,6 +105,20 @@ namespace Microsoft.Azure.Jobs
                 _watcher.Dispose();
                 _watcher = null;
             }
+        }
+
+        internal static WebJobsShutdownWatcher Create(CancellationTokenSource cancellationTokenSource)
+        {
+            WebJobsShutdownWatcher watcher =
+                new WebJobsShutdownWatcher(cancellationTokenSource, ownsCancellationTokenSource: false);
+
+            if (watcher._watcher == null)
+            {
+                watcher.Dispose();
+                return null;
+            }
+
+            return watcher;
         }
     }
 }

--- a/test/Microsoft.Azure.Jobs.Host.EndToEndTests/AzureStorageEndToEndTests.cs
+++ b/test/Microsoft.Azure.Jobs.Host.EndToEndTests/AzureStorageEndToEndTests.cs
@@ -156,12 +156,9 @@ namespace Microsoft.Azure.Jobs.Host.EndToEndTests
             // The jobs host is started
             JobHost host = new JobHost(hostConfig);
 
-            CancellationTokenSource tokenSource = new CancellationTokenSource();
-
             _functionChainWaitHandle = new ManualResetEvent(initialState: false);
 
-            Thread hostThread = new Thread(() => host.RunAndBlock(tokenSource.Token));
-            hostThread.Start();
+            host.Start();
 
             if (!uploadBlobBeforeHostStart)
             {
@@ -172,8 +169,7 @@ namespace Microsoft.Azure.Jobs.Host.EndToEndTests
             bool signaled = _functionChainWaitHandle.WaitOne(15 * 60 * 1000);
 
             // Stop the host and wait for it to finish
-            tokenSource.Cancel();
-            hostThread.Join();
+            host.Stop();
 
             Assert.True(signaled);
 

--- a/test/Microsoft.Azure.Jobs.Host.EndToEndTests/LeaseExpirationTests.cs
+++ b/test/Microsoft.Azure.Jobs.Host.EndToEndTests/LeaseExpirationTests.cs
@@ -74,9 +74,10 @@ namespace Microsoft.Azure.Jobs.Host.EndToEndTests
                 queue.AddMessage(new CloudQueueMessage("Test"));
 
                 _tokenSource = new CancellationTokenSource();
-
                 JobHost host = new JobHost(hostConfig);
-                host.RunAndBlock(_tokenSource.Token);
+
+                _tokenSource.Token.Register(host.Stop);
+                host.RunAndBlock();
 
                 Assert.False(_messageFoundAgain);
             }

--- a/test/Microsoft.Azure.Jobs.Host.EndToEndTests/ServiceBusEndToEndTests.cs
+++ b/test/Microsoft.Azure.Jobs.Host.EndToEndTests/ServiceBusEndToEndTests.cs
@@ -128,21 +128,17 @@ namespace Microsoft.Azure.Jobs.Host.EndToEndTests
 
             JobHost host = new JobHost(config);
 
-            CancellationTokenSource tokenSource = new CancellationTokenSource();
-
             _topicSubscriptionCalled1 = new ManualResetEvent(initialState: false);
             _topicSubscriptionCalled2 = new ManualResetEvent(initialState: false);
 
-            Thread hostThread = new Thread(() => host.RunAndBlock(tokenSource.Token));
-            hostThread.Start();
+            host.Start();
 
             bool signaled = WaitHandle.WaitAll(
                 new WaitHandle[] { _topicSubscriptionCalled1, _topicSubscriptionCalled2 },
                 2 * 60 * 1000);
 
             // Wait for the host to terminate
-            tokenSource.Cancel();
-            hostThread.Join();
+            host.Stop();
 
             Assert.True(signaled);
 

--- a/test/Microsoft.Azure.Jobs.Host.TestCommon/TestJobHost.cs
+++ b/test/Microsoft.Azure.Jobs.Host.TestCommon/TestJobHost.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.WindowsAzure.Storage;
 
 namespace Microsoft.Azure.Jobs.Host.TestCommon
@@ -49,10 +49,10 @@ namespace Microsoft.Azure.Jobs.Host.TestCommon
             Host.Call(methodInfo, arguments);
         }
 
-        public void Call(string methodName, object arguments, CancellationToken cancellationToken)
+        public Task CallAsync(string methodName, object arguments, CancellationToken cancellationToken)
         {
             var methodInfo = typeof(T).GetMethod(methodName);
-            Host.Call(methodInfo, arguments, cancellationToken);
+            return Host.CallAsync(methodInfo, arguments, cancellationToken);
         }
     }  
 }

--- a/test/Microsoft.Azure.Jobs.Host.UnitTests/JobHostTests.cs
+++ b/test/Microsoft.Azure.Jobs.Host.UnitTests/JobHostTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.Jobs.Host.UnitTests
         }
 
         [Fact]
-        public void CallWithCancellationToken_PassesCancellationTokenToMethod()
+        public void CallAsyncWithCancellationToken_PassesCancellationTokenToMethod()
         {
             // Arrange
             ProgramWithCancellationToken.Cleanup();
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.Jobs.Host.UnitTests
                 ProgramWithCancellationToken.CancellationTokenSource = source;
 
                 // Act
-                host.Call("BindCancellationToken", null, source.Token);
+                host.CallAsync("BindCancellationToken", null, source.Token).Wait();
 
                 // Assert
                 Assert.True(ProgramWithCancellationToken.IsCancellationRequested);
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.Jobs.Host.UnitTests
         }
 
         [Fact]
-        public void CallWithCancellationToken_PassesCancellationTokenToMethodViaIBinder()
+        public void CallAsyncWithCancellationToken_PassesCancellationTokenToMethodViaIBinder()
         {
             // Arrange
             ProgramWithCancellationToken.Cleanup();
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Jobs.Host.UnitTests
                 ProgramWithCancellationToken.CancellationTokenSource = source;
 
                 // Act
-                host.Call("BindCancellationTokenViaIBinder", null, source.Token);
+                host.CallAsync("BindCancellationTokenViaIBinder", null, source.Token).Wait();
 
                 // Assert
                 Assert.True(ProgramWithCancellationToken.IsCancellationRequested);


### PR DESCRIPTION
Add methods such as StartAsync, StopAsync and CallAsync.
For now, implementations are still synchronous.
