### PR TITLE
Reduce creation code duplication in blob bindings.

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Blobs/Bindings/CloudBlobStreamArgumentBinderProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Blobs/Bindings/CloudBlobStreamArgumentBinderProvider.cs
@@ -44,17 +44,8 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
 
             public async Task<IValueProvider> BindAsync(ICloudBlob blob, ValueBindingContext context)
             {
-                CloudBlockBlob blockBlob = blob as CloudBlockBlob;
-
-                if (blockBlob == null)
-                {
-                    throw new InvalidOperationException("Cannot bind a page blob to a CloudBlobStream.");
-                }
-
-                CloudBlobStream rawStream = await blockBlob.OpenWriteAsync(context.CancellationToken);
-                IBlobCommitedAction committedAction = new BlobCommittedAction(blob, context.FunctionInstanceId,
-                    context.BlobWrittenWatcher);
-                WatchableCloudBlobStream watchableStream = new WatchableCloudBlobStream(rawStream, committedAction);
+                WatchableCloudBlobStream watchableStream = await WriteBlobArgumentBinding.BindStreamAsync(blob,
+                    context);
                 return new CloudBlobStreamValueBinder(blob, watchableStream);
             }
 

--- a/src/Microsoft.Azure.WebJobs.Host/Blobs/Bindings/OutObjectArgumentBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Blobs/Bindings/OutObjectArgumentBindingProvider.cs
@@ -61,17 +61,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
 
             public async Task<IValueProvider> BindAsync(ICloudBlob blob, ValueBindingContext context)
             {
-                CloudBlockBlob blockBlob = blob as CloudBlockBlob;
-
-                if (blockBlob == null)
-                {
-                    throw new InvalidOperationException("Cannot bind a page blob using an ICloudBlobStreamBinder.");
-                }
-
-                CloudBlobStream rawStream = await blockBlob.OpenWriteAsync(context.CancellationToken);
-                IBlobCommitedAction committedAction = new BlobCommittedAction(blob, context.FunctionInstanceId,
-                    context.BlobWrittenWatcher);
-                WatchableCloudBlobStream watchableStream = new WatchableCloudBlobStream(rawStream, committedAction);
+                WatchableCloudBlobStream watchableStream = await WriteBlobArgumentBinding.BindStreamAsync(blob, context);
                 return new ObjectValueBinder(blob, watchableStream, _objectBinder, _valueType);
             }
 

--- a/src/Microsoft.Azure.WebJobs.Host/Blobs/Bindings/OutStringArgumentBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Blobs/Bindings/OutStringArgumentBindingProvider.cs
@@ -44,17 +44,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
 
             public async Task<IValueProvider> BindAsync(ICloudBlob blob, ValueBindingContext context)
             {
-                CloudBlockBlob blockBlob = blob as CloudBlockBlob;
-
-                if (blockBlob == null)
-                {
-                    throw new InvalidOperationException("Cannot bind a page blob using an out string.");
-                }
-
-                CloudBlobStream rawStream = await blockBlob.OpenWriteAsync(context.CancellationToken);
-                IBlobCommitedAction committedAction = new BlobCommittedAction(blob, context.FunctionInstanceId,
-                    context.BlobWrittenWatcher);
-                WatchableCloudBlobStream watchableStream = new WatchableCloudBlobStream(rawStream, committedAction);
+                WatchableCloudBlobStream watchableStream = await WriteBlobArgumentBinding.BindStreamAsync(blob, context);
                 return new StringValueBinder(blob, watchableStream);
             }
 

--- a/src/Microsoft.Azure.WebJobs.Host/Blobs/Bindings/TextWriterArgumentBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Blobs/Bindings/TextWriterArgumentBindingProvider.cs
@@ -45,17 +45,8 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
 
             public async Task<IValueProvider> BindAsync(ICloudBlob blob, ValueBindingContext context)
             {
-                CloudBlockBlob blockBlob = blob as CloudBlockBlob;
-
-                if (blockBlob == null)
-                {
-                    throw new InvalidOperationException("Cannot bind a page blob to a TextWriter.");
-                }
-
-                CloudBlobStream rawStream = await blockBlob.OpenWriteAsync(context.CancellationToken);
-                IBlobCommitedAction committedAction = new BlobCommittedAction(blob, context.FunctionInstanceId,
-                    context.BlobWrittenWatcher);
-                WatchableCloudBlobStream watchableStream = new WatchableCloudBlobStream(rawStream, committedAction);
+                WatchableCloudBlobStream watchableStream = await WriteBlobArgumentBinding.BindStreamAsync(blob,
+                    context);
                 const int defaultBufferSize = 1024;
                 TextWriter writer = new StreamWriter(watchableStream, Encoding.UTF8, defaultBufferSize,
                     leaveOpen: true);

--- a/src/Microsoft.Azure.WebJobs.Host/Blobs/Bindings/WriteBlobArgumentBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Blobs/Bindings/WriteBlobArgumentBinding.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.WindowsAzure.Storage.Blob;
+
+namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
+{
+    internal static class WriteBlobArgumentBinding
+    {
+        public static async Task<WatchableCloudBlobStream> BindStreamAsync(ICloudBlob blob, ValueBindingContext context)
+        {
+            CloudBlockBlob blockBlob = blob as CloudBlockBlob;
+
+            if (blockBlob == null)
+            {
+                throw new InvalidOperationException("Cannot bind a page blob using an out string.");
+            }
+
+            CloudBlobStream rawStream = await blockBlob.OpenWriteAsync(context.CancellationToken);
+            IBlobCommitedAction committedAction = new BlobCommittedAction(blob, context.FunctionInstanceId,
+                context.BlobWrittenWatcher);
+            return new WatchableCloudBlobStream(rawStream, committedAction);
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Blobs/ObjectArgumentBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Blobs/ObjectArgumentBindingProvider.cs
@@ -69,8 +69,8 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs
                 object value;
                 ParameterLog status;
 
-                using (Stream rawStream = await blob.OpenReadAsync(context.CancellationToken))
-                using (WatchableReadStream watchableStream = new WatchableReadStream(rawStream))
+                using (WatchableReadStream watchableStream = await ReadBlobArgumentBinding.BindStreamAsync(blob,
+                    context))
                 {
                     value = await _objectBinder.ReadFromStreamAsync(watchableStream, context.CancellationToken);
                     status = watchableStream.GetStatus();

--- a/src/Microsoft.Azure.WebJobs.Host/Blobs/ReadBlobArgumentBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Blobs/ReadBlobArgumentBinding.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.WindowsAzure.Storage.Blob;
+
+namespace Microsoft.Azure.WebJobs.Host.Blobs
+{
+    internal static class ReadBlobArgumentBinding
+    {
+        public static async Task<WatchableReadStream> BindStreamAsync(ICloudBlob blob, ValueBindingContext context)
+        {
+            Stream rawStream = await blob.OpenReadAsync(context.CancellationToken);
+            return new WatchableReadStream(rawStream);
+        }
+
+        public static TextReader CreateTextReader(WatchableReadStream watchableStream)
+        {
+            return new StreamReader(watchableStream);
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Blobs/StringArgumentBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Blobs/StringArgumentBindingProvider.cs
@@ -46,9 +46,9 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs
                 string value;
                 ParameterLog status;
 
-                using (Stream rawStream = await blob.OpenReadAsync(context.CancellationToken))
-                using (WatchableReadStream watchableStream = new WatchableReadStream(rawStream))
-                using (TextReader reader = new StreamReader(watchableStream))
+                using (WatchableReadStream watchableStream = await ReadBlobArgumentBinding.BindStreamAsync(blob,
+                    context))
+                using (TextReader reader = ReadBlobArgumentBinding.CreateTextReader(watchableStream))
                 {
                     context.CancellationToken.ThrowIfCancellationRequested();
                     value = await reader.ReadToEndAsync();

--- a/src/Microsoft.Azure.WebJobs.Host/Blobs/TextReaderArgumentBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Blobs/TextReaderArgumentBindingProvider.cs
@@ -44,11 +44,11 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs
 
             public async Task<IValueProvider> BindAsync(ICloudBlob blob, ValueBindingContext context)
             {
-                Stream rawStream;
+                WatchableReadStream watchableStream;
 
                 try
                 {
-                    rawStream = await blob.OpenReadAsync(context.CancellationToken);
+                    watchableStream = await ReadBlobArgumentBinding.BindStreamAsync(blob, context);
                 }
                 catch (StorageException exception)
                 {
@@ -62,8 +62,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs
                     }
                 }
 
-                WatchableReadStream watchableStream = new WatchableReadStream(rawStream);
-                TextReader reader = new StreamReader(watchableStream);
+                TextReader reader = ReadBlobArgumentBinding.CreateTextReader(watchableStream);
                 return new BlobWatchableDisposableValueProvider(blob, reader, typeof(TextReader),
                     watcher: watchableStream, disposable: reader);
             }

--- a/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
+++ b/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
@@ -300,6 +300,7 @@
     <Compile Include="Bindings\Invoke\ClassInvokeBinding.cs" />
     <Compile Include="Bindings\Invoke\InvokeBinding.cs" />
     <Compile Include="Bindings\Runtime\CollectingDisposable.cs" />
+    <Compile Include="Blobs\Bindings\WriteBlobArgumentBinding.cs" />
     <Compile Include="Blobs\Bindings\CancellableTaskFactory.cs" />
     <Compile Include="Blobs\Bindings\TaskCancellableAsyncResult.cs" />
     <Compile Include="Blobs\Listeners\BlobListener.cs" />
@@ -314,6 +315,7 @@
     <Compile Include="Blobs\Listeners\SharedBlobListenerFactory.cs" />
     <Compile Include="Blobs\TaskAsyncResultOfTResult.cs" />
     <Compile Include="Blobs\TaskAsyncResult.cs" />
+    <Compile Include="Blobs\ReadBlobArgumentBinding.cs" />
     <Compile Include="ConnectionStringNames.cs" />
     <Compile Include="Converters\CompositeAsyncObjectToTypeConverter.cs" />
     <Compile Include="Converters\IAsyncConverter.cs" />


### PR DESCRIPTION
The TextReader side was trickier because we still need the stream reference for parameter status. We may want to do something better later, but for now at least it removes the relevant duplication.
