### PR TITLE
Increase poison blob integration test timeout.

### DIFF
--- a/test/Microsoft.Azure.WebJobs.Host.IntegrationTests/Scenarios.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.IntegrationTests/Scenarios.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Azure.WebJobs.Host.IntegrationTests
                     host.Start();
 
                     // Act
-                    bool poisonMessageReceived = source.Token.WaitHandle.WaitOne(6 * 1000);
+                    bool poisonMessageReceived = source.Token.WaitHandle.WaitOne(12 * 1000);
 
                     // Assert
                     Assert.True(poisonMessageReceived); // Guard


### PR DESCRIPTION
This test can fail if run on its own (when it pays the host startup/connection cost).
@victorhurdugaci 
