### PR TITLE
Dashboard function invocations optimization

### DIFF
--- a/src/Dashboard/Dashboard.csproj
+++ b/src/Dashboard/Dashboard.csproj
@@ -202,6 +202,7 @@
     <Compile Include="Data\BlobContinuationTokenSerializer.cs" />
     <Compile Include="Data\BlobParameterSnapshot.cs" />
     <Compile Include="Data\FunctionIndexReader.cs" />
+    <Compile Include="Data\FunctionInstanceMetadata.cs" />
     <Compile Include="Data\IFunctionIndexReader.cs" />
     <Compile Include="Data\HeartbeatValidityMonitor.cs" />
     <Compile Include="Data\FunctionIndexVersionManager.cs" />

--- a/src/Dashboard/Data/BlobConcurrentTextStore.cs
+++ b/src/Dashboard/Data/BlobConcurrentTextStore.cs
@@ -105,7 +105,13 @@ namespace Dashboard.Data
 
         public void CreateOrUpdate(string id, string text)
         {
+            CreateOrUpdate(id, metadata: null, text: text);
+        }
+
+        public void CreateOrUpdate(string id, IDictionary<string, string> metadata, string text)
+        {
             CloudBlockBlob blob = _directory.GetBlockBlobReference(id);
+            CopyMetadata(metadata, blob);
 
             try
             {

--- a/src/Dashboard/Data/BlobRecentInvocationIndexReader.cs
+++ b/src/Dashboard/Data/BlobRecentInvocationIndexReader.cs
@@ -39,7 +39,7 @@ namespace Dashboard.Data
                 blobSegment = _container.ListBlobsSegmented(
                     prefix: prefix,
                     useFlatBlobListing: true,
-                    blobListingDetails: BlobListingDetails.None,
+                    blobListingDetails: BlobListingDetails.Metadata,
                     maxResults: maximumResults,
                     currentToken: blobContinuationToken,
                     options: null,
@@ -68,7 +68,7 @@ namespace Dashboard.Data
             foreach (ICloudBlob blob in blobSegment.Results)
             {
                 string nameWithoutPrefix = blob.Name.Substring(prefix.Length);
-                results.Add(RecentInvocationEntry.Parse(nameWithoutPrefix));
+                results.Add(RecentInvocationEntry.Parse(nameWithoutPrefix, blob.Metadata));
             }
 
             string nextContinuationToken = BlobContinuationTokenSerializer.Serialize(blobSegment.ContinuationToken);

--- a/src/Dashboard/Data/FunctionInstanceMetadata.cs
+++ b/src/Dashboard/Data/FunctionInstanceMetadata.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Dashboard.Data
+{
+    public static class FunctionInstanceMetadata
+    {
+        public static readonly string DisplayTitle = "displayTitle";
+
+        public static readonly string StartTime = "startTime";
+
+        public static readonly string EndTime = "endTime";
+
+        public static readonly string Succeeded = "succeeded";
+
+        public static readonly string HeartbeatContainer = "heartbeatContainer";
+
+        public static readonly string HeartbeatDirectory = "heartbeatDirectory";
+
+        public static readonly string HeartbeatName = "heartbeatName";
+
+        public static readonly string HeartbeatExpiration = "heartbeatExpiration";
+
+        internal static Dictionary<string, string> CreateFromSnapshot(FunctionInstanceSnapshot snapshot)
+        {
+            var metadata = new Dictionary<string, string>();
+
+            metadata.Add(FunctionInstanceMetadata.DisplayTitle, snapshot.DisplayTitle);
+
+            if (snapshot.StartTime.HasValue)
+            {
+                metadata.Add(FunctionInstanceMetadata.StartTime, SerializeDateTimeOffset(snapshot.StartTime.Value));
+            }
+            if (snapshot.EndTime.HasValue)
+            {
+                metadata.Add(FunctionInstanceMetadata.EndTime, SerializeDateTimeOffset(snapshot.EndTime.Value));
+            }
+            if (snapshot.Succeeded.HasValue)
+            {
+                metadata.Add(FunctionInstanceMetadata.Succeeded, snapshot.Succeeded.Value.ToString());
+            }
+            if (snapshot.Heartbeat != null)
+            {
+                metadata.Add(FunctionInstanceMetadata.HeartbeatContainer, snapshot.Heartbeat.SharedContainerName);
+                metadata.Add(FunctionInstanceMetadata.HeartbeatDirectory, snapshot.Heartbeat.SharedDirectoryName);
+                metadata.Add(FunctionInstanceMetadata.HeartbeatName, snapshot.Heartbeat.InstanceBlobName);
+                metadata.Add(FunctionInstanceMetadata.HeartbeatExpiration, snapshot.Heartbeat.ExpirationInSeconds.ToString());
+            }
+            return metadata;
+        }
+
+        private static string SerializeDateTimeOffset(DateTimeOffset dto)
+        {
+            return dto.UtcDateTime.ToString("o", CultureInfo.InvariantCulture);
+        }
+
+        internal static DateTimeOffset? DeserializeDateTimeOffset(string s)
+        {
+            DateTimeOffset result;
+            if (DateTimeOffset.TryParseExact(s, "o", CultureInfo.InvariantCulture, DateTimeStyles.None, out result))
+            {
+                return result;
+            }
+            return null;
+        }
+    }
+}

--- a/src/Dashboard/Data/FunctionInstanceSnapshot.cs
+++ b/src/Dashboard/Data/FunctionInstanceSnapshot.cs
@@ -3,12 +3,17 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using Microsoft.Azure.Jobs.Protocols;
+using Newtonsoft.Json;
 
 namespace Dashboard.Data
 {
     public class FunctionInstanceSnapshot
     {
+        private string _displayTitle;
+
         public Guid Id { get; set; }
 
         public Guid HostInstanceId { get; set; }
@@ -54,5 +59,46 @@ namespace Dashboard.Data
         public string ExceptionType { get; set; }
 
         public string ExceptionMessage { get; set; }
+
+        [JsonIgnore]
+        public string DisplayTitle
+        {
+            get
+            {
+                if (_displayTitle == null)
+                {
+                    _displayTitle = BuildFunctionDisplayTitle();
+                }
+                return _displayTitle;
+            }
+            set
+            {
+                _displayTitle = value;
+            }
+        }
+
+        private string BuildFunctionDisplayTitle()
+        {
+            var name = new StringBuilder(FunctionShortName);
+            IEnumerable<string> argumentValues = Arguments.Values.Select(v => v.Value);
+            string parametersDisplayText = String.Join(", ", argumentValues);
+            if (parametersDisplayText != null)
+            {
+                name.Append(" (");
+                if (parametersDisplayText.Length > 20)
+                {
+                    name.Append(parametersDisplayText.Substring(0, 18))
+                        .Append(" ...");
+                }
+                else
+                {
+                    name.Append(parametersDisplayText);
+                }
+                name.Append(")");
+            }
+            // Remove newlines to avoid 403/forbidden storage exceptions when saving display title to blob metadata
+            // for function indexes. Newlines may be present in JSON-formatted arguments.
+            return name.ToString().Replace("\r\n", String.Empty);
+        }
     }
 }

--- a/src/Dashboard/Data/IConcurrentMetadataTextStore.cs
+++ b/src/Dashboard/Data/IConcurrentMetadataTextStore.cs
@@ -13,6 +13,8 @@ namespace Dashboard.Data
 
         ConcurrentMetadata ReadMetadata(string id);
 
+        void CreateOrUpdate(string id, IDictionary<string, string> metadata, string text);
+
         bool TryCreate(string id, IDictionary<string, string> metadata, string text);
 
         bool TryUpdate(string id, string eTag, IDictionary<string, string> metadata, string text);

--- a/src/Dashboard/Data/IRecentInvocationIndexByFunctionWriter.cs
+++ b/src/Dashboard/Data/IRecentInvocationIndexByFunctionWriter.cs
@@ -7,7 +7,7 @@ namespace Dashboard.Data
 {
     public interface IRecentInvocationIndexByFunctionWriter
     {
-        void CreateOrUpdate(string functionId, DateTimeOffset timestamp, Guid id);
+        void CreateOrUpdate(FunctionInstanceSnapshot snapshot, DateTimeOffset timestamp);
 
         void DeleteIfExists(string functionId, DateTimeOffset timestamp, Guid id);
     }

--- a/src/Dashboard/Data/IRecentInvocationIndexByJobRunWriter.cs
+++ b/src/Dashboard/Data/IRecentInvocationIndexByJobRunWriter.cs
@@ -8,7 +8,7 @@ namespace Dashboard.Data
 {
     public interface IRecentInvocationIndexByJobRunWriter
     {
-        void CreateOrUpdate(WebJobRunIdentifier webJobRunId, DateTimeOffset timestamp, Guid id);
+        void CreateOrUpdate(FunctionInstanceSnapshot snapshot, WebJobRunIdentifier webJobRunId, DateTimeOffset timestamp);
 
         void DeleteIfExists(WebJobRunIdentifier webJobRunId, DateTimeOffset timestamp, Guid id);
     }

--- a/src/Dashboard/Data/IRecentInvocationIndexByParentWriter.cs
+++ b/src/Dashboard/Data/IRecentInvocationIndexByParentWriter.cs
@@ -7,7 +7,7 @@ namespace Dashboard.Data
 {
     public interface IRecentInvocationIndexByParentWriter
     {
-        void CreateOrUpdate(Guid parentId, DateTimeOffset timestamp, Guid id);
+        void CreateOrUpdate(FunctionInstanceSnapshot snapshot, DateTimeOffset timestamp);
 
         void DeleteIfExists(Guid parentId, DateTimeOffset timestamp, Guid id);
     }

--- a/src/Dashboard/Data/IRecentInvocationIndexWriter.cs
+++ b/src/Dashboard/Data/IRecentInvocationIndexWriter.cs
@@ -7,7 +7,7 @@ namespace Dashboard.Data
 {
     public interface IRecentInvocationIndexWriter
     {
-        void CreateOrUpdate(DateTimeOffset timestamp, Guid id);
+        void CreateOrUpdate(FunctionInstanceSnapshot snapshot, DateTimeOffset timestamp);
 
         void DeleteIfExists(DateTimeOffset timestamp, Guid id);
     }

--- a/src/Dashboard/Data/RecentInvocationEntry.cs
+++ b/src/Dashboard/Data/RecentInvocationEntry.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 
 namespace Dashboard.Data
@@ -10,11 +11,13 @@ namespace Dashboard.Data
     {
         private readonly DateTimeOffset _timestamp;
         private readonly Guid _id;
+        private readonly IDictionary<string, string> _metadata;
 
-        public RecentInvocationEntry(DateTimeOffset timestamp, Guid id)
+        public RecentInvocationEntry(DateTimeOffset timestamp, Guid id, IDictionary<string, string> metadata)
         {
             _timestamp = timestamp;
             _id = id;
+            _metadata = metadata;
         }
 
         public DateTimeOffset Timestamp
@@ -25,6 +28,11 @@ namespace Dashboard.Data
         public Guid Id
         {
             get { return _id; }
+        }
+
+        public IDictionary<string, string> Metadata
+        {
+            get { return _metadata; }
         }
 
         public override string ToString()
@@ -42,11 +50,11 @@ namespace Dashboard.Data
             return String.Format(CultureInfo.InvariantCulture, "{0:D19}_{1:N}", reverseTicks, id);
         }
 
-        public static RecentInvocationEntry Parse(string input)
+        public static RecentInvocationEntry Parse(string input, IDictionary<string, string> metadata)
         {
             RecentInvocationEntry parsed;
 
-            if (!TryParse(input, out parsed))
+            if (!TryParse(input, metadata, out parsed))
             {
                 throw new FormatException("Recent function instance blob names must be in the format timestamp_guid.");
             }
@@ -54,7 +62,7 @@ namespace Dashboard.Data
             return parsed;
         }
 
-        private static bool TryParse(string input, out RecentInvocationEntry parsed)
+        private static bool TryParse(string input, IDictionary<string, string> metadata, out RecentInvocationEntry parsed)
         {
             if (input == null)
             {
@@ -93,7 +101,7 @@ namespace Dashboard.Data
             long ticks = DateTimeOffset.MaxValue.Ticks - reverseTicks; // Recompute the original ticks.
             DateTimeOffset timestamp = new DateTimeOffset(reverseTicks, TimeSpan.Zero); // Ticks must be UTC-relative.
 
-            parsed = new RecentInvocationEntry(timestamp, id);
+            parsed = new RecentInvocationEntry(timestamp, id, metadata);
             return true;
         }
     }

--- a/src/Dashboard/Data/RecentInvocationIndexByFunctionWriter.cs
+++ b/src/Dashboard/Data/RecentInvocationIndexByFunctionWriter.cs
@@ -8,7 +8,7 @@ namespace Dashboard.Data
 {
     public class RecentInvocationIndexByFunctionWriter : IRecentInvocationIndexByFunctionWriter
     {
-        private readonly IConcurrentTextStore _store;
+        private readonly IConcurrentMetadataTextStore _store;
 
         [CLSCompliant(false)]
         public RecentInvocationIndexByFunctionWriter(CloudBlobClient client)
@@ -17,15 +17,16 @@ namespace Dashboard.Data
         {
         }
 
-        private RecentInvocationIndexByFunctionWriter(IConcurrentTextStore store)
+        private RecentInvocationIndexByFunctionWriter(IConcurrentMetadataTextStore store)
         {
             _store = store;
         }
 
-        public void CreateOrUpdate(string functionId, DateTimeOffset timestamp, Guid id)
+        public void CreateOrUpdate(FunctionInstanceSnapshot snapshot, DateTimeOffset timestamp)
         {
-            string innerId = CreateInnerId(functionId, timestamp, id);
-            _store.CreateOrUpdate(innerId, String.Empty);
+            var innerId = CreateInnerId(snapshot.FunctionId, timestamp, snapshot.Id);
+            var metadata = FunctionInstanceMetadata.CreateFromSnapshot(snapshot);
+            _store.CreateOrUpdate(innerId, metadata, String.Empty);
         }
 
         public void DeleteIfExists(string functionId, DateTimeOffset timestamp, Guid id)

--- a/src/Dashboard/Data/RecentInvocationIndexByJobRunWriter.cs
+++ b/src/Dashboard/Data/RecentInvocationIndexByJobRunWriter.cs
@@ -9,7 +9,7 @@ namespace Dashboard.Data
 {
     public class RecentInvocationIndexByJobRunWriter : IRecentInvocationIndexByJobRunWriter
     {
-        private readonly IConcurrentTextStore _store;
+        private readonly IConcurrentMetadataTextStore _store;
 
         [CLSCompliant(false)]
         public RecentInvocationIndexByJobRunWriter(CloudBlobClient client)
@@ -18,15 +18,16 @@ namespace Dashboard.Data
         {
         }
 
-        private RecentInvocationIndexByJobRunWriter(IConcurrentTextStore store)
+        private RecentInvocationIndexByJobRunWriter(IConcurrentMetadataTextStore store)
         {
             _store = store;
         }
 
-        public void CreateOrUpdate(WebJobRunIdentifier webJobRunId, DateTimeOffset timestamp, Guid id)
+        public void CreateOrUpdate(FunctionInstanceSnapshot snapshot, WebJobRunIdentifier webJobRunId, DateTimeOffset timestamp)
         {
-            string innerId = CreateInnerId(webJobRunId, timestamp, id);
-            _store.CreateOrUpdate(innerId, String.Empty);
+            var innerId = CreateInnerId(webJobRunId, timestamp, snapshot.Id);
+            var metadata = FunctionInstanceMetadata.CreateFromSnapshot(snapshot);
+            _store.CreateOrUpdate(innerId, metadata, String.Empty);
         }
 
         public void DeleteIfExists(WebJobRunIdentifier webJobRunId, DateTimeOffset timestamp, Guid id)

--- a/src/Dashboard/Data/RecentInvocationIndexByParentWriter.cs
+++ b/src/Dashboard/Data/RecentInvocationIndexByParentWriter.cs
@@ -8,7 +8,7 @@ namespace Dashboard.Data
 {
     public class RecentInvocationIndexByParentWriter : IRecentInvocationIndexByParentWriter
     {
-        private readonly IConcurrentTextStore _store;
+        private readonly IConcurrentMetadataTextStore _store;
 
         [CLSCompliant(false)]
         public RecentInvocationIndexByParentWriter(CloudBlobClient client)
@@ -17,15 +17,16 @@ namespace Dashboard.Data
         {
         }
 
-        private RecentInvocationIndexByParentWriter(IConcurrentTextStore store)
+        private RecentInvocationIndexByParentWriter(IConcurrentMetadataTextStore store)
         {
             _store = store;
         }
 
-        public void CreateOrUpdate(Guid parentId, DateTimeOffset timestamp, Guid id)
+        public void CreateOrUpdate(FunctionInstanceSnapshot snapshot, DateTimeOffset timestamp)
         {
-            string innerId = CreateInnerId(parentId, timestamp, id);
-            _store.CreateOrUpdate(innerId, String.Empty);
+            var innerId = CreateInnerId(snapshot.ParentId.Value, timestamp, snapshot.Id);
+            var metadata = FunctionInstanceMetadata.CreateFromSnapshot(snapshot);
+            _store.CreateOrUpdate(innerId, metadata, String.Empty);
         }
 
         public void DeleteIfExists(Guid parentId, DateTimeOffset timestamp, Guid id)

--- a/src/Dashboard/Data/RecentInvocationIndexWriter.cs
+++ b/src/Dashboard/Data/RecentInvocationIndexWriter.cs
@@ -8,7 +8,7 @@ namespace Dashboard.Data
 {
     public class RecentInvocationIndexWriter : IRecentInvocationIndexWriter
     {
-        private readonly IConcurrentTextStore _store;
+        private readonly IConcurrentMetadataTextStore _store;
 
         [CLSCompliant(false)]
         public RecentInvocationIndexWriter(CloudBlobClient client)
@@ -17,15 +17,16 @@ namespace Dashboard.Data
         {
         }
 
-        private RecentInvocationIndexWriter(IConcurrentTextStore store)
+        private RecentInvocationIndexWriter(IConcurrentMetadataTextStore store)
         {
             _store = store;
         }
 
-        public void CreateOrUpdate(DateTimeOffset timestamp, Guid id)
+        public void CreateOrUpdate(FunctionInstanceSnapshot snapshot, DateTimeOffset timestamp)
         {
-            string innerId = CreateInnerId(timestamp, id);
-            _store.CreateOrUpdate(innerId, String.Empty);
+            var innerId = CreateInnerId(timestamp, snapshot.Id);
+            var metadata = FunctionInstanceMetadata.CreateFromSnapshot(snapshot);
+            _store.CreateOrUpdate(innerId, metadata, String.Empty);
         }
 
         public void DeleteIfExists(DateTimeOffset timestamp, Guid id)

--- a/src/Dashboard/ViewModels/InvocationLogViewModel.cs
+++ b/src/Dashboard/ViewModels/InvocationLogViewModel.cs
@@ -19,7 +19,7 @@ namespace Dashboard.ViewModels
             FunctionName = snapshot.FunctionShortName;
             FunctionId = snapshot.FunctionId;
             FunctionFullName = snapshot.FunctionFullName;
-            FunctionDisplayTitle = BuildFunctionDisplayTitle(snapshot);
+            FunctionDisplayTitle = snapshot.DisplayTitle;
             HostInstanceId = snapshot.HostInstanceId;
             InstanceQueueName = snapshot.InstanceQueueName;
             if (snapshot.WebSiteName != null
@@ -60,28 +60,6 @@ namespace Dashboard.ViewModels
         }
 
         public WebJobRunIdentifierViewModel ExecutingJobRunId { get; set; }
-
-        internal static string BuildFunctionDisplayTitle(FunctionInstanceSnapshot snapshot)
-        {
-            var name = new StringBuilder(snapshot.FunctionShortName);
-            IEnumerable<string> argumentValues = snapshot.Arguments.Values.Select(v => v.Value);
-            string parametersDisplayText = String.Join(", ", argumentValues);
-            if (parametersDisplayText != null)
-            {
-                name.Append(" (");
-                if (parametersDisplayText.Length > 20)
-                {
-                    name.Append(parametersDisplayText.Substring(0, 18))
-                        .Append(" ...");
-                }
-                else
-                {
-                    name.Append(parametersDisplayText);
-                }
-                name.Append(")");
-            }
-            return name.ToString();
-        }
 
         public Guid Id { get; set; }
         public string FunctionId { get; set; }

--- a/test/Dashboard.UnitTests/Data/VersionedMetadataTextStoreTests.cs
+++ b/test/Dashboard.UnitTests/Data/VersionedMetadataTextStoreTests.cs
@@ -1072,6 +1072,11 @@ namespace Dashboard.UnitTests.Data
                 throw new NotImplementedException();
             }
 
+            public void CreateOrUpdate(string id, IDictionary<string, string> metadata, string text)
+            {
+                throw new NotImplementedException();
+            }
+
             public void DeleteIfExists(string id)
             {
                 throw new NotImplementedException();
@@ -1201,6 +1206,11 @@ namespace Dashboard.UnitTests.Data
             }
 
             public void CreateOrUpdate(string id, string text)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void CreateOrUpdate(string id, IDictionary<string, string> metadata, string text)
             {
                 throw new NotImplementedException();
             }


### PR DESCRIPTION
Storing some invocation details with recent indexes to reduce blob requests required to render invocations table. Now only requires single ListBlobs with metadata, and does not need to download function or heartbeat instance blobs. Left function invocation caching unchanged.
