### PR TITLE
Ignore methods with generics parameter(s). Fix of issue #25

### DIFF
--- a/src/Microsoft.Azure.Jobs.Host/Bindings/Data/DataBindingProvider.cs
+++ b/src/Microsoft.Azure.Jobs.Host/Bindings/Data/DataBindingProvider.cs
@@ -28,6 +28,11 @@ namespace Microsoft.Azure.Jobs.Host.Bindings.Data
                 return Task.FromResult<IBinding>(null);
             }
 
+            if (bindingDataType.ContainsGenericParameters)
+            {
+                return Task.FromResult<IBinding>(null);
+            }
+
             IBindingProvider typedProvider = CreateTypedBindingProvider(bindingDataType);
             return typedProvider.TryCreateAsync(context);
         }

--- a/src/Microsoft.Azure.Jobs.Host/Bindings/Invoke/InvokeBinding.cs
+++ b/src/Microsoft.Azure.Jobs.Host/Bindings/Invoke/InvokeBinding.cs
@@ -14,6 +14,11 @@ namespace Microsoft.Azure.Jobs.Host.Bindings.Invoke
                 return null;
             }
 
+            if (parameterType.ContainsGenericParameters)
+            { 
+                return null; 
+            }
+
             Type genericTypeDefinition;
 
             if (!parameterType.IsValueType)

--- a/src/Microsoft.Azure.Jobs.Host/Indexers/FunctionIndexer.cs
+++ b/src/Microsoft.Azure.Jobs.Host/Indexers/FunctionIndexer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -11,7 +12,6 @@ using Microsoft.Azure.Jobs.Host.Bindings;
 using Microsoft.Azure.Jobs.Host.Bindings.ConsoleOutput;
 using Microsoft.Azure.Jobs.Host.Bindings.Invoke;
 using Microsoft.Azure.Jobs.Host.Executors;
-using Microsoft.Azure.Jobs.Host.Listeners;
 using Microsoft.Azure.Jobs.Host.Protocols;
 using Microsoft.Azure.Jobs.Host.Triggers;
 
@@ -21,28 +21,78 @@ namespace Microsoft.Azure.Jobs.Host.Indexers
     internal class FunctionIndexer
     {
         private static readonly BindingFlags _publicStaticMethodFlags = BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly;
+        private static readonly Func<MethodInfo, bool> _hasServiceBusAttributeDefault = _ => false;
 
         private readonly FunctionIndexerContext _context;
         private readonly ITriggerBindingProvider _triggerBindingProvider;
         private readonly IBindingProvider _bindingProvider;
+        private readonly Func<MethodInfo, bool> _hasServiceBusAttribute;
+        
 
         public FunctionIndexer(FunctionIndexerContext context)
         {
             _context = context;
             _triggerBindingProvider = context.TriggerBindingProvider;
             _bindingProvider = context.BindingProvider;
+            Type serviceBusIndexerType = ServiceBusExtensionTypeLoader.Get("Microsoft.Azure.Jobs.ServiceBus.ServiceBusIndexer");
+            if (serviceBusIndexerType != null)
+            {
+                MethodInfo serviceBusIndexerMethod = serviceBusIndexerType.GetMethod("HasAzureJobsAttribute", new Type[] { typeof(MethodInfo) });
+                Debug.Assert(serviceBusIndexerMethod != null);
+                _hasServiceBusAttribute = (Func<MethodInfo, bool>)serviceBusIndexerMethod.CreateDelegate(
+                    typeof(Func<MethodInfo, bool>));
+            }
+            else
+            {
+                _hasServiceBusAttribute = _hasServiceBusAttributeDefault;
+            }
         }
 
         public async Task IndexTypeAsync(Type type, IFunctionIndex index, CancellationToken cancellationToken)
         {
-            foreach (MethodInfo method in type.GetMethods(_publicStaticMethodFlags))
+            foreach (MethodInfo method in type.GetMethods(_publicStaticMethodFlags).Where(IsAzureJobsMethod))
             {
                 await IndexMethodAsync(method, index, cancellationToken);
             }
         }
 
-        public async Task IndexMethodAsync(MethodInfo method, IFunctionIndex index, CancellationToken cancellationToken)
+        public bool IsAzureJobsMethod(MethodInfo method)
         {
+            if (method.ContainsGenericParameters)
+            {
+                return false;
+            }
+
+            if (method.GetParameters().Length == 0)
+            {
+                return false;
+            }
+
+            if (method.GetCustomAttributesData().Any(HasAzureJobsAttribute))
+            {
+                return true;
+            }
+
+            if (method.GetParameters().Any(p => p.GetCustomAttributesData().Any(HasAzureJobsAttribute)))
+            {
+                return true;
+            }
+
+            if (_hasServiceBusAttribute(method))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool HasAzureJobsAttribute(CustomAttributeData attributeData)
+        {
+            return attributeData.AttributeType.Assembly == typeof(BlobAttribute).Assembly;
+        }
+
+        public async Task IndexMethodAsync(MethodInfo method, IFunctionIndex index, CancellationToken cancellationToken)
+{
             try
             {
                 await IndexMethodAsyncCore(method, index, cancellationToken);

--- a/src/Microsoft.Azure.Jobs.Host/Tables/PocoEntityArgumentBindingProvider.cs
+++ b/src/Microsoft.Azure.Jobs.Host/Tables/PocoEntityArgumentBindingProvider.cs
@@ -15,6 +15,11 @@ namespace Microsoft.Azure.Jobs.Host.Tables
                 return null;
             }
 
+            if (parameterType.ContainsGenericParameters)
+            {
+                return null;
+            }
+
             TableClient.VerifyDefaultConstructor(parameterType);
 
             return CreateBinding(parameterType);

--- a/src/Microsoft.Azure.Jobs.Host/Tables/TableEntityArgumentBindingProvider.cs
+++ b/src/Microsoft.Azure.Jobs.Host/Tables/TableEntityArgumentBindingProvider.cs
@@ -10,6 +10,11 @@ namespace Microsoft.Azure.Jobs.Host.Tables
     {
         public IArgumentBinding<TableEntityContext> TryCreate(Type parameterType)
         {
+            if (parameterType.ContainsGenericParameters)
+            {
+                return null;
+            }
+
             if (!TableClient.ImplementsITableEntity(parameterType))
             {
                 return null;

--- a/src/Microsoft.Azure.Jobs.ServiceBus/Jobs.ServiceBus.csproj
+++ b/src/Microsoft.Azure.Jobs.ServiceBus/Jobs.ServiceBus.csproj
@@ -109,6 +109,7 @@
     <Compile Include="Bindings\UserTypeArgumentBindingProvider.cs" />
     <Compile Include="ServiceBusAttribute.cs" />
     <Compile Include="ServiceBusClient.cs" />
+    <Compile Include="ServiceBusIndexer.cs" />
     <Compile Include="ServiceBusTriggerAttribute.cs" />
     <Compile Include="StrictEncodings.cs" />
     <Compile Include="Triggers\BrokeredMessageValueProvider.cs" />

--- a/src/Microsoft.Azure.Jobs.ServiceBus/ServiceBusIndexer.cs
+++ b/src/Microsoft.Azure.Jobs.ServiceBus/ServiceBusIndexer.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using System.Reflection;
+
+namespace Microsoft.Azure.Jobs.ServiceBus
+{
+    internal static class ServiceBusIndexer
+    {
+        public static bool HasAzureJobsAttribute (MethodInfo method)
+        {
+            return method.GetParameters().Any(p => p.GetCustomAttributesData().Any(a => a.AttributeType.Assembly == typeof(ServiceBusIndexer).Assembly));
+        }
+    }
+}

--- a/test/Microsoft.Azure.Jobs.Host.UnitTests/Bindings/Data/DataBindingProviderTests.cs
+++ b/test/Microsoft.Azure.Jobs.Host.UnitTests/Bindings/Data/DataBindingProviderTests.cs
@@ -21,6 +21,17 @@ namespace Microsoft.Azure.Jobs.Host.UnitTests.Bindings.Data
 
             string parameterName = "Parameter";
             Type parameterType = typeof(int).MakeByRefType();
+            BindingProviderContext context = CreateBindingContext(parameterName, parameterType);
+
+            // Act
+            IBinding binding = product.TryCreateAsync(context).Result;
+
+            // Assert
+            Assert.Null(binding);
+        }
+
+        private static BindingProviderContext CreateBindingContext(string parameterName, Type parameterType)
+        {
             ParameterInfo parameter = new StubParameterInfo(parameterName, parameterType);
             Dictionary<string, Type> bindingDataContract = new Dictionary<string, Type>
             {
@@ -28,12 +39,41 @@ namespace Microsoft.Azure.Jobs.Host.UnitTests.Bindings.Data
             };
             BindingProviderContext context =
                 new BindingProviderContext(null, null, null, parameter, bindingDataContract, CancellationToken.None);
+            return context;
+        }
+
+        [Fact]
+        public void Create_ReturnsNull_IfContainsUnresolvedGenericParameter()
+        {
+            // Arrange
+            IBindingProvider product = new DataBindingProvider();
+
+            string parameterName = "Parameter";
+            Type parameterType = typeof(IEnumerable<>);
+            BindingProviderContext context = CreateBindingContext(parameterName, parameterType);
 
             // Act
             IBinding binding = product.TryCreateAsync(context).Result;
 
             // Assert
             Assert.Null(binding);
+        }
+
+        [Fact]
+        public void Create_ReturnsBinding_IfContainsResolvedGenericParameter()
+        {
+            // Arrange
+            IBindingProvider product = new DataBindingProvider();
+
+            string parameterName = "Parameter";
+            Type parameterType = typeof(IEnumerable<int>);
+            BindingProviderContext context = CreateBindingContext(parameterName, parameterType);
+
+            // Act
+            IBinding binding = product.TryCreateAsync(context).Result;
+
+            // Assert
+            Assert.NotNull(binding);
         }
 
         private class StubParameterInfo : ParameterInfo

--- a/test/Microsoft.Azure.Jobs.Host.UnitTests/Bindings/Invoke/InvokeBindingTests.cs
+++ b/test/Microsoft.Azure.Jobs.Host.UnitTests/Bindings/Invoke/InvokeBindingTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.Azure.Jobs.Host.Bindings;
 using Microsoft.Azure.Jobs.Host.Bindings.Invoke;
 using Xunit;
@@ -22,6 +23,34 @@ namespace Microsoft.Azure.Jobs.Host.UnitTests.Bindings.Invoke
 
             // Assert
             Assert.Null(binding);
+        }
+
+        [Fact]
+        public void Create_ReturnsNull_IfContainsUnresolvedGenericParameter()
+        {
+            // Arrange
+            string parameterName = "Parameter";
+            Type parameterType = typeof(IEnumerable<>);
+
+            // Act
+            IBinding binding = InvokeBinding.Create(parameterName, parameterType);
+
+            // Assert
+            Assert.Null(binding);
+        }
+
+        [Fact]
+        public void Create_ReturnsBinding_IfContainsResolvedGenericParameter()
+        {
+            // Arrange
+            string parameterName = "Parameter";
+            Type parameterType = typeof(IEnumerable<int>);
+
+            // Act
+            IBinding binding = InvokeBinding.Create(parameterName, parameterType);
+
+            // Assert
+            Assert.NotNull(binding);
         }
     }
 }

--- a/test/Microsoft.Azure.Jobs.Host.UnitTests/Indexers/FunctionIndexerTests.cs
+++ b/test/Microsoft.Azure.Jobs.Host.UnitTests/Indexers/FunctionIndexerTests.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 using System.Threading;
 using Microsoft.Azure.Jobs.Host.Indexers;
@@ -54,6 +56,90 @@ namespace Microsoft.Azure.Jobs.Host.UnitTests.Indexers
             Assert.Equal("Cannot bind parameter 'parsed' to type Foo&.", innerException.Message);
         }
 
+        [Fact]
+        public void IndexMethod_IgnoresMethod_IfMethodHasUnresolvedGenericParameter()
+        {
+            // Arrange
+            Mock<IFunctionIndex> indexMock = new Mock<IFunctionIndex>();
+            FunctionIndexer product = CreateProductUnderTest();
+
+            // Act
+            product.IndexMethodAsync(typeof(FunctionIndexerTests).GetMethod("MethodWithGenericParameter"), indexMock.Object, CancellationToken.None).Wait();
+
+            // Verify
+            indexMock.Verify(i => i.Add(It.IsAny<IFunctionDefinition>(), It.IsAny<FunctionDescriptor>(), It.IsAny<MethodInfo>()), Times.Never);
+        }
+
+        [Fact]
+        public void IsAzureJobsMethod_ReturnsFalse_IfMethodHasUnresolvedGenericParameter()
+        {
+            // Arrange
+            Mock<IFunctionIndex> indexMock = new Mock<IFunctionIndex>();
+            FunctionIndexer product = CreateProductUnderTest();
+
+            // Act
+            bool actual = product.IsAzureJobsMethod(typeof(FunctionIndexerTests).GetMethod("MethodWithGenericParameter"));
+
+            // Verify
+            Assert.Equal(false, actual);
+        }
+
+        [Fact]
+        public void IsAzureJobsMethod_ReturnsFalse_IfMethodHasNoParameters()
+        {
+            // Arrange
+            Mock<IFunctionIndex> indexMock = new Mock<IFunctionIndex>();
+            FunctionIndexer product = CreateProductUnderTest();
+
+            // Act
+            bool actual = product.IsAzureJobsMethod(typeof(FunctionIndexerTests).GetMethod("MethodWithNoParameters"));
+
+            // Verify
+            Assert.Equal(false, actual);
+        }
+
+        [Fact]
+        public void IsAzureJobsMethod_ReturnsTrue_IfMethodHasAzureJobsAttribute()
+        {
+            // Arrange
+            Mock<IFunctionIndex> indexMock = new Mock<IFunctionIndex>();
+            FunctionIndexer product = CreateProductUnderTest();
+
+            // Act
+            bool actual = product.IsAzureJobsMethod(typeof(FunctionIndexerTests).GetMethod("MethodWithAzureJobsAttribute"));
+
+            // Verify
+            Assert.Equal(true, actual);
+        }
+
+        [Fact]
+        public void IsAzureJobsMethod_ReturnsTrue_IfMethodHasAzureJobsParameterAttributes()
+        {
+            // Arrange
+            Mock<IFunctionIndex> indexMock = new Mock<IFunctionIndex>();
+            FunctionIndexer product = CreateProductUnderTest();
+
+            // Act
+            bool actual = product.IsAzureJobsMethod(typeof(FunctionIndexerTests).GetMethod("MethodWithAzureJobsParameterAttributes"));
+
+            // Verify
+            Assert.Equal(true, actual);
+        }
+
+        [Fact]
+        public void IsAzureJobsMethod_ReturnsFalse_IfMethodHasNoAzureJobsAttributes()
+        {
+            // Arrange
+            Mock<IFunctionIndex> indexMock = new Mock<IFunctionIndex>();
+            FunctionIndexer product = CreateProductUnderTest();
+
+            // Act
+            bool actual = product.IsAzureJobsMethod(typeof(FunctionIndexerTests).GetMethod("TryParse"));
+
+            // Verify
+            Assert.Equal(false, actual);
+        }
+
         private static FunctionIndexer CreateProductUnderTest()
         {
             FunctionIndexerContext context = FunctionIndexerContext.CreateDefault(null, null, null, null);
@@ -73,6 +159,27 @@ namespace Microsoft.Azure.Jobs.Host.UnitTests.Indexers
 
         public class Foo
         {
+        }
+
+        public static IEnumerable<IEnumerable<T>> MethodWithGenericParameter<T>(IEnumerable<T> source)
+        {
+            throw new NotImplementedException();
+        }
+
+        public static bool MethodWithNoParameters()
+        {
+            throw new NotImplementedException();
+        }
+
+        [NoAutomaticTrigger]
+        public static bool MethodWithAzureJobsAttribute(string input, out string output)
+        {
+            throw new NotImplementedException();
+        }
+
+        public static void MethodWithAzureJobsParameterAttributes([QueueTrigger("queue")] string input, [Blob("container/output")] TextWriter writer)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/test/Microsoft.Azure.Jobs.Host.UnitTests/Tables/PocoEntityArgumentBindingProviderTests.cs
+++ b/test/Microsoft.Azure.Jobs.Host.UnitTests/Tables/PocoEntityArgumentBindingProviderTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.Azure.Jobs.Host.Bindings;
 using Microsoft.Azure.Jobs.Host.Tables;
 using Xunit;
@@ -25,7 +26,41 @@ namespace Microsoft.Azure.Jobs.Host.UnitTests.Tables
             Assert.Null(binding);
         }
 
+        [Fact]
+        public void Create_ReturnsNull_IfContainsUnresolvedGenericParameter()
+        {
+            // Arrange
+            ITableEntityArgumentBindingProvider product = new PocoEntityArgumentBindingProvider();
+
+            Type parameterType = typeof(GenericClass<>);
+
+            // Act
+            IArgumentBinding<TableEntityContext> binding = product.TryCreate(parameterType);
+
+            // Assert
+            Assert.Null(binding);
+        }
+
+        [Fact]
+        public void Create_ReturnsBinding_IfContainsResolvedGenericParameter()
+        {
+            // Arrange
+            ITableEntityArgumentBindingProvider product = new PocoEntityArgumentBindingProvider();
+
+            Type parameterType = typeof(GenericClass<SimpleTableEntity>);
+            
+            // Act
+            IArgumentBinding<TableEntityContext> binding = product.TryCreate(parameterType);
+
+            // Assert
+            Assert.NotNull(binding);
+        }
+
         private class SimpleTableEntity
+        {
+        }
+
+        private class GenericClass<TArgument>
         {
         }
     }

--- a/test/Microsoft.Azure.Jobs.Host.UnitTests/Tables/TableEntityArgumentBindingProviderTests.cs
+++ b/test/Microsoft.Azure.Jobs.Host.UnitTests/Tables/TableEntityArgumentBindingProviderTests.cs
@@ -26,7 +26,41 @@ namespace Microsoft.Azure.Jobs.Host.UnitTests.Tables
             Assert.Null(binding);
         }
 
+        [Fact]
+        public void Create_ReturnsNull_IfContainsUnresolvedGenericParameter()
+        {
+            // Arrange
+            ITableEntityArgumentBindingProvider product = new TableEntityArgumentBindingProvider();
+
+            Type parameterType = typeof(GenericClass<>);
+
+            // Act
+            IArgumentBinding<TableEntityContext> binding = product.TryCreate(parameterType);
+
+            // Assert
+            Assert.Null(binding);
+        }
+
+        [Fact]
+        public void Create_ReturnsBinding_IfContainsResolvedGenericParameter()
+        {
+            // Arrange
+            ITableEntityArgumentBindingProvider product = new TableEntityArgumentBindingProvider();
+
+            Type parameterType = typeof(GenericClass<int>);
+
+            // Act
+            IArgumentBinding<TableEntityContext> binding = product.TryCreate(parameterType);
+
+            // Assert
+            Assert.NotNull(binding);
+        }
+
         private class SimpleTableEntity : TableEntity
+        {
+        }
+
+        private class GenericClass<TArgument> : TableEntity
         {
         }
     }


### PR DESCRIPTION
1. Verified every call to MakeGenericType is guarded with ContainsGenericParameters data type check. 
2. Added high level filter to the FunctionIndexer to ignore non- "AzureJobs" methods, i.e. methods having generic parameters and methods not marked with Azure Jobs attributes.
3. Added necessary unit tests to validate correct indexer behavior in case of methods having generic parameters.
