### PR TITLE
Dashboard indexer optimizations

### DIFF
--- a/src/Microsoft.Azure.Jobs.Protocols/PersistentQueueMessage.cs
+++ b/src/Microsoft.Azure.Jobs.Protocols/PersistentQueueMessage.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.WindowsAzure.Storage.Blob;
 using Newtonsoft.Json;
 
 #if PUBLICPROTOCOL
@@ -21,6 +22,14 @@ namespace Microsoft.Azure.Jobs.Host.Protocols
     {
         /// <summary>Gets or sets the message type.</summary>
         public string Type { get; set; }
+
+        /// <summary>Gets or sets the blob object.</summary>
+        [JsonIgnore]
+        internal ICloudBlob Blob { get; set; }
+
+        /// <summary>Gets or sets the blob text.</summary>
+        [JsonIgnore]
+        internal string BlobText { get; set; }
 
         /// <summary>Gets or sets the time the message was enqueued.</summary>
         [JsonIgnore]

--- a/src/Microsoft.Azure.Jobs.Protocols/PersistentQueueReader.cs
+++ b/src/Microsoft.Azure.Jobs.Protocols/PersistentQueueReader.cs
@@ -3,9 +3,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Threading;
 #if PUBLICPROTOCOL
 using Microsoft.Azure.Jobs.Storage;
 #else
@@ -36,6 +38,9 @@ namespace Microsoft.Azure.Jobs.Host.Protocols
         private readonly CloudBlobContainer _outputContainer;
         private readonly CloudBlobContainer _archiveContainer;
 
+        private ConcurrentQueue<ICloudBlob> _outputBlobs = new ConcurrentQueue<ICloudBlob>();
+        private int _updating;
+
         /// <summary>Initializes a new instance of the <see cref="PersistentQueueReader{T}"/> class.</summary>
         /// <param name="client">
         /// A blob client for the storage account into which host output messages are written.
@@ -62,27 +67,40 @@ namespace Microsoft.Azure.Jobs.Host.Protocols
         {
             ICloudBlob possibleNextItem;
             T nextItem = null;
+            DateTimeOffset createdOn;
+
+            if (_outputBlobs.Count == 0 && Interlocked.CompareExchange(ref _updating, 1, 0) == 0)
+            {
+                try
+                {
+                    EnqueueNextVisibleItems(_outputBlobs);
+                }
+                finally
+                {
+                    Interlocked.Exchange(ref _updating, 0);
+                }
+            }
 
             // Keep racing to take ownership of the next visible item until that succeeds or there are no more left.
-            do
+            while (_outputBlobs.TryDequeue(out possibleNextItem))
             {
-                possibleNextItem = GetNextVisibleItem();
-
                 // There two reasons to keep racing:
                 // 1. We tried to mark the item as invisible, and failed (409, someone else won the race)
                 // 2. We then tried to download the item and failed (404, someone else finished processing an item, even
                 // though we owned it).
-            } while (possibleNextItem != null && (!TryMakeItemInvisible(possibleNextItem)
-                || !TryDownloadItem(possibleNextItem, out nextItem)));
+                if (TryMakeItemInvisible(possibleNextItem, out createdOn) && TryDownloadItem(possibleNextItem, createdOn, out nextItem))
+                {
+                    break;
+                }
+            }
 
             return nextItem;
         }
 
-        private ICloudBlob GetNextVisibleItem()
+        private void EnqueueNextVisibleItems(ConcurrentQueue<ICloudBlob> results)
         {
             BlobContinuationToken currentToken = null;
             BlobResultSegment segment;
-            ICloudBlob nextVisibleItem = null;
 
             do
             {
@@ -90,14 +108,22 @@ namespace Microsoft.Azure.Jobs.Host.Protocols
 
                 if (segment == null)
                 {
-                    return null;
+                    return;
                 }
 
                 currentToken = segment.ContinuationToken;
-                nextVisibleItem = GetNextVisibleItem(segment.Results);
-            } while (nextVisibleItem == null && currentToken != null);
 
-            return nextVisibleItem;
+                if (segment.Results != null)
+                {
+                    foreach (var blob in segment.Results.OfType<ICloudBlob>())
+                    {
+                        if (!blob.Metadata.ContainsKey(NextVisibleTimeKey) || IsInPast(blob.Metadata[NextVisibleTimeKey]))
+                        {
+                            results.Enqueue(blob);
+                        }
+                    }
+                }
+            } while (results.Count == 0 && currentToken != null);
         }
 
         private BlobResultSegment GetSegment(BlobContinuationToken currentToken)
@@ -127,17 +153,6 @@ namespace Microsoft.Azure.Jobs.Host.Protocols
             }
         }
 
-        private ICloudBlob GetNextVisibleItem(IEnumerable<IListBlobItem> results)
-        {
-            if (results == null)
-            {
-                return null;
-            }
-
-            return results.OfType<ICloudBlob>().FirstOrDefault(b => !b.Metadata.ContainsKey(NextVisibleTimeKey)
-                || IsInPast(b.Metadata[NextVisibleTimeKey]));
-        }
-
         private static bool IsInPast(string nextVisibleTimeValue)
         {
             DateTimeOffset nextVisibleTime;
@@ -152,7 +167,7 @@ namespace Microsoft.Azure.Jobs.Host.Protocols
             return DateTimeOffset.UtcNow > nextVisibleTime;
         }
 
-        private static bool TryMakeItemInvisible(ICloudBlob item)
+        private static bool TryMakeItemInvisible(ICloudBlob item, out DateTimeOffset createdOn)
         {
             // After this window expires, others may attempt to process the item.
             const double processingWindowInMinutes = 5;
@@ -160,9 +175,13 @@ namespace Microsoft.Azure.Jobs.Host.Protocols
             item.Metadata[NextVisibleTimeKey] =
                 DateTimeOffset.UtcNow.AddMinutes(processingWindowInMinutes).ToString("o", CultureInfo.InvariantCulture);
 
-            if (!item.Metadata.ContainsKey(CreatedKey))
+            if (item.Metadata.ContainsKey(CreatedKey))
             {
-                item.Metadata.Add(CreatedKey, item.Properties.LastModified.GetValueOrDefault(DateTimeOffset.UtcNow).ToString("o", CultureInfo.InvariantCulture));
+                createdOn = GetCreatedOn(item);
+            }
+            else{
+                createdOn = item.Properties.LastModified.GetValueOrDefault(DateTimeOffset.UtcNow);
+                item.Metadata.Add(CreatedKey, createdOn.ToString("o", CultureInfo.InvariantCulture));
             }
 
             try
@@ -183,7 +202,7 @@ namespace Microsoft.Azure.Jobs.Host.Protocols
             }
         }
 
-        private static bool TryDownloadItem(ICloudBlob possibleNextItem, out T nextItem)
+        private static bool TryDownloadItem(ICloudBlob possibleNextItem, DateTimeOffset createdOn, out T nextItem)
         {
             string contents;
 
@@ -213,8 +232,11 @@ namespace Microsoft.Azure.Jobs.Host.Protocols
             }
 
             nextItem = JsonConvert.DeserializeObject<T>(contents, JsonSerialization.Settings);
-            nextItem.EnqueuedOn = GetCreatedOn(possibleNextItem);
+            nextItem.Blob = possibleNextItem;
+            nextItem.BlobText = contents;
+            nextItem.EnqueuedOn = createdOn;
             nextItem.PopReceipt = possibleNextItem.Name;
+
             return true;
         }
 
@@ -246,40 +268,18 @@ namespace Microsoft.Azure.Jobs.Host.Protocols
         /// <inheritdoc />
         public void Delete(T message)
         {
-            string blobName = message.PopReceipt;
-            CloudBlockBlob outputBlob = _outputContainer.GetBlockBlobReference(message.PopReceipt);
-            Stream outputStream;
-
-            try
-            {
-                outputStream = outputBlob.OpenRead();
-            }
-            catch (StorageException exception)
-            {
-                if (!exception.IsNotFound())
-                {
-                    throw;
-                }
-                else
-                {
-                    // The output blob no longer exists; someone else finished processing it.
-                    return;
-                }
-            }
-
-            // Before archiving the blob, remove the metadata containing the processing virtual lock.
-            // Calling SetMetadata afterwards is not required since we're doing a client-side blob copy.
-            outputBlob.Metadata.RemoveIfContainsKey(NextVisibleTimeKey);
+            ICloudBlob outputBlob = message.Blob;
 
             // Do a client-side blob copy. Note that StartCopyFromBlob is another option, but that would require polling to
             // wait for completion.
             CloudBlockBlob archiveBlob = _archiveContainer.GetBlockBlobReference(message.PopReceipt);
             CopyProperties(outputBlob, archiveBlob);
             CopyMetadata(outputBlob, archiveBlob);
+            archiveBlob.Metadata.RemoveIfContainsKey(NextVisibleTimeKey);
 
             try
             {
-                archiveBlob.UploadFromStream(outputStream);
+                archiveBlob.UploadText(message.BlobText);
             }
             catch (StorageException exception)
             {
@@ -290,8 +290,7 @@ namespace Microsoft.Azure.Jobs.Host.Protocols
                 else
                 {
                     _archiveContainer.CreateIfNotExists();
-                    outputStream.Position = 0;
-                    archiveBlob.UploadFromStream(outputStream);
+                    archiveBlob.UploadText(message.BlobText);
                 }
             }
 


### PR DESCRIPTION
Dashboard indexer optimizations:
-Moved indexing to dedicated background threads (1 per core)
-Made polling of output blobs single-threaded, adding work to a blocking queue for workers. Kept polling on worker thread to avoid changes to the protocol APIs
-Workers fully drain the local queue before polling blob storage again
-Blob, including content and creation time, are cached in a message context to avoid extra blob storage calls in Delete
-Kept performance counter that I used for tracking, but maybe this should be disabled by default?
