### PR TITLE
Index static classes

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Indexers/DefaultTypeLocator.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Indexers/DefaultTypeLocator.cs
@@ -72,7 +72,9 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
             }
 
             return type.IsClass
-                && !type.IsAbstract
+                // For C# static keyword classes, IsAbstract and IsSealed both return true. Include C# static keyword
+                // classes but not C# abstract keyword classes.
+                && (!type.IsAbstract || type.IsSealed)
                 // We only consider public top-level classes as job classes. IsPublic returns false for nested classes,
                 // regardless of visibility modifiers. 
                 && type.IsPublic

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Indexers/DefaultTypeLocatorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Indexers/DefaultTypeLocatorTests.cs
@@ -105,6 +105,18 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Indexers
             Assert.True(result);
         }
 
+        [Fact]
+        public void IsJobClass_IfNormalStaticClass_ReturnsTrue()
+        {
+            Type type = typeof(StaticClass);
+
+            // Act
+            bool result = DefaultTypeLocator.IsJobClass(type);
+
+            // Assert
+            Assert.True(result);
+        }
+
         public class NestedPublicClass { }
 
         private class PrivateClass { }
@@ -119,4 +131,6 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Indexers
     public class GenericClass<T> { }
 
     public class PublicClass { }
+
+    public static class StaticClass { }
 }


### PR DESCRIPTION
Index static classes

Note that this parts from MVC/MVC vNext rules. IsAbstract somewhat surprisingly returns true for C# static classes. This change special-cases to allow C# static but not C# abstract.
