### PR TITLE
Don't index private types

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Indexers/DefaultTypeLocator.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Indexers/DefaultTypeLocator.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 
 namespace Microsoft.Azure.WebJobs.Host.Indexers
@@ -56,11 +57,26 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
 
                 if (assemblyTypes != null)
                 {
-                    allTypes.AddRange(assemblyTypes);
+                    allTypes.AddRange(assemblyTypes.Where(IsJobClass));
                 }
             }
 
             return allTypes;
+        }
+
+        public static bool IsJobClass(Type type)
+        {
+            if (type == null)
+            {
+                return false;
+            }
+
+            return type.IsClass
+                && !type.IsAbstract
+                // We only consider public top-level classes as job classes. IsPublic returns false for nested classes,
+                // regardless of visibility modifiers. 
+                && type.IsPublic
+                && !type.ContainsGenericParameters;
         }
 
         private static IEnumerable<Assembly> GetUserAssemblies()

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Indexers/DefaultTypeLocatorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Indexers/DefaultTypeLocatorTests.cs
@@ -1,0 +1,122 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs.Host.Indexers;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Host.UnitTests.Indexers
+{
+    public class DefaultTypeLocatorTests
+    {
+        [Fact]
+        public void IsJobClass_IfNull_ReturnsFalse()
+        {
+            Type type = null;
+
+            // Act
+            bool result = DefaultTypeLocator.IsJobClass(type);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsJobClass_IfValueType_ReturnsFalse()
+        {
+            Type type = typeof(PublicStruct);
+
+            // Act
+            bool result = DefaultTypeLocator.IsJobClass(type);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsJobClass_IfInterface_ReturnsFalse()
+        {
+            Type type = typeof(PublicInterface);
+
+            // Act
+            bool result = DefaultTypeLocator.IsJobClass(type);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsJobClass_IfAbstract_ReturnsFalse()
+        {
+            Type type = typeof(AbstractClass);
+
+            // Act
+            bool result = DefaultTypeLocator.IsJobClass(type);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsJobClass_IfPrivate_ReturnsFalse()
+        {
+            Type type = typeof(PrivateClass);
+
+            // Act
+            bool result = DefaultTypeLocator.IsJobClass(type);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsJobClass_IfNestedPublic_ReturnsFalse()
+        {
+            Type type = typeof(NestedPublicClass);
+
+            // Act
+            bool result = DefaultTypeLocator.IsJobClass(type);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsJobClass_IfContainsGenericParameters_ReturnsFalse()
+        {
+            Type type = typeof(GenericClass<>);
+
+            // Act
+            bool result = DefaultTypeLocator.IsJobClass(type);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsJobClass_IfNormalPublicClass_ReturnsTrue()
+        {
+            Type type = typeof(PublicClass);
+
+            // Act
+            bool result = DefaultTypeLocator.IsJobClass(type);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        public class NestedPublicClass { }
+
+        private class PrivateClass { }
+    }
+
+    public abstract class AbstractClass { }
+
+    public struct PublicStruct { }
+
+    public interface PublicInterface { }
+
+    public class GenericClass<T> { }
+
+    public class PublicClass { }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
@@ -107,6 +107,7 @@
     <Compile Include="Blobs\CompletedAsyncResult.cs" />
     <Compile Include="Blobs\WatchableReadStreamTests.cs" />
     <Compile Include="Indexers\FunctionIndexerTests.cs" />
+    <Compile Include="Indexers\DefaultTypeLocatorTests.cs" />
     <Compile Include="Loggers\UpdateOutputLogCommandExtensions.cs" />
     <Compile Include="Protocols\HostStartedMessageTests.cs" />
     <Compile Include="Blobs\Bindings\WatchableCloudBlobStreamTests.cs" />


### PR DESCRIPTION
Only index normal public classes (fixes #75).

I "leveraged" this logic from MVC vNext.
