### PR TITLE
Re-factored blob causality mechanics (fixes #31).

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Blobs/Bindings/BlobCommittedAction.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Blobs/Bindings/BlobCommittedAction.cs
@@ -11,27 +11,22 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
     internal class BlobCommittedAction : IBlobCommitedAction
     {
         private readonly ICloudBlob _blob;
-        private readonly Guid _functionInstanceId;
         private readonly IBlobWrittenWatcher _blobWrittenWatcher;
 
-        public BlobCommittedAction(ICloudBlob blob, Guid functionInstanceId, IBlobWrittenWatcher blobWrittenWatcher)
+        public BlobCommittedAction(ICloudBlob blob, IBlobWrittenWatcher blobWrittenWatcher)
         {
             _blob = blob;
-            _functionInstanceId = functionInstanceId;
             _blobWrittenWatcher = blobWrittenWatcher;
         }
 
-        public async Task ExecuteAsync(CancellationToken cancellationToken)
+        public Task ExecuteAsync(CancellationToken cancellationToken)
         {
-            // This is the critical call to record causality. 
-            // This must be called after the blob is written, since it may stamp the blob. 
-            await BlobCausalityManager.SetWriterAsync(_blob, _functionInstanceId, cancellationToken);
-
-            // Notify that blob is available. 
             if (_blobWrittenWatcher != null)
             {
                 _blobWrittenWatcher.Notify(_blob);
             }
+
+            return Task.FromResult(0);
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Blobs/Bindings/WriteBlobArgumentBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Blobs/Bindings/WriteBlobArgumentBinding.cs
@@ -19,9 +19,10 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
                 throw new InvalidOperationException("Cannot bind a page blob using an out string.");
             }
 
+            BlobCausalityManager.SetWriter(blob.Metadata, context.FunctionInstanceId);
+
             CloudBlobStream rawStream = await blockBlob.OpenWriteAsync(context.CancellationToken);
-            IBlobCommitedAction committedAction = new BlobCommittedAction(blob, context.FunctionInstanceId,
-                context.BlobWrittenWatcher);
+            IBlobCommitedAction committedAction = new BlobCommittedAction(blob, context.BlobWrittenWatcher);
             return new WatchableCloudBlobStream(rawStream, committedAction);
         }
     }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Blobs/BlobCausalityManagerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Blobs/BlobCausalityManagerTests.cs
@@ -1,0 +1,157 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.Blobs;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Blob;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Host.UnitTests.Blobs
+{
+    public class BlobCausalityManagerTests
+    {
+        [Fact]
+        public void SetWriter_IfValidGuid_AddsWriter()
+        {
+            // Arrange
+            IDictionary<string, string> metadata = new Dictionary<string, string>();
+            Guid g = Guid.NewGuid();
+
+            // Act
+            BlobCausalityManager.SetWriter(metadata, g);
+
+            // Assert
+            AssertWriterEqual(g, metadata);
+        }
+
+        [Fact]
+        public void SetWriter_IfNullObject_Throws()
+        {
+            // Arrange
+            Guid g = Guid.NewGuid();
+
+            // Act & Assert
+            ExceptionAssert.ThrowsArgumentNull(() => BlobCausalityManager.SetWriter(null, g), "metadata");
+        }
+
+        [Fact]
+        public void GetWriter_IfMetadataDoesNotHaveWriterProperty_ReturnsNull()
+        {
+            // Arrange
+            Mock<ICloudBlob> blobMock = SetupBlobMock(isFetchSuccess: true);
+
+            // Act
+            Guid? writer = BlobCausalityManager.GetWriterAsync(blobMock.Object, CancellationToken.None).GetAwaiter().GetResult();
+
+            // Assert
+            Assert.Null(writer);
+            blobMock.Verify();
+        }
+
+        [Fact]
+        public void GetWriter_IfFetchFails_ReturnsNull()
+        {
+            // Arrange
+            Mock<ICloudBlob> blobMock = SetupBlobMock(isFetchSuccess: false);
+
+            // Act
+            Guid? writer = BlobCausalityManager.GetWriterAsync(blobMock.Object, CancellationToken.None).GetAwaiter().GetResult();
+
+            // Assert
+            Assert.Null(writer);
+            blobMock.Verify();
+        }
+
+        [Fact]
+        public void GetWriter_IfMetadataPropertyIsNotGuid_ReturnsNull()
+        {
+            // Arrange
+            Mock<ICloudBlob> blobMock = SetupBlobMock(isFetchSuccess: true);
+            blobMock.Object.Metadata[BlobCausalityManager.MetadataKeyName] = "abc";
+
+            // Act
+            Guid? writer = BlobCausalityManager.GetWriterAsync(blobMock.Object, CancellationToken.None).GetAwaiter().GetResult();
+
+            // Assert
+            Assert.Null(writer);
+            blobMock.Verify();
+        }
+
+        [Fact]
+        public void GetWriter_IfMetadataPropertyIsGuid_ReturnsThatGuid()
+        {
+            // Arrange
+            Guid expected = Guid.NewGuid();
+            Mock<ICloudBlob> blobMock = SetupBlobMock(isFetchSuccess: true);
+            blobMock.Object.Metadata[BlobCausalityManager.MetadataKeyName] = expected.ToString();
+
+            // Act
+            Guid? writer = BlobCausalityManager.GetWriterAsync(blobMock.Object, CancellationToken.None).GetAwaiter().GetResult();
+
+            // Assert
+            Assert.Equal(expected, writer);
+            blobMock.Verify();
+        }
+
+        private static void AssertWriterEqual(Guid expectedWriter, IDictionary<string, string> metadata)
+        {
+            Guid? owner = GetWriter(metadata);
+            Assert.Equal(expectedWriter, owner);
+        }
+
+        private static void AssertWriterIsNull(IDictionary<string, string> metadata)
+        {
+            Guid? writer = GetWriter(metadata);
+            Assert.Null(writer);
+        }
+
+        private static Mock<ICloudBlob> SetupBlobMock(bool? isFetchSuccess = null)
+        {
+            Dictionary<string, string> metadata = new Dictionary<string, string>();
+            var blobMock = new Mock<ICloudBlob>(MockBehavior.Strict);
+            blobMock.Setup(s => s.Metadata).Returns(metadata);
+            
+            if (isFetchSuccess.HasValue)
+            {
+                var fetchAttributesSetup = blobMock.Setup(s => s.FetchAttributesAsync(It.IsAny<CancellationToken>()));
+                if (isFetchSuccess.Value)
+                {
+                    fetchAttributesSetup.Returns(Task.FromResult(0));
+                }
+                else
+                {
+                    RequestResult requestResult = new RequestResult();
+                    requestResult.HttpStatusCode = 404;
+                    StorageException blobNotFoundException = new StorageException(requestResult, String.Empty, null);
+                    fetchAttributesSetup.Throws(blobNotFoundException);
+                }
+                fetchAttributesSetup.Verifiable();
+            }
+
+            return blobMock;
+        }
+
+        private static Guid? GetWriter(IDictionary<string, string> metadata)
+        {
+            if (!metadata.ContainsKey(BlobCausalityManager.MetadataKeyName))
+            {
+                return null;
+            }
+
+            string val = metadata[BlobCausalityManager.MetadataKeyName];
+            Guid result;
+            if (Guid.TryParse(val, out result))
+            {
+                return result;
+            }
+
+            return null;
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Blobs\Bindings\SetupOfCloudBlobStreamICancellableAsyncResultExtensions.cs" />
     <Compile Include="Blobs\Bindings\SetupOfCloudBlobStreamIAsyncResultExtensions.cs" />
     <Compile Include="Blobs\Bindings\UncompletedCancellableAsyncResult.cs" />
+    <Compile Include="Blobs\BlobCausalityManagerTests.cs" />
     <Compile Include="Blobs\CompletingAsyncResult.cs" />
     <Compile Include="Blobs\Listeners\BlobQueueTriggerExecutorTests.cs" />
     <Compile Include="Blobs\Listeners\BlobTriggerExecutorTests.cs" />


### PR DESCRIPTION
Re-factored cloud blob binding to call BlobCausalityManager at the moment when BindAsync is called as opposed to WatchableCloudBlobStream commit action as it had been before. This approach is based on assumption (and verified!) blob metadata is to be updated by Azure Storage SDK on next blob write operation. Therefore dedicated metadata fetch/update/upload cycle becomes redundant.

Moved implementation code of IBlobArgumentBinding replicated 5x times into stand-alone class WriteStreamBasedArgumentBinding.

Wrapped instantiation logic of WatchableCloudBlobStream into a builder class with a "fluent" interface.

Added unit-tests where possible. Ran integration and end-to-end tests to verify no regressions introduced with the change.
