### PR TITLE
Use random factor in the Azure Queue exponential polling algorithm (fixes #46)

### DIFF
--- a/src/Microsoft.Azure.Jobs.Host/Jobs.Host.csproj
+++ b/src/Microsoft.Azure.Jobs.Host/Jobs.Host.csproj
@@ -366,6 +366,7 @@
     <Compile Include="Timers\FixedIntervalsTimerCommand.cs" />
     <Compile Include="Timers\ITimerFactory.cs" />
     <Compile Include="Timers\NullCanFailCommand.cs" />
+    <Compile Include="Timers\RandomExtensions.cs" />
     <Compile Include="Triggers\TriggeredFunctionInstanceFactory.cs" />
     <Compile Include="Executors\HostMessageExecutor.cs" />
     <Compile Include="Executors\IBindingSource.cs" />

--- a/src/Microsoft.Azure.Jobs.Host/Queues/Listeners/HostMessageListenerFactory.cs
+++ b/src/Microsoft.Azure.Jobs.Host/Queues/Listeners/HostMessageListenerFactory.cs
@@ -15,7 +15,8 @@ namespace Microsoft.Azure.Jobs.Host.Queues.Listeners
 {
     internal class HostMessageListenerFactory : IListenerFactory
     {
-        private static readonly TimeSpan maxmimum = TimeSpan.FromMinutes(1);
+        private static readonly TimeSpan Minimum = QueuePollingIntervals.Minimum;
+        private static readonly TimeSpan Maxmimum = TimeSpan.FromMinutes(1);
 
         private readonly CloudQueue _queue;
         private readonly IFunctionIndexLookup _functionLookup;
@@ -35,8 +36,7 @@ namespace Microsoft.Azure.Jobs.Host.Queues.Listeners
                 _functionInstanceLogger);
             ICanFailCommand command = new PollQueueCommand(_queue, poisonQueue: null, triggerExecutor: triggerExecutor);
             // Use a shorter maximum polling interval for run/abort from dashboard.
-            IntervalSeparationTimer timer = ExponentialBackoffTimerCommand.CreateTimer(command,
-                QueuePollingIntervals.Minimum, maxmimum);
+            IntervalSeparationTimer timer = ExponentialBackoffTimerCommand.CreateTimer(command, Minimum, Maxmimum);
             IListener listener = new TimerListener(timer);
             return Task.FromResult(listener);
         }

--- a/src/Microsoft.Azure.Jobs.Host/Queues/Listeners/QueuePollingIntervals.cs
+++ b/src/Microsoft.Azure.Jobs.Host/Queues/Listeners/QueuePollingIntervals.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Azure.Jobs.Host.Queues.Listeners
 {
     internal static class QueuePollingIntervals
     {
-        public static readonly TimeSpan Minimum = new TimeSpan(0, 0, 2);
-        public static readonly TimeSpan Maximum = new TimeSpan(0, 10, 0);
+        public static readonly TimeSpan Minimum = TimeSpan.FromSeconds(2);
+        public static readonly TimeSpan Maximum = TimeSpan.FromMinutes(10);
     }
 }

--- a/src/Microsoft.Azure.Jobs.Host/Timers/RandomExtensions.cs
+++ b/src/Microsoft.Azure.Jobs.Host/Timers/RandomExtensions.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.Jobs.Host.Timers
+{
+    internal static class RandomExtensions
+    {
+        public static double Next(this Random random, double minValue, double maxValue)
+        {
+            if (random == null)
+            {
+                throw new ArgumentNullException("random");
+            }
+
+            return (maxValue - minValue) * random.NextDouble() + minValue;
+        }
+    }
+}


### PR DESCRIPTION
Refactored ExecuteAsync method of ExponentialBackoffTimerCommand to use random factor within range of +/-20% when calculating next wait period.

Fixed bug when minimal interval returned after failed execution following succeeded one. Now it returns roughly double minimal interval. Test scenario in unit test suite modified to verify that.
