### PR TITLE
Handle trying to lease deleted message (fixes #60).

### DIFF
--- a/src/Microsoft.Azure.Jobs.Protocols/PersistentQueueReader.cs
+++ b/src/Microsoft.Azure.Jobs.Protocols/PersistentQueueReader.cs
@@ -88,7 +88,8 @@ namespace Microsoft.Azure.Jobs.Host.Protocols
                 // 1. We tried to mark the item as invisible, and failed (409, someone else won the race)
                 // 2. We then tried to download the item and failed (404, someone else finished processing an item, even
                 // though we owned it).
-                if (TryMakeItemInvisible(possibleNextItem, out createdOn) && TryDownloadItem(possibleNextItem, createdOn, out nextItem))
+                if (TryMakeItemInvisible(possibleNextItem, out createdOn) && TryDownloadItem(possibleNextItem,
+                    createdOn, out nextItem))
                 {
                     break;
                 }
@@ -161,7 +162,8 @@ namespace Microsoft.Azure.Jobs.Host.Protocols
                     // Cast from IListBlobItem to ICloudBlob is safe due to useFlatBlobListing: true in GetSegment.
                     foreach (ICloudBlob blob in segment.Results)
                     {
-                        if (!blob.Metadata.ContainsKey(NextVisibleTimeKey) || IsInPast(blob.Metadata[NextVisibleTimeKey]))
+                        if (!blob.Metadata.ContainsKey(NextVisibleTimeKey) ||
+                            IsInPast(blob.Metadata[NextVisibleTimeKey]))
                         {
                             results.Enqueue(blob);
                         }
@@ -236,7 +238,7 @@ namespace Microsoft.Azure.Jobs.Host.Protocols
             }
             catch (StorageException exception)
             {
-                if (exception.IsPreconditionFailed())
+                if (exception.IsPreconditionFailed() || exception.IsNotFoundBlobNotFound())
                 {
                     return false;
                 }
@@ -315,8 +317,8 @@ namespace Microsoft.Azure.Jobs.Host.Protocols
         {
             ICloudBlob outputBlob = message.Blob;
 
-            // Do a client-side blob copy. Note that StartCopyFromBlob is another option, but that would require polling to
-            // wait for completion.
+            // Do a client-side blob copy. Note that StartCopyFromBlob is another option, but that would require polling
+            // to wait for completion.
             CloudBlockBlob archiveBlob = _archiveContainer.GetBlockBlobReference(message.PopReceipt);
             CopyProperties(outputBlob, archiveBlob);
             CopyMetadata(outputBlob, archiveBlob);

--- a/src/Microsoft.Azure.Jobs.Storage/StorageExceptionExtensions.cs
+++ b/src/Microsoft.Azure.Jobs.Storage/StorageExceptionExtensions.cs
@@ -249,6 +249,43 @@ namespace Microsoft.Azure.Jobs.Host.Storage
         }
 
         /// <summary>
+        /// Determines whether the exception is due to a 404 Not Found error with the error code BlobNotFound.
+        /// </summary>
+        /// <param name="exception">The storage exception.</param>
+        /// <returns>
+        /// <see langword="true"/> if the exception is due to a 404 Not Found error with the error code BlobNotFound;
+        /// otherwise <see langword="false"/>.
+        /// </returns>
+        public static bool IsNotFoundBlobNotFound(this StorageException exception)
+        {
+            if (exception == null)
+            {
+                throw new ArgumentNullException("exception");
+            }
+
+            RequestResult result = exception.RequestInformation;
+
+            if (result == null)
+            {
+                return false;
+            }
+
+            if (result.HttpStatusCode != 404)
+            {
+                return false;
+            }
+
+            StorageExtendedErrorInformation extendedInformation = result.ExtendedErrorInformation;
+
+            if (extendedInformation == null)
+            {
+                return false;
+            }
+
+            return extendedInformation.ErrorCode == "BlobNotFound";
+        }
+
+        /// <summary>
         /// Determines whether the exception is due to a 404 Not Found error with the error code ContainerNotFound.
         /// </summary>
         /// <param name="exception">The storage exception.</param>


### PR DESCRIPTION
If the message has already been deleted, simply return false from TryMakeItemInvisible rather than throwing.
