### PR TITLE
Call async methods safely from ASP.NET to prevent deadlocks (fixes #122).

### DIFF
--- a/src/Dashboard/App_Start/AppModule.cs
+++ b/src/Dashboard/App_Start/AppModule.cs
@@ -9,6 +9,7 @@ using Dashboard.Data;
 using Dashboard.Data.Logs;
 using Dashboard.HostMessaging;
 using Dashboard.Indexers;
+using Dashboard.Infrastructure;
 using Microsoft.Azure.Jobs;
 using Microsoft.Azure.Jobs.Host.Executors;
 using Microsoft.Azure.Jobs.Protocols;
@@ -104,7 +105,7 @@ namespace Dashboard
             if (account != null)
             {
                 DefaultStorageCredentialsValidator validator = new DefaultStorageCredentialsValidator();
-                validator.ValidateCredentialsAsync(account, CancellationToken.None).GetAwaiter().GetResult();
+                AspNetTaskExecutor.Execute(() => validator.ValidateCredentialsAsync(account, CancellationToken.None));
             }
             return account;
         }

--- a/src/Dashboard/Controllers/FunctionController.cs
+++ b/src/Dashboard/Controllers/FunctionController.cs
@@ -10,6 +10,7 @@ using System.Web.Mvc;
 using Dashboard.ApiControllers;
 using Dashboard.Data;
 using Dashboard.HostMessaging;
+using Dashboard.Infrastructure;
 using Dashboard.ViewModels;
 using Microsoft.Azure.Jobs;
 using Microsoft.Azure.Jobs.Host.Blobs;
@@ -269,7 +270,8 @@ namespace Dashboard.Controllers
 
             try
             {
-                guid = BlobCausalityManager.GetWriterAsync(blob, CancellationToken.None).Result;
+                guid = AspNetTaskExecutor.Execute(
+                    () => BlobCausalityManager.GetWriterAsync(blob, CancellationToken.None));
             }
             catch
             {

--- a/src/Dashboard/Dashboard.csproj
+++ b/src/Dashboard/Dashboard.csproj
@@ -303,6 +303,7 @@
     <Compile Include="Indexers\IHostIndexer.cs" />
     <Compile Include="Indexers\HostIndexer.cs" />
     <Compile Include="Indexers\FunctionIndexer.cs" />
+    <Compile Include="Infrastructure\AspNetTaskExecutor.cs" />
     <Compile Include="Infrastructure\MoreHtmlHelpers.cs" />
     <Compile Include="Results\TextResult.cs" />
     <Compile Include="ViewModels\BlobBoundParamModel.cs" />

--- a/src/Dashboard/Infrastructure/AspNetTaskExecutor.cs
+++ b/src/Dashboard/Infrastructure/AspNetTaskExecutor.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Dashboard.Infrastructure
+{
+    public static class AspNetTaskExecutor
+    {
+        private static readonly TaskFactory _factory = new TaskFactory(TaskScheduler.Default);
+
+        public static void Execute(Func<Task> taskFactory)
+        {
+            if (taskFactory == null)
+            {
+                throw new ArgumentNullException("taskFactory");
+            }
+
+            CultureInfo capturedCulture = CultureInfo.CurrentCulture;
+            CultureInfo capturedUICulture = CultureInfo.CurrentUICulture;
+
+            _factory.StartNew(() =>
+            {
+                Thread.CurrentThread.CurrentCulture = capturedCulture;
+                Thread.CurrentThread.CurrentUICulture = capturedUICulture;
+                return taskFactory.Invoke();
+            }).Unwrap().GetAwaiter().GetResult();
+        }
+
+        public static TResult Execute<TResult>(Func<Task<TResult>> taskFactory)
+        {
+            if (taskFactory == null)
+            {
+                throw new ArgumentNullException("task");
+            }
+
+            CultureInfo capturedCulture = CultureInfo.CurrentCulture;
+            CultureInfo capturedUICulture = CultureInfo.CurrentUICulture;
+
+            return _factory.StartNew(() =>
+            {
+                Thread.CurrentThread.CurrentCulture = capturedCulture;
+                Thread.CurrentThread.CurrentUICulture = capturedUICulture;
+                return taskFactory.Invoke();
+            }).Unwrap().GetAwaiter().GetResult();
+        }
+    }
+}

--- a/src/Dashboard/Infrastructure/LogAnalysis.cs
+++ b/src/Dashboard/Infrastructure/LogAnalysis.cs
@@ -19,6 +19,7 @@ using Microsoft.WindowsAzure.Storage.Blob;
 using Newtonsoft.Json;
 using Microsoft.Azure.Jobs.Host.Executors;
 using System.Threading;
+using Dashboard.Infrastructure;
 
 namespace Dashboard
 {
@@ -139,7 +140,8 @@ namespace Dashboard
 
             try
             {
-                return BlobCausalityManager.GetWriterAsync(blob, CancellationToken.None).Result ?? Guid.Empty;
+                return AspNetTaskExecutor.Execute(
+                    () => BlobCausalityManager.GetWriterAsync(blob, CancellationToken.None)) ?? Guid.Empty;
             }
             catch (StorageException e)
             {

--- a/src/Microsoft.Azure.Jobs/BinderExtensions.cs
+++ b/src/Microsoft.Azure.Jobs/BinderExtensions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Jobs
                 throw new ArgumentNullException("binder");
             }
 
-            return binder.BindAsync<T>(attribute).Result;
+            return binder.BindAsync<T>(attribute).GetAwaiter().GetResult();
         }
     }
 }

--- a/test/Microsoft.Azure.Jobs.Host.IntegrationTests/LocalExecutionContext.cs
+++ b/test/Microsoft.Azure.Jobs.Host.IntegrationTests/LocalExecutionContext.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Jobs.Host.IntegrationTests
             _type = type;
             FunctionIndex index = FunctionIndex.CreateAsync(
                 new FunctionIndexContext(null, null, account, null, CancellationToken.None),
-                new Type[] { type }, cloudBlobStreamBinderTypes).Result;
+                new Type[] { type }, cloudBlobStreamBinderTypes).GetAwaiter().GetResult();
             _index = index;
 
             _blobClient = account.CreateCloudBlobClient();
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.Jobs.Host.IntegrationTests
             ValueBindingContext context = new ValueBindingContext(new FunctionBindingContext(_context, instance.Id,
                 CancellationToken.None, TextWriter.Null), CancellationToken.None);
             FunctionExecutor.ExecuteWithWatchersAsync(instance.Method, instance.Method.GetParameters(),
-                instance.BindingSource.BindAsync(context).Result, TextWriter.Null,
+                instance.BindingSource.BindAsync(context).GetAwaiter().GetResult(), TextWriter.Null,
                 CancellationToken.None).GetAwaiter().GetResult();
         }
     }

--- a/test/Microsoft.Azure.Jobs.Host.IntegrationTests/LocalOrchestratorTests.cs
+++ b/test/Microsoft.Azure.Jobs.Host.IntegrationTests/LocalOrchestratorTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.Jobs.Host.IntegrationTests
             {
                 // $$$ Put this in its own unit test?
                 var blob = account.CreateCloudBlobClient().GetContainerReference("daas-test-input").GetBlockBlobReference("note.csv");
-                var guid = BlobCausalityManager.GetWriterAsync(blob, CancellationToken.None).Result;
+                var guid = BlobCausalityManager.GetWriterAsync(blob, CancellationToken.None).GetAwaiter().GetResult();
 
                 Assert.True(guid != Guid.Empty, "Blob is missing causality information");
             }

--- a/test/Microsoft.Azure.Jobs.Host.UnitTests/Bindings/Data/DataBindingProviderTests.cs
+++ b/test/Microsoft.Azure.Jobs.Host.UnitTests/Bindings/Data/DataBindingProviderTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.Jobs.Host.UnitTests.Bindings.Data
             BindingProviderContext context = CreateBindingContext(parameterName, parameterType);
 
             // Act
-            IBinding binding = product.TryCreateAsync(context).Result;
+            IBinding binding = product.TryCreateAsync(context).GetAwaiter().GetResult();
 
             // Assert
             Assert.Null(binding);
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.Jobs.Host.UnitTests.Bindings.Data
             BindingProviderContext context = CreateBindingContext(parameterName, parameterType);
 
             // Act
-            IBinding binding = product.TryCreateAsync(context).Result;
+            IBinding binding = product.TryCreateAsync(context).GetAwaiter().GetResult();
 
             // Assert
             Assert.Null(binding);
@@ -70,7 +70,7 @@ namespace Microsoft.Azure.Jobs.Host.UnitTests.Bindings.Data
             BindingProviderContext context = CreateBindingContext(parameterName, parameterType);
 
             // Act
-            IBinding binding = product.TryCreateAsync(context).Result;
+            IBinding binding = product.TryCreateAsync(context).GetAwaiter().GetResult();
 
             // Assert
             Assert.NotNull(binding);

--- a/test/Microsoft.Azure.Jobs.Host.UnitTests/Blobs/Listeners/BlobTriggerExecutorTests.cs
+++ b/test/Microsoft.Azure.Jobs.Host.UnitTests/Blobs/Listeners/BlobTriggerExecutorTests.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Azure.Jobs.Host.UnitTests.Blobs.Listeners
             ICloudBlob possibleTrigger = inputContainer.GetBlockBlobReference(input.BlobName);
 
             return BlobTriggerExecutor.ShouldExecuteTriggerAsync(possibleTrigger, new FixedBlobPathSource(input),
-                outputs, new LambdaTimestampReader(LookupTime), CancellationToken.None).Result;
+                outputs, new LambdaTimestampReader(LookupTime), CancellationToken.None).GetAwaiter().GetResult();
         }
 
         private static BlobPath CreateInput(string containerName, string blobName)

--- a/test/Microsoft.Azure.Jobs.Host.UnitTests/Blobs/WatchableReadStreamTests.cs
+++ b/test/Microsoft.Azure.Jobs.Host.UnitTests/Blobs/WatchableReadStreamTests.cs
@@ -1401,7 +1401,7 @@ namespace Microsoft.Azure.Jobs.Host.UnitTests.Blobs
             using (WatchableReadStream product = CreateProductUnderTest(innerStream))
             {
                 byte[] buffer = new byte[contents.Length];
-                int bytesRead = product.ReadAsync(buffer, 0, buffer.Length).Result;
+                int bytesRead = product.ReadAsync(buffer, 0, buffer.Length).GetAwaiter().GetResult();
                 Assert.Equal(bytesRead, buffer.Length); // Guard
 
                 // Act

--- a/test/Microsoft.Azure.Jobs.Host.UnitTests/Indexers/FunctionIndexerTests.cs
+++ b/test/Microsoft.Azure.Jobs.Host.UnitTests/Indexers/FunctionIndexerTests.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.Jobs.Host.UnitTests.Indexers
             FunctionIndexer product = CreateProductUnderTest();
 
             // Act
-            product.IndexMethodAsync(typeof(FunctionIndexerTests).GetMethod("MethodWithGenericParameter"), indexMock.Object, CancellationToken.None).Wait();
+            product.IndexMethodAsync(typeof(FunctionIndexerTests).GetMethod("MethodWithGenericParameter"), indexMock.Object, CancellationToken.None).GetAwaiter().GetResult();
 
             // Verify
             indexMock.Verify(i => i.Add(It.IsAny<IFunctionDefinition>(), It.IsAny<FunctionDescriptor>(), It.IsAny<MethodInfo>()), Times.Never);

--- a/test/Microsoft.Azure.Jobs.Host.UnitTests/Loggers/UpdateOutputLogCommandExtensions.cs
+++ b/test/Microsoft.Azure.Jobs.Host.UnitTests/Loggers/UpdateOutputLogCommandExtensions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.Jobs.Host.UnitTests.Loggers
                 throw new ArgumentNullException("command");
             }
 
-            return command.TryExecuteAsync(CancellationToken.None).Result;
+            return command.TryExecuteAsync(CancellationToken.None).GetAwaiter().GetResult();
         }
 
         public static void SaveAndClose(this UpdateOutputLogCommand command)

--- a/test/Microsoft.Azure.Jobs.Host.UnitTests/Loggers/UpdateOutputLogCommandTests.cs
+++ b/test/Microsoft.Azure.Jobs.Host.UnitTests/Loggers/UpdateOutputLogCommandTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.Jobs.Host.UnitTests.Loggers
             string content = null;
             Func<string, CancellationToken, Task> fp = (x, _) => { content = x; return Task.FromResult(0); };
             UpdateOutputLogCommand writer = UpdateOutputLogCommand.CreateAsync(
-                new CloudBlockBlob(new Uri("aa://b/c")), null, fp, CancellationToken.None).Result;
+                new CloudBlockBlob(new Uri("aa://b/c")), null, fp, CancellationToken.None).GetAwaiter().GetResult();
 
             var tw = writer.Output;
             tw.Write("1");


### PR DESCRIPTION
I also made some minor orthogonal improvements to accessing Task results elsewhere (using GetAwaiter().GetResult() for better exceptions).
