### PR TITLE
Implement async support in timers (fixes #9).

### DIFF
--- a/src/Microsoft.Azure.Jobs.Host/Executors/JobHostContext.cs
+++ b/src/Microsoft.Azure.Jobs.Host/Executors/JobHostContext.cs
@@ -203,8 +203,8 @@ namespace Microsoft.Azure.Jobs.Host.Executors
                 IListenerFactory allFunctionsListenerFactory = new HostListenerFactory(functions.ReadAll(),
                     sharedQueueListenerFactory, instanceQueueListenerFactory);
 
-                IFunctionExecutor hostCallExecutor = CreateHostCallExecutor(instanceQueueListenerFactory, bindingContext,
-                    heartbeatCommand, shutdownToken, executor);
+                IFunctionExecutor hostCallExecutor = CreateHostCallExecutor(instanceQueueListenerFactory,
+                    bindingContext, heartbeatCommand, shutdownToken, executor);
 
                 IListener listener = CreateHostListener(allFunctionsListenerFactory, bindingContext, heartbeatCommand,
                     shutdownToken, executor);

--- a/src/Microsoft.Azure.Jobs.Host/Jobs.Host.csproj
+++ b/src/Microsoft.Azure.Jobs.Host/Jobs.Host.csproj
@@ -364,6 +364,8 @@
     <Compile Include="Tables\TableEntityArgumentBinding.cs" />
     <Compile Include="Timers\ExponentialBackoffTimerCommand.cs" />
     <Compile Include="Timers\FixedIntervalsTimerCommand.cs" />
+    <Compile Include="Timers\BackgroundExceptionDispatcher.cs" />
+    <Compile Include="Timers\IBackgroundExceptionDispatcher.cs" />
     <Compile Include="Timers\ITimerFactory.cs" />
     <Compile Include="Timers\NullCanFailCommand.cs" />
     <Compile Include="Timers\RandomExtensions.cs" />

--- a/src/Microsoft.Azure.Jobs.Host/Timers/BackgroundExceptionDispatcher.cs
+++ b/src/Microsoft.Azure.Jobs.Host/Timers/BackgroundExceptionDispatcher.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Diagnostics;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+
+namespace Microsoft.Azure.Jobs.Host.Timers
+{
+    internal class BackgroundExceptionDispatcher : IBackgroundExceptionDispatcher
+    {
+        private static readonly BackgroundExceptionDispatcher _instance = new BackgroundExceptionDispatcher();
+
+        private BackgroundExceptionDispatcher()
+        {
+        }
+
+        public static BackgroundExceptionDispatcher Instance
+        {
+            get { return _instance; }
+        }
+
+        public void Throw(ExceptionDispatchInfo exceptionInfo)
+        {
+            Debug.Assert(exceptionInfo != null);
+
+            Thread thread = new Thread(() =>
+            {
+                exceptionInfo.Throw();
+            });
+            thread.Start();
+            thread.Join();
+        }
+    }
+}

--- a/src/Microsoft.Azure.Jobs.Host/Timers/IBackgroundExceptionDispatcher.cs
+++ b/src/Microsoft.Azure.Jobs.Host/Timers/IBackgroundExceptionDispatcher.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Runtime.ExceptionServices;
+
+namespace Microsoft.Azure.Jobs.Host.Timers
+{
+    internal interface IBackgroundExceptionDispatcher
+    {
+        void Throw(ExceptionDispatchInfo exceptionInfo);
+    }
+}


### PR DESCRIPTION
This PR is intended to be the last major part needed for async support throughout the JobHost stack. There are a few small pieces with async TODO remaining, but if they need to happen in a subsequent release, I think that's OK.
