### PR TITLE
Changed test to signal after guarding for the cancellation token not set

### DIFF
--- a/test/Microsoft.Azure.Jobs.Host.EndToEndTests/AsyncCancellationEndToEndTests.cs
+++ b/test/Microsoft.Azure.Jobs.Host.EndToEndTests/AsyncCancellationEndToEndTests.cs
@@ -83,11 +83,11 @@ namespace Microsoft.Azure.Jobs.Host.EndToEndTests
 
         private static void FunctionBody(CancellationToken token)
         {
-            _functionStarted.Set();
-
             // If the token is cancelled here, something is not right
             if (!token.IsCancellationRequested)
             {
+                _functionStarted.Set();
+
                 _invokeInFunction();
                 _invokeInFunctionInvoked = true;
 


### PR DESCRIPTION
I cannot repro the test failures but I think they happen in the CI run because the host get disposed between the moment when the wait handle is signaled and the not cancelled guard check.

cc @davidmatson 
