### PR TITLE
Fix bug causing Service Bus end to end test failure.

### DIFF
--- a/src/Microsoft.Azure.Jobs.Host/Listeners/ListenerFactoryListener.cs
+++ b/src/Microsoft.Azure.Jobs.Host/Listeners/ListenerFactoryListener.cs
@@ -72,7 +72,12 @@ namespace Microsoft.Azure.Jobs.Host.Listeners
             if (!_disposed)
             {
                 _cancellationRegistration.Dispose();
-                _cancellationSource.Dispose();
+
+                // StartAsync might still be using this cancellation token.
+                // Mark it canceled but don't dispose of the source while the callers are running.
+                // Otherwise, callers would receive ObjectDisposedException when calling token.Register.
+                // For now, rely on finalization to clean up _shutdownTokenSource's wait handle (if allocated).
+                _cancellationSource.Cancel();
 
                 if (_listener != null)
                 {

--- a/src/Microsoft.Azure.Jobs.Host/Listeners/ShutdownListener.cs
+++ b/src/Microsoft.Azure.Jobs.Host/Listeners/ShutdownListener.cs
@@ -21,12 +21,12 @@ namespace Microsoft.Azure.Jobs.Host.Listeners
             _innerListener = innerListener;
         }
 
-        public Task StartAsync(CancellationToken cancellationToken)
+        public async Task StartAsync(CancellationToken cancellationToken)
         {
             using (CancellationTokenSource combinedCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(
                 cancellationToken, _shutdownToken))
             {
-                return _innerListener.StartAsync(combinedCancellationSource.Token);
+                await _innerListener.StartAsync(combinedCancellationSource.Token);
             }
         }
 


### PR DESCRIPTION
Needed to make the method async in ShutdownListener so the using doesn't dispose until after awaiting the task.
