### PR TITLE
Fixed function indexer regression issue (fixes #185).

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexer.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexer.cs
@@ -63,14 +63,14 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
                 return false;
             }
 
-            if (method.GetParameters().Length == 0)
-            {
-                return false;
-            }
-
             if (method.GetCustomAttributesData().Any(HasSdkAttribute))
             {
                 return true;
+            }
+
+            if (method.GetParameters().Length == 0)
+            {
+                return false;
             }
 
             if (method.GetParameters().Any(p => p.GetCustomAttributesData().Any(HasSdkAttribute)))


### PR DESCRIPTION
Changed order of if-statements in main sdk method filter of the FunctionIndexer to allow methods with no parameters but having sdk method attribute to be discovered.
