### PR TITLE
Fix over-concurrency causing excessive backoff for E2E tests.

### DIFF
--- a/src/Microsoft.Azure.Jobs.Host/Timers/IntervalSeparationTimer.cs
+++ b/src/Microsoft.Azure.Jobs.Host/Timers/IntervalSeparationTimer.cs
@@ -112,8 +112,6 @@ namespace Microsoft.Azure.Jobs.Host.Timers
                 // Allow Start to return immediately without waiting for the first command to execute.
                 await Task.Yield();
 
-                List<Task> runningCommands = new List<Task>();
-
                 // Schedule another execution until stopped.
                 while (!cancellationToken.IsCancellationRequested)
                 {
@@ -148,13 +146,12 @@ namespace Microsoft.Azure.Jobs.Host.Timers
                             _backgroundExceptionDispatcher.Throw(exceptionInfo);
                         }
 
-                        // Just allow the continuation task to run to completion if t.Status is Canceled or RanToCompletion.
+                        // Just allow the continuation task to run to completion if t.Status is Canceled or
+                        // RanToCompletion.
                     }, TaskContinuationOptions.ExecuteSynchronously);
 
-                    runningCommands.Add(continuationTask);
+                    await continuationTask;
                 }
-
-                await Task.WhenAll(runningCommands);
             }
             catch (Exception exception)
             {

--- a/test/Microsoft.Azure.Jobs.Host.UnitTests/Timers/IntervalSeparationTimerTests.cs
+++ b/test/Microsoft.Azure.Jobs.Host.UnitTests/Timers/IntervalSeparationTimerTests.cs
@@ -63,44 +63,6 @@ namespace Microsoft.Azure.Jobs.Host.UnitTests.Timers
         }
 
         [Fact]
-        public void Start_IfCommandExecuteAsyncReturnsUncompletedTask_StartsExecuteAsyncAgain()
-        {
-            // Arrange
-            TaskCompletionSource<object> firstTaskSource = new TaskCompletionSource<object>();
-            bool executedOnce = false;
-            TimeSpan interval = TimeSpan.Zero;
-
-            using (EventWaitHandle waitForSecondExecution = new ManualResetEvent(initialState: false))
-            {
-                IIntervalSeparationCommand command = CreateCommand(() =>
-                {
-                    if (!executedOnce)
-                    {
-                        executedOnce = true;
-                        return firstTaskSource.Task;
-                    }
-                    else
-                    {
-                        waitForSecondExecution.Set();
-                        return Task.FromResult(0);
-                    }
-                }, interval);
-
-                using (IntervalSeparationTimer product = CreateProductUnderTest(command))
-                {
-                    // Act
-                    product.Start();
-
-                    // Assert
-                    Assert.True(waitForSecondExecution.WaitOne(1000));
-
-                    // Cleanup
-                    firstTaskSource.SetResult(null);
-                }
-            }
-        }
-
-        [Fact]
         public void Start_AfterSeparationInternalChanges_WaitsForNewInterval()
         {
             // Arrange
@@ -140,7 +102,9 @@ namespace Microsoft.Azure.Jobs.Host.UnitTests.Timers
                     waitForSecondExecution.WaitOne();
 
                     // Assert
-                    Assert.True(stopwatch.ElapsedMilliseconds >= subsequentInterval.TotalMilliseconds, String.Format("{0} >= {1}", stopwatch.ElapsedMilliseconds, subsequentInterval.TotalMilliseconds));
+                    Assert.True(stopwatch.ElapsedMilliseconds >= subsequentInterval.TotalMilliseconds,
+                        String.Format("{0} >= {1}", stopwatch.ElapsedMilliseconds,
+                        subsequentInterval.TotalMilliseconds));
                 }
             }
         }


### PR DESCRIPTION
Having IntervalSeparationTimer start as many tasks as it can doesn't actually work end-to-end, because the task goes async as soon as queue polling starts, and exponential backoff means these concurrent queue polling commands basically immediately back off to maximum.

For concurrent execution within the same queue, the logic will need to move lower, tied to finding whether or not a queue message exists, not just when some task goes async.
