### PR TITLE
Streamlined NULL and empty behaviour across argument binders (fixes #109).

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Blobs/Bindings/CloudBlobStreamArgumentBinderProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Blobs/Bindings/CloudBlobStreamArgumentBinderProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Threading;
@@ -87,6 +88,9 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
 
                 public async Task SetValueAsync(object value, CancellationToken cancellationToken)
                 {
+                    Debug.Assert(value == null || value == GetValue(), 
+                        "The value argument should be either the same instance as returned by GetValue() or null");
+
                     // Not ByRef, so can ignore value argument.
 
                     // Determine whether or not to upload the blob.

--- a/src/Microsoft.Azure.WebJobs.Host/Blobs/Bindings/OutStringArgumentBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Blobs/Bindings/OutStringArgumentBindingProvider.cs
@@ -86,8 +86,37 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
                     return null;
                 }
 
+                /// <summary>
+                /// Stores content of a string in utf-8 encoded format into the bound CloudBLob.
+                /// </summary>
+                /// <param name="value">string object as retrieved from user's WebJobs method argument.</param>
+                /// <param name="cancellationToken">a cancellation token</param>
+                /// <remarks>As this method handles out string parameter it distinguishes following possible scenarios:
+                /// <list type="bullet">
+                /// <item>
+                /// <description>
+                /// the value is null - no CloudBlob will be created;
+                /// </description>
+                /// </item>
+                /// <item>
+                /// <description>
+                /// the value is an empty string - a CloudBlob with empty content will be created;
+                /// </description>
+                /// </item>
+                /// <item>
+                /// <description>
+                /// the value is a non-empty string - a CloudBlob with content from given string will be created.
+                /// </description>
+                /// </item>
+                /// </list>
+                /// </remarks>
                 public async Task SetValueAsync(object value, CancellationToken cancellationToken)
                 {
+                    if (value == null)
+                    {
+                        return;
+                    }
+
                     string text = (string)value;
 
                     const int defaultBufferSize = 1024;

--- a/src/Microsoft.Azure.WebJobs.Host/Blobs/Bindings/TextWriterArgumentBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Blobs/Bindings/TextWriterArgumentBindingProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Text;
@@ -93,6 +94,9 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
 
                 public async Task SetValueAsync(object value, CancellationToken cancellationToken)
                 {
+                    Debug.Assert(value == null || value == GetValue(),
+                        "The value argument should be either the same instance as returned by GetValue() or null");
+
                     // Not ByRef, so can ignore value argument.
                     cancellationToken.ThrowIfCancellationRequested();
                     await _value.FlushAsync();

--- a/src/Microsoft.Azure.WebJobs.Host/Blobs/StreamArgumentBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Blobs/StreamArgumentBindingProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Threading;
@@ -115,6 +116,9 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs
 
                 public async Task SetValueAsync(object value, CancellationToken cancellationToken)
                 {
+                    Debug.Assert(value == null || value == GetValue(),
+                        "The value argument should be either the same instance as returned by GetValue() or null");
+
                     // Not ByRef, so can ignore value argument.
 
                     // Determine whether or not to upload the blob.

--- a/src/Microsoft.Azure.WebJobs.Host/JsonCustom.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/JsonCustom.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Host
 {
@@ -56,7 +57,7 @@ namespace Microsoft.Azure.WebJobs.Host
 
         public static string SerializeObject(object o)
         {
-            return JsonConvert.SerializeObject(o, _settings);
+            return (o != null) ? JsonConvert.SerializeObject(o, _settings) : new JValue(o).ToString();
         }
 
         public static T DeserializeObject<T>(string json)

--- a/src/Microsoft.Azure.WebJobs.Host/Queues/Bindings/ByteArrayArgumentBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Queues/Bindings/ByteArrayArgumentBinding.cs
@@ -53,8 +53,35 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Bindings
                 return _queue.Name;
             }
 
+            /// <summary>
+            /// Creates and sends a CloudQueueMessage with content provided in specified byte array.
+            /// </summary>
+            /// <param name="value">byte array as retrieved from user's WebJobs method argument.</param>
+            /// <param name="cancellationToken">a cancellation token</param>
+            /// <remarks>As this method handles out byte array parameter it distinguishes following possible scenarios:
+            /// <item>
+            /// <description>
+            /// the value is null - no message will be sent;
+            /// </description>
+            /// </item>
+            /// <item>
+            /// <description>
+            /// the value is an empty byte array - a message with empty content will be sent;
+            /// </description>
+            /// </item>
+            /// <item>
+            /// <description>
+            /// the value is a non-empty byte array - a message with content from given argument will be sent.
+            /// </description>
+            /// </item>
+            /// </remarks>
             public async Task SetValueAsync(object value, CancellationToken cancellationToken)
             {
+                if (value == null)
+                {
+                    return;
+                }
+
                 byte[] bytes = (byte[])value;
 
                 await _queue.AddMessageAndCreateIfNotExistsAsync(new CloudQueueMessage(bytes), cancellationToken);

--- a/src/Microsoft.Azure.WebJobs.Host/Queues/Bindings/CloudQueueMessageArgumentBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Queues/Bindings/CloudQueueMessageArgumentBinding.cs
@@ -53,8 +53,35 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Bindings
                 return _queue.Name;
             }
 
+            /// <summary>
+            /// Sends a CloudQueueMessage to the bound queue.
+            /// </summary>
+            /// <param name="value">CloudQueueMessage instance as retrieved from user's WebJobs method argument.</param>
+            /// <param name="cancellationToken">a cancellation token</param>
+            /// <remarks>As this method handles out message instance parameter it distinguishes following possible scenarios:
+            /// <item>
+            /// <description>
+            /// the value is null - no message will be sent;
+            /// </description>
+            /// </item>
+            /// <item>
+            /// <description>
+            /// the value is an instance with empty content - a message with empty content will be sent;
+            /// </description>
+            /// </item>
+            /// <item>
+            /// <description>
+            /// the value is an instance with non-empty content - a message with content from given argument will be sent.
+            /// </description>
+            /// </item>
+            /// </remarks>
             public async Task SetValueAsync(object value, CancellationToken cancellationToken)
             {
+                if (value == null)
+                {
+                    return;
+                }
+
                 CloudQueueMessage message = (CloudQueueMessage)value;
 
                 await _queue.AddMessageAndCreateIfNotExistsAsync(message, cancellationToken);

--- a/src/Microsoft.Azure.WebJobs.Host/Queues/Bindings/CollectionArgumentBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Queues/Bindings/CollectionArgumentBindingProvider.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
+using System.Diagnostics;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -121,6 +121,9 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Bindings
 
                 public async Task SetValueAsync(object value, CancellationToken cancellationToken)
                 {
+                    Debug.Assert(value == null || value == GetValue(),
+                        "The value argument should be either the same instance as returned by GetValue() or null");
+
                     // Not ByRef, so can ignore value argument.
                     foreach (TItem item in _value)
                     {

--- a/src/Microsoft.Azure.WebJobs.Host/Queues/Bindings/StringArgumentBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Queues/Bindings/StringArgumentBinding.cs
@@ -53,8 +53,35 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Bindings
                 return _queue.Name;
             }
 
+            /// <summary>
+            /// Creates and sends a CloudQueueMessage with content provided in specified string.
+            /// </summary>
+            /// <param name="value">string as retrieved from user's WebJobs method argument.</param>
+            /// <param name="cancellationToken">a cancellation token</param>
+            /// <remarks>As this method handles out string parameter it distinguishes following possible scenarios:
+            /// <item>
+            /// <description>
+            /// the value is null - no message will be sent;
+            /// </description>
+            /// </item>
+            /// <item>
+            /// <description>
+            /// the value is an empty string - a message with empty content will be sent;
+            /// </description>
+            /// </item>
+            /// <item>
+            /// <description>
+            /// the value is a non-empty string - a message with content from given argument will be sent.
+            /// </description>
+            /// </item>
+            /// </remarks>
             public async Task SetValueAsync(object value, CancellationToken cancellationToken)
             {
+                if (value == null)
+                {
+                    return;
+                }
+
                 string text = (string)value;
 
                 await _queue.AddMessageAndCreateIfNotExistsAsync(new CloudQueueMessage(text), cancellationToken);

--- a/src/Microsoft.Azure.WebJobs.Host/Queues/QueueCausalityManager.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Queues/QueueCausalityManager.cs
@@ -4,32 +4,38 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.Contracts;
 using Microsoft.WindowsAzure.Storage.Queue;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Host.Queues
 {
-    // This tracks causality via the queue message payload. 
-    // Important that this can interoperate with external queue messages, so be resilient to a missing guid marker. 
-    // Can we switch to some auxillary table? Beware, CloudQueueMessage.Id is not 
-    // filled out until after the message is queued, but then there's a race between updating 
-    // the aux storage and another function picking up the message.
+    /// <summary>
+    /// Tracks causality via JSON formatted queue message content. 
+    /// Adds an extra field to the JSON object for the parent guid name.
+    /// </summary>
+    /// <remarks>
+    /// Important that this class can interoperate with external queue messages, 
+    /// so be resilient to a missing guid marker. 
+    /// Can we switch to some auxillary table? Beware, CloudQueueMessage. 
+    /// Id is not filled out until after the message is queued, 
+    /// but then there's a race between updating the aux storage and another function picking up the message.
+    /// </remarks>
     internal static class QueueCausalityManager
     {
-        // Serialize Payloads as JSON. Add an extra field to the JSON object for the parent guid name.
         const string parentGuidFieldName = "$AzureWebJobsParentId";
 
-        // When we enqueue, add the 
-        public static CloudQueueMessage EncodePayload(Guid functionOwner, object payload)
+        public static void SetOwner(Guid functionOwner, JObject token)
         {
-            JToken token = JToken.FromObject(payload);
-            token[parentGuidFieldName] = functionOwner.ToString();
+            if (token == null)
+            {
+                throw new ArgumentNullException("token");
+            }
 
-            string json = token.ToString();
-
-            CloudQueueMessage msg = new CloudQueueMessage(json);
-            // Beware, msg.id is not filled out yet. 
-            return msg;
+            if (functionOwner != null && !Guid.Equals(Guid.Empty, functionOwner))
+            {
+                token[parentGuidFieldName] = functionOwner.ToString();
+            }
         }
 
         [DebuggerNonUserCode]

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/BrokeredMessageArgumentBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/BrokeredMessageArgumentBinding.cs
@@ -53,11 +53,38 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Bindings
                 return _entity.MessageSender.Path;
             }
 
-            public Task SetValueAsync(object value, CancellationToken cancellationToken)
+            /// <summary>
+            /// Sends a BrokeredMessage to the bound queue.
+            /// </summary>
+            /// <param name="value">BrokeredMessage instance as retrieved from user's WebJobs method argument.</param>
+            /// <param name="cancellationToken">a cancellation token</param>
+            /// <remarks>As this method handles out message instance parameter it distinguishes following possible scenarios:
+            /// <item>
+            /// <description>
+            /// the value is null - no message will be sent;
+            /// </description>
+            /// </item>
+            /// <item>
+            /// <description>
+            /// the value is an instance with empty content - a message with empty content will be sent;
+            /// </description>
+            /// </item>
+            /// <item>
+            /// <description>
+            /// the value is an instance with non-empty content - a message with content from given argument will be sent.
+            /// </description>
+            /// </item>
+            /// </remarks>
+            public async Task SetValueAsync(object value, CancellationToken cancellationToken)
             {
+                if (value == null)
+                {
+                    return;
+                }
+
                 BrokeredMessage message = (BrokeredMessage)value;
 
-                return _entity.SendAndCreateQueueIfNotExistsAsync(message, _functionInstanceId, cancellationToken);
+                await _entity.SendAndCreateQueueIfNotExistsAsync(message, _functionInstanceId, cancellationToken);
             }
         }
     }

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/ByteArrayArgumentBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/ByteArrayArgumentBinding.cs
@@ -54,8 +54,35 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Bindings
                 return _entity.MessageSender.Path;
             }
 
+            /// <summary>
+            /// Creates and sends a BrokeredMessage with content provided in specified byte array.
+            /// </summary>
+            /// <param name="value">byte array as retrieved from user's WebJobs method argument.</param>
+            /// <param name="cancellationToken">a cancellation token</param>
+            /// <remarks>As this method handles out byte array parameter it distinguishes following possible scenarios:
+            /// <item>
+            /// <description>
+            /// the value is null - no message will be sent;
+            /// </description>
+            /// </item>
+            /// <item>
+            /// <description>
+            /// the value is an empty byte array - a message with empty content will be sent;
+            /// </description>
+            /// </item>
+            /// <item>
+            /// <description>
+            /// the value is a non-empty byte array - a message with content from given argument will be sent.
+            /// </description>
+            /// </item>
+            /// </remarks>
             public async Task SetValueAsync(object value, CancellationToken cancellationToken)
             {
+                if (value == null)
+                {
+                    return;
+                }
+
                 byte[] bytes = (byte[])value;
 
                 using (MemoryStream stream = new MemoryStream(bytes, writable: false))

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/CollectionArgumentBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/CollectionArgumentBindingProvider.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -120,6 +121,9 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Bindings
 
                 public async Task SetValueAsync(object value, CancellationToken cancellationToken)
                 {
+                    Debug.Assert(value == null || value == GetValue(),
+                        "The value argument should be either the same instance as returned by GetValue() or null");
+
                     // Not ByRef, so can ignore value argument.
                     foreach (T item in _value)
                     {

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/StringArgumentBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/StringArgumentBinding.cs
@@ -55,8 +55,35 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Bindings
                 return _entity.MessageSender.Path;
             }
 
+            /// <summary>
+            /// Creates and sends a BrokeredMessage with content provided in specified string.
+            /// </summary>
+            /// <param name="value">string as retrieved from user's WebJobs method argument.</param>
+            /// <param name="cancellationToken">a cancellation token</param>
+            /// <remarks>As this method handles out string parameter it distinguishes following possible scenarios:
+            /// <item>
+            /// <description>
+            /// the value is null - no message will be sent;
+            /// </description>
+            /// </item>
+            /// <item>
+            /// <description>
+            /// the value is an empty string - a message with empty content will be sent;
+            /// </description>
+            /// </item>
+            /// <item>
+            /// <description>
+            /// the value is a non-empty string - a message with content from given argument will be sent.
+            /// </description>
+            /// </item>
+            /// </remarks>
             public async Task SetValueAsync(object value, CancellationToken cancellationToken)
             {
+                if (value == null)
+                {
+                    return;
+                }
+
                 string text = (string)value;
                 byte[] bytes = StrictEncodings.Utf8.GetBytes(text);
 

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/ExceptionAssert.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/ExceptionAssert.cs
@@ -13,6 +13,12 @@ namespace Microsoft.Azure.WebJobs.Host.TestCommon
             Assert.DoesNotThrow(() => action.Invoke());
         }
 
+        public static void ThrowsArgument(Action action, string expectedParameterName)
+        {
+            ArgumentException exception = Assert.Throws<ArgumentException>(() => action.Invoke());
+            Assert.Equal(expectedParameterName, exception.ParamName);
+        }
+
         public static void ThrowsArgument(Action action, string expectedParameterName, string expectedMessage)
         {
             ArgumentException exception = Assert.Throws<ArgumentException>(() => action.Invoke());


### PR DESCRIPTION
1. Added NULL value case to skip sending a message for string, ByteArray, CloudQueueMessage, and BrokeredMessage argument binders.
2. Added special case for NULL value of user data out parameter to send `null` as valid JSON representation of NULL value.
3. Added throw statement for NULL value at the rest of non-ref argument binders for sanity check.
4. Moved Json serialization logic out of QueueCausalityManager method.
