### PR TITLE
Model bind queue name from message payload (fixes #116).

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingDataPath.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingDataPath.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
                     int endIndex = path.IndexOf('}', index);
                     if (endIndex == -1)
                     {
-                        throw new InvalidOperationException("Input pattern is not well formed. Missing a closing bracket");
+                        throw new InvalidOperationException("Input pattern is not well formed. Missing a closing bracket.");
                     }
                     string name = path.Substring(index + 1, endIndex - index - 1);
                     parameterNames.Add(name);
@@ -243,7 +243,7 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
                     int endIndex = path.IndexOf('}', index);
                     if (endIndex == -1)
                     {
-                        throw new InvalidOperationException("Input pattern is not well formed. Missing a closing bracket");
+                        throw new InvalidOperationException("Input pattern is not well formed. Missing a closing bracket.");
                     }
                     string name = path.Substring(index + 1, endIndex - index - 1);
                     string value = null;

--- a/src/Microsoft.Azure.WebJobs.Host/Queues/BindableQueuePath.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Queues/BindableQueuePath.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+
+namespace Microsoft.Azure.WebJobs.Host.Queues
+{
+    /// <summary>
+    /// Utility class with factory method to create an instance of a strategy class implementing <see cref="IBindableQueuePath"/> interface.
+    /// </summary>
+    internal static class BindableQueuePath
+    {
+        /// <summary>
+        /// Factory method detecting parameters in supplied queue name pattern and creating 
+        /// an instance of relevant strategy implementing <see cref="IBindableQueuePath"/>.
+        /// </summary>
+        /// <param name="queueNamePattern">Storage queue name pattern containing optional binding parameters.</param>
+        /// <returns>An object implementing <see cref="IBindableQueuePath"/></returns>
+        public static IBindableQueuePath Create(string queueNamePattern)
+        {
+            if (queueNamePattern == null)
+            {
+                throw new ArgumentNullException("queueNamePattern");
+            }
+
+            List<string> parameterNames = new List<string>();
+            BindingDataPath.AddParameterNames(queueNamePattern, parameterNames);
+
+            if (parameterNames.Count > 0)
+            {
+                return new ParameterizedQueuePath(queueNamePattern, parameterNames);
+            }
+
+            return new BoundQueuePath(queueNamePattern);
+        }
+
+        /// <summary>
+        /// Helper method to normalize and validate resolved queue name.
+        /// </summary>
+        /// <param name="queueName">A storage queue name containing no parameters</param>
+        /// <returns>Normalized (lower-case'd) storage queue name</returns>
+        /// <exception cref="System.ArgumentException">If the normalized name is invalid</exception>
+        public static string NormalizeAndValidate(string queueName)
+        {
+            queueName = queueName.ToLowerInvariant(); // must be lowercase. coerce here to be nice.
+            QueueClient.ValidateQueueName(queueName);
+            return queueName;
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Queues/Bindings/QueueAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Queues/Bindings/QueueAttributeBindingProvider.cs
@@ -30,25 +30,18 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Bindings
             }
 
             string queueName = context.Resolve(queueAttribute.QueueName);
-            queueName = NormalizeAndValidate(queueName);
+            IBindableQueuePath path = BindableQueuePath.Create(queueName);
+            path.ValidateContractCompatibility(context.BindingDataContract);
 
             IArgumentBinding<CloudQueue> argumentBinding = _innerProvider.TryCreate(parameter);
-
             if (argumentBinding == null)
             {
                 throw new InvalidOperationException("Can't bind Queue to type '" + parameter.ParameterType + "'.");
             }
 
             IBinding binding = new QueueBinding(parameter.Name, argumentBinding,
-                context.StorageAccount.CreateCloudQueueClient(), queueName);
+                context.StorageAccount.CreateCloudQueueClient(), path);
             return Task.FromResult(binding);
-        }
-
-        private static string NormalizeAndValidate(string queueName)
-        {
-            queueName = queueName.ToLowerInvariant(); // must be lowercase. coerce here to be nice.
-            QueueClient.ValidateQueueName(queueName);
-            return queueName;
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Queues/Bindings/StringToCloudQueueConverter.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Queues/Bindings/StringToCloudQueueConverter.cs
@@ -10,12 +10,12 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Bindings
     internal class StringToCloudQueueConverter : IConverter<string, CloudQueue>
     {
         private readonly CloudQueueClient _client;
-        private readonly string _defaultQueueName;
+        private readonly IBindableQueuePath _defaultPath;
 
-        public StringToCloudQueueConverter(CloudQueueClient client, string defaultQueueName)
+        public StringToCloudQueueConverter(CloudQueueClient client, IBindableQueuePath defaultPath)
         {
             _client = client;
-            _defaultQueueName = defaultQueueName;
+            _defaultPath = defaultPath;
         }
 
         public CloudQueue Convert(string input)
@@ -23,13 +23,13 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Bindings
             string queueName;
 
             // For convenience, treat an an empty string as a request for the default value.
-            if (String.IsNullOrEmpty(input))
+            if (String.IsNullOrEmpty(input) && _defaultPath.IsBound)
             {
-                queueName = _defaultQueueName;
+                queueName = _defaultPath.Bind(null);
             }
             else
             {
-                queueName = input;
+                queueName = BindableQueuePath.NormalizeAndValidate(input);
             }
 
             return _client.GetQueueReference(queueName);

--- a/src/Microsoft.Azure.WebJobs.Host/Queues/BoundQueuePath.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Queues/BoundQueuePath.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Azure.WebJobs.Host.Queues
+{
+    /// <summary>
+    /// Bindable queue path strategy implementation for "degenerate" bindable patterns, 
+    /// i.e. containing no parameters.
+    /// </summary>
+    internal class BoundQueuePath : IBindableQueuePath
+    {
+        private readonly string _queueNamePattern;
+
+        public BoundQueuePath(string queueNamePattern)
+        {
+            _queueNamePattern = BindableQueuePath.NormalizeAndValidate(queueNamePattern);
+        }
+
+        public string QueueNamePattern
+        {
+            get { return _queueNamePattern; }
+        }
+
+        public bool IsBound
+        {
+            get { return true; }
+        }
+
+        public IEnumerable<string> ParameterNames
+        {
+            get { return Enumerable.Empty<string>(); }
+        }
+
+        public string Bind(IReadOnlyDictionary<string, object> bindingData)
+        {
+            return QueueNamePattern;
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Queues/IBindableQueuePath.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Queues/IBindableQueuePath.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Azure.WebJobs.Host.Bindings;
+
+namespace Microsoft.Azure.WebJobs.Host.Queues
+{
+    interface IBindableQueuePath : IBindablePath<string>
+    {
+        string QueueNamePattern { get; }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Queues/ParameterizedQueuePath.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Queues/ParameterizedQueuePath.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+
+namespace Microsoft.Azure.WebJobs.Host.Queues
+{
+    /// <summary>
+    /// Implementation of <see cref="IBindableQueuePath"/> strategy for paths 
+    /// containing one or more parameters.
+    /// </summary>
+    internal class ParameterizedQueuePath : IBindableQueuePath
+    {
+        private readonly string _queueNamePattern;
+        private readonly IReadOnlyList<string> _parameterNames;
+
+        public ParameterizedQueuePath(string queueNamePattern, IReadOnlyList<string> parameterNames)
+        {
+            Debug.Assert(parameterNames != null, "parameterNames must not be null");
+            Debug.Assert(parameterNames.Count > 0, "parameterNames must contain one or more parameters");
+
+            _queueNamePattern = queueNamePattern;
+            _parameterNames = parameterNames;
+        }
+
+        public string QueueNamePattern
+        {
+            get { return _queueNamePattern; }
+        }
+
+        public bool IsBound
+        {
+            get { return false; }
+        }
+
+        public IEnumerable<string> ParameterNames
+        {
+            get { return _parameterNames; }
+        }
+
+        public string Bind(IReadOnlyDictionary<string, object> bindingData)
+        {
+            if (bindingData == null)
+            {
+                throw new ArgumentNullException("bindingData");
+            }
+
+            IReadOnlyDictionary<string, string> parameters = BindingDataPath.GetParameters(bindingData);
+            string queueName = BindingDataPath.Resolve(QueueNamePattern, parameters);
+            return BindableQueuePath.NormalizeAndValidate(queueName);
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
+++ b/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
@@ -371,12 +371,16 @@
     <Compile Include="Loggers\IFunctionOutputDefinition.cs" />
     <Compile Include="Loggers\IFunctionParameterLog.cs" />
     <Compile Include="Loggers\IFunctionOutput.cs" />
+    <Compile Include="Queues\BindableQueuePath.cs" />
+    <Compile Include="Queues\BoundQueuePath.cs" />
+    <Compile Include="Queues\IBindableQueuePath.cs" />
     <Compile Include="Queues\IQueueConfiguration.cs" />
     <Compile Include="Queues\IMessageEnqueuedWatcher.cs" />
     <Compile Include="Queues\Listeners\INotificationCommand.cs" />
     <Compile Include="Queues\Listeners\QueuePollingIntervals.cs" />
     <Compile Include="Queues\Listeners\SharedQueueWatcher.cs" />
     <Compile Include="Queues\Listeners\SharedQueueWatcherFactory.cs" />
+    <Compile Include="Queues\ParameterizedQueuePath.cs" />
     <Compile Include="Tables\PocoEntityValueBinder.cs" />
     <Compile Include="Tables\PocoEntityArgumentBinding.cs" />
     <Compile Include="Tables\TableEntityValueBinder.cs" />

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/BindableServiceBusPath.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/BindableServiceBusPath.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+
+namespace Microsoft.Azure.WebJobs.ServiceBus.Bindings
+{
+    /// <summary>
+    /// Utility class with factory method to create an instance of a strategy class implementing <see cref="IBindableServiceBusPath"/> interface.
+    /// </summary>
+    internal static class BindableServiceBusPath
+    {
+        /// <summary>
+        /// A factory method detecting parameters in supplied queue or topic name pattern and creating 
+        /// an instance of relevant strategy class implementing <see cref="IBindableServiceBusPath"/>.
+        /// </summary>
+        /// <param name="queueOrTopicNamePattern">Service Bus queue or topic name pattern containing optional binding parameters.</param>
+        /// <returns>An object implementing <see cref="IBindableServiceBusPath"/></returns>
+        public static IBindableServiceBusPath Create(string queueOrTopicNamePattern)
+        {
+            if (queueOrTopicNamePattern == null)
+            {
+                throw new ArgumentNullException("queueOrTopicNamePattern");
+            }
+
+            List<string> parameterNames = new List<string>();
+            BindingDataPath.AddParameterNames(queueOrTopicNamePattern, parameterNames);
+
+            if (parameterNames.Count > 0)
+            {
+                return new ParameterizedServiceBusPath(queueOrTopicNamePattern, parameterNames);
+            }
+
+            return new BoundServiceBusPath(queueOrTopicNamePattern);
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/BoundServiceBusPath.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/BoundServiceBusPath.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Azure.WebJobs.ServiceBus.Bindings
+{
+    /// <summary>
+    /// Bindable queue or topic path strategy implementation for "degenerate" bindable patterns, 
+    /// i.e. containing no parameters.
+    /// </summary>
+    internal class BoundServiceBusPath : IBindableServiceBusPath
+    {
+        private readonly string _queueOrTopicNamePattern;
+
+        public BoundServiceBusPath(string queueOrTopicNamePattern)
+        {
+            _queueOrTopicNamePattern = queueOrTopicNamePattern;
+        }
+
+        public string QueueOrTopicNamePattern
+        {
+            get { return _queueOrTopicNamePattern; }
+        }
+
+        public bool IsBound
+        {
+            get { return true; }
+        }
+
+        public IEnumerable<string> ParameterNames
+        {
+            get { return Enumerable.Empty<string>(); }
+        }
+
+        public string Bind(IReadOnlyDictionary<string, object> bindingData)
+        {
+            return QueueOrTopicNamePattern;
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/IBindableServiceBusPath.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/IBindableServiceBusPath.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Azure.WebJobs.Host.Bindings;
+
+namespace Microsoft.Azure.WebJobs.ServiceBus.Bindings
+{
+    interface IBindableServiceBusPath : IBindablePath<string>
+    {
+        string QueueOrTopicNamePattern { get; }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/ParameterizedServiceBusPath.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/ParameterizedServiceBusPath.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+
+namespace Microsoft.Azure.WebJobs.ServiceBus.Bindings
+{
+    /// <summary>
+    /// Omplementation of <see cref="IBindableServiceBusPath"/> strategy for paths 
+    /// containing one or more parameters.
+    /// </summary>
+    internal class ParameterizedServiceBusPath : IBindableServiceBusPath
+    {
+        private readonly string _queueOrTopicNamePattern;
+        private readonly IReadOnlyList<string> _parameterNames;
+
+        public ParameterizedServiceBusPath(string queueOrTopicNamePattern, IReadOnlyList<string> parameterNames)
+        {
+            Debug.Assert(parameterNames != null, "parameterNames must not be null");
+            Debug.Assert(parameterNames.Count > 0, "parameterNames must not be empty");
+
+            _queueOrTopicNamePattern = queueOrTopicNamePattern;
+            _parameterNames = parameterNames;
+        }
+
+        public string QueueOrTopicNamePattern
+        {
+            get { return _queueOrTopicNamePattern; }
+        }
+
+        public bool IsBound
+        {
+            get { return false; }
+        }
+
+        public IEnumerable<string> ParameterNames
+        {
+            get { return _parameterNames; }
+        }
+
+        public string Bind(IReadOnlyDictionary<string, object> bindingData)
+        {
+            if (bindingData == null)
+            {
+                throw new ArgumentNullException("bindingData");
+            }
+                
+            IReadOnlyDictionary<string, string> parameters = BindingDataPath.GetParameters(bindingData);
+            string queueOrTopicName = BindingDataPath.Resolve(QueueOrTopicNamePattern, parameters);
+            return queueOrTopicName;
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/ServiceBusAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/ServiceBusAttributeBindingProvider.cs
@@ -29,6 +29,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Bindings
             }
 
             string queueOrTopicName = context.Resolve(serviceBusAttribute.QueueOrTopicName);
+            IBindableServiceBusPath path = BindableServiceBusPath.Create(queueOrTopicName);
+            path.ValidateContractCompatibility(context.BindingDataContract);
 
             IArgumentBinding<ServiceBusEntity> argumentBinding = _innerProvider.TryCreate(parameter);
 
@@ -40,7 +42,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Bindings
             ServiceBusAccount account = ServiceBusAccount.CreateFromConnectionString(
                 context.ServiceBusConnectionString);
 
-            IBinding binding = new ServiceBusBinding(parameter.Name, argumentBinding, account, queueOrTopicName);
+            IBinding binding = new ServiceBusBinding(parameter.Name, argumentBinding, account, path);
             return Task.FromResult(binding);
         }
     }

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/StringToServiceBusEntityConverter.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/StringToServiceBusEntityConverter.cs
@@ -12,12 +12,12 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Bindings
     internal class StringToServiceBusEntityConverter : IAsyncConverter<string, ServiceBusEntity>
     {
         private readonly ServiceBusAccount _account;
-        private readonly string _defaultQueueOrTopicName;
+        private readonly IBindableServiceBusPath _defaultPath;
 
-        public StringToServiceBusEntityConverter(ServiceBusAccount account, string defaultQueueOrTopicName)
+        public StringToServiceBusEntityConverter(ServiceBusAccount account, IBindableServiceBusPath defaultPath)
         {
             _account = account;
-            _defaultQueueOrTopicName = defaultQueueOrTopicName;
+            _defaultPath = defaultPath;
         }
 
         public async Task<ServiceBusEntity> ConvertAsync(string input, CancellationToken cancellationToken)
@@ -25,9 +25,9 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Bindings
             string queueOrTopicName;
 
             // For convenience, treat an an empty string as a request for the default value.
-            if (String.IsNullOrEmpty(input))
+            if (String.IsNullOrEmpty(input) && _defaultPath.IsBound)
             {
-                queueOrTopicName = _defaultQueueOrTopicName;
+                queueOrTopicName = _defaultPath.Bind(null);
             }
             else
             {

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/WebJobs.ServiceBus.csproj
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/WebJobs.ServiceBus.csproj
@@ -85,8 +85,12 @@
     <Compile Include="..\Common\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Bindings\BindableServiceBusPath.cs" />
+    <Compile Include="Bindings\BoundServiceBusPath.cs" />
     <Compile Include="Bindings\ByteArrayArgumentBinding.cs" />
     <Compile Include="Bindings\CollectionArgumentBindingProvider.cs" />
+    <Compile Include="Bindings\IBindableServiceBusPath.cs" />
+    <Compile Include="Bindings\ParameterizedServiceBusPath.cs" />
     <Compile Include="Bindings\StringArgumentBinding.cs" />
     <Compile Include="Bindings\BrokeredMessageArgumentBinding.cs" />
     <Compile Include="Bindings\ByteArrayArgumentBindingProvider.cs" />

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Blobs/BlobPathSourceTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Blobs/BlobPathSourceTests.cs
@@ -133,35 +133,5 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Blobs
             Assert.Equal("name", names[0]);
             Assert.Equal("date", names[1]);
         }
-
-        [Fact]
-        public void Resolve1()
-        {
-            var d = new Dictionary<string, string> {{"name", "value"}};
-            string result = BindingDataPath.Resolve("container", d);
-            Assert.Equal("container", result);
-        }
-
-        [Fact]
-        public void Resolve2()
-        {
-            var d = new Dictionary<string, string> {{"name", "value"}};
-            string result = BindingDataPath.Resolve(@"container/{name}", d);
-            Assert.Equal(@"container/value", result);
-        }
-
-        [Fact]
-        public void Resolve3()
-        {
-            var d = new Dictionary<string, string> {{"name", "value"}};
-            Assert.Throws<InvalidOperationException>(() => BindingDataPath.Resolve(@"container/{missing}", d));
-        }
-
-        [Fact]
-        public void Resolve4()
-        {
-            var d = new Dictionary<string, string> {{"name", "value"}};
-            Assert.Throws<InvalidOperationException>(() => BindingDataPath.Resolve(@"container/{missing", d));
-        }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Queues/BindableQueuePathTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Queues/BindableQueuePathTests.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.Azure.WebJobs.Host.Queues;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Host.UnitTests.Queues
+{
+    public class BindableQueuePathTests
+    {
+        [Fact]
+        public void Create_IfNonParameterizedPattern_ReturnsBoundPath()
+        {
+            const string queueNamePattern = "queue-name-with-no-parameters";
+
+            IBindableQueuePath path = BindableQueuePath.Create(queueNamePattern);
+
+            Assert.NotNull(path);
+            Assert.Equal(queueNamePattern, path.QueueNamePattern);
+            Assert.True(path.IsBound);
+        }
+
+        [Fact]
+        public void Create_IfParameterizedPattern_ReturnsNotBoundPath()
+        {
+            const string queueNamePattern = "queue-{name}-with-{parameter}";
+
+            IBindableQueuePath path = BindableQueuePath.Create(queueNamePattern);
+
+            Assert.NotNull(path);
+            Assert.Equal(queueNamePattern, path.QueueNamePattern);
+            Assert.False(path.IsBound);
+        }
+
+        [Fact]
+        public void Create_IfNullPattern_Throws()
+        {
+            ExceptionAssert.ThrowsArgumentNull(() => BindableQueuePath.Create(null), "queueNamePattern");
+        }
+
+        [Fact]
+        public void Create_IfMalformedPattern_PropagatesThrownException()
+        {
+            const string queueNamePattern = "malformed-queue-{{name%";
+
+            ExceptionAssert.ThrowsInvalidOperation(() => BindableQueuePath.Create(queueNamePattern), "Input pattern is not well formed. Missing a closing bracket.");
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Queues/BoundQueuePathTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Queues/BoundQueuePathTests.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.Azure.WebJobs.Host.Queues;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Host.UnitTests.Queues
+{
+    public class BoundQueuePathTests
+    {
+        [Fact]
+        public void Bind_IfNotNullBindingData_ReturnsResolvedQueueName()
+        {
+            const string queueNamePattern = "queue-name-with-no-parameters";
+            var bindingData = new Dictionary<string, object> { { "name", "value" } };
+            IBindableQueuePath path = new BoundQueuePath(queueNamePattern);
+
+            string result = path.Bind(bindingData);
+
+            Assert.Equal(queueNamePattern, result);
+        }
+
+        [Fact]
+        public void Bind_IfNullBindingData_ReturnsResolvedQueueName()
+        {
+            const string queueNamePattern = "queue-name-with-no-parameters";
+            IBindableQueuePath path = new BoundQueuePath(queueNamePattern);
+
+            string result = path.Bind(null);
+
+            Assert.Equal(queueNamePattern, result);
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Queues/ParameterizedQueuePathTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Queues/ParameterizedQueuePathTests.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Azure.WebJobs.Host.Queues;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Host.UnitTests.Queues
+{
+    public class ParameterizedQueuePathTests
+    {
+        [Fact]
+        public void Bind_IfNotNullBindingData_ReturnsResolvedQueueName()
+        {
+            const string queueNamePattern = "queue-{name}-with-{parameter}";
+            var bindingData = new Dictionary<string, object> { { "name", "name" }, { "parameter", "parameter" } };
+            IBindableQueuePath path = CreateProductUnderTest(queueNamePattern);
+
+            string result = path.Bind(bindingData);
+
+            Assert.Equal("queue-name-with-parameter", result);
+        }
+
+        [Fact]
+        public void Bind_IfNullBindingData_Throws()
+        {
+            const string queueNamePattern = "queue-{name}-with-{parameter}";
+            IBindableQueuePath path = CreateProductUnderTest(queueNamePattern);
+
+            ExceptionAssert.ThrowsArgumentNull(() => path.Bind(null), "bindingData");
+        }
+
+        private static IBindableQueuePath CreateProductUnderTest(string queueNamePattern)
+        {
+            List<string> parameterNames = new List<string>();
+            BindingDataPath.AddParameterNames(queueNamePattern, parameterNames);
+            IBindableQueuePath path = new ParameterizedQueuePath(queueNamePattern, parameterNames);
+            return path;
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
@@ -110,6 +110,9 @@
     <Compile Include="Loggers\UpdateOutputLogCommandExtensions.cs" />
     <Compile Include="Protocols\HostStartedMessageTests.cs" />
     <Compile Include="Blobs\Bindings\WatchableCloudBlobStreamTests.cs" />
+    <Compile Include="Queues\BindableQueuePathTests.cs" />
+    <Compile Include="Queues\BoundQueuePathTests.cs" />
+    <Compile Include="Queues\ParameterizedQueuePathTests.cs" />
     <Compile Include="Queues\QueueTriggerBindingIntegrationTests.cs" />
     <Compile Include="Tables\PocoEntityArgumentBindingProviderTests.cs" />
     <Compile Include="Tables\TableEntityValueBinderTests.cs" />

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Bindings/BindableServiceBusPathTests.cs
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Bindings/BindableServiceBusPathTests.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Microsoft.Azure.WebJobs.ServiceBus.Bindings;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Bindings
+{
+    public class BindableServiceBusPathTests
+    {
+        [Fact]
+        public void Create_IfNonParameterizedPattern_ReturnsBoundPath()
+        {
+            const string queueOrTopicNamePattern = "queue-name-with-no-parameters";
+
+            IBindableServiceBusPath path = BindableServiceBusPath.Create(queueOrTopicNamePattern);
+
+            Assert.NotNull(path);
+            Assert.Equal(queueOrTopicNamePattern, path.QueueOrTopicNamePattern);
+            Assert.True(path.IsBound);
+        }
+
+        [Fact]
+        public void Create_IfParameterizedPattern_ReturnsNotBoundPath()
+        {
+            const string queueOrTopicNamePattern = "queue-{name}-with-{parameter}";
+
+            IBindableServiceBusPath path = BindableServiceBusPath.Create(queueOrTopicNamePattern);
+
+            Assert.NotNull(path);
+            Assert.Equal(queueOrTopicNamePattern, path.QueueOrTopicNamePattern);
+            Assert.False(path.IsBound);
+        }
+
+        [Fact]
+        public void Create_IfNullPattern_Throws()
+        {
+            ExceptionAssert.ThrowsArgumentNull(() => BindableServiceBusPath.Create(null), "queueOrTopicNamePattern");
+        }
+
+        [Fact]
+        public void Create_IfMalformedPattern_PropagatesThrownException()
+        {
+            const string queueNamePattern = "malformed-queue-{{name%";
+
+            ExceptionAssert.ThrowsInvalidOperation(() => BindableServiceBusPath.Create(queueNamePattern), "Input pattern is not well formed. Missing a closing bracket.");
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Bindings/BoundServiceBusTests.cs
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Bindings/BoundServiceBusTests.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.ServiceBus.Bindings;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Bindings
+{
+    public class BoundServiceBusTests
+    {
+        [Fact]
+        public void Bind_IfNotNullBindingData_ReturnsResolvedQueueName()
+        {
+            const string queueOrTopicNamePattern = "queue-name-with-no-parameters";
+            var bindingData = new Dictionary<string, object> { { "name", "value" } };
+            IBindableServiceBusPath path = new BoundServiceBusPath(queueOrTopicNamePattern);
+
+            string result = path.Bind(bindingData);
+
+            Assert.Equal(queueOrTopicNamePattern, result);
+        }
+
+        [Fact]
+        public void Bind_IfNullBindingData_ReturnsResolvedQueueName()
+        {
+            const string queueOrTopicNamePattern = "queue-name-with-no-parameters";
+            IBindableServiceBusPath path = new BoundServiceBusPath(queueOrTopicNamePattern);
+
+            string result = path.Bind(null);
+
+            Assert.Equal(queueOrTopicNamePattern, result);
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Bindings/ParameterizedServiceBusPathTests.cs
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Bindings/ParameterizedServiceBusPathTests.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Microsoft.Azure.WebJobs.ServiceBus.Bindings;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Bindings
+{
+    public class ParameterizedServiceBusPathTests
+    {
+        [Fact]
+        public void Bind_IfNotNullBindingData_ReturnsResolvedQueueName()
+        {
+            const string queueOrTopicNamePattern = "queue-{name}-with-{parameter}";
+            var bindingData = new Dictionary<string, object> { { "name", "name" }, { "parameter", "parameter" } };
+            IBindableServiceBusPath path = CreateProductUnderTest(queueOrTopicNamePattern);
+
+            string result = path.Bind(bindingData);
+
+            Assert.Equal("queue-name-with-parameter", result);
+        }
+
+        [Fact]
+        public void Bind_IfNullBindingData_Throws()
+        {
+            const string queueOrTopicNamePattern = "queue-{name}-with-{parameter}";
+            IBindableServiceBusPath path = CreateProductUnderTest(queueOrTopicNamePattern);
+
+            ExceptionAssert.ThrowsArgumentNull(() => path.Bind(null), "bindingData");
+        }
+
+        private static IBindableServiceBusPath CreateProductUnderTest(string queueOrTopicNamePattern)
+        {
+            List<string> parameterNames = new List<string>();
+            BindingDataPath.AddParameterNames(queueOrTopicNamePattern, parameterNames);
+            IBindableServiceBusPath path = new ParameterizedServiceBusPath(queueOrTopicNamePattern, parameterNames);
+            return path;
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/WebJobs.ServiceBus.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/WebJobs.ServiceBus.UnitTests.csproj
@@ -85,6 +85,9 @@
     <Compile Include="..\Common\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Bindings\BindableServiceBusPathTests.cs" />
+    <Compile Include="Bindings\BoundServiceBusTests.cs" />
+    <Compile Include="Bindings\ParameterizedServiceBusPathTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Listeners\NamespaceManagerExtensionsTests.cs" />
     <Compile Include="Triggers\ServiceBusTriggerBindingIntegrationTests.cs" />


### PR DESCRIPTION
- Implemented bindable path strategies for Storage queues and Service Bus entities.
- Updated relevant binding classes to use bindable paths instead of raw strings.
- Added unit-test for new bindable path classes.
- Added missing relevant unit tests for the BindingDataPath class that provides actual core functionality for all bindable path "wrapper" classes.
