### PR TITLE
Fix invoker return value

### DIFF
--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncChainEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncChainEndToEndTests.cs
@@ -145,18 +145,21 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
         private void Cleanup()
         {
-            CloudBlobClient blobClient = _storageAccount.CreateCloudBlobClient();
-            blobClient
-                .GetContainerReference(_resolver.ResolveInString(ContainerName))
-                .DeleteIfExists();
+            if (_storageAccount != null)
+            {
+                CloudBlobClient blobClient = _storageAccount.CreateCloudBlobClient();
+                blobClient
+                    .GetContainerReference(_resolver.ResolveInString(ContainerName))
+                    .DeleteIfExists();
 
-            CloudQueueClient queueClient = _storageAccount.CreateCloudQueueClient();
-            queueClient
-                .GetQueueReference(_resolver.ResolveInString(Queue1Name))
-                .DeleteIfExists();
-            queueClient
-                .GetQueueReference(_resolver.ResolveInString(Queue2Name))
-                .DeleteIfExists();
+                CloudQueueClient queueClient = _storageAccount.CreateCloudQueueClient();
+                queueClient
+                    .GetQueueReference(_resolver.ResolveInString(Queue1Name))
+                    .DeleteIfExists();
+                queueClient
+                    .GetQueueReference(_resolver.ResolveInString(Queue2Name))
+                    .DeleteIfExists();
+            }
         }
     }
 }


### PR DESCRIPTION
Return task from invoker with output parameters (fixes #256).

The last expression of Expression.Block is the return value. For methods that return task and have output parameters, ensure the last expression is the returned task.
