### PR TITLE
Concurrency-safe table entity binding

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Tables/PocoEntityValueBinder.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Tables/PocoEntityValueBinder.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.WebJobs.Host.Tables
 
             if (HasChanged)
             {
-                return _entityContext.Table.ExecuteAsync(TableOperation.InsertOrReplace(entity), cancellationToken);
+                return _entityContext.Table.ExecuteAsync(TableOperation.Replace(entity), cancellationToken);
             }
 
             return Task.FromResult(0);

--- a/src/Microsoft.Azure.WebJobs.Host/Tables/TableEntityValueBinder.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Tables/TableEntityValueBinder.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.WebJobs.Host.Tables
 
             if (HasChanged)
             {
-                return _entityContext.Table.ExecuteAsync(TableOperation.InsertOrReplace(_value), cancellationToken);
+                return _entityContext.Table.ExecuteAsync(TableOperation.Replace(_value), cancellationToken);
             }
 
             return Task.FromResult(0);


### PR DESCRIPTION
Use optimistic concurrency for table entity binding (fixes #231).
