### PR TITLE
No double-commit of blob bound to T

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Blobs/Bindings/OutObjectArgumentBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Blobs/Bindings/OutObjectArgumentBindingProvider.cs
@@ -101,7 +101,12 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
                 public async Task SetValueAsync(object value, CancellationToken cancellationToken)
                 {
                     await _objectBinder.WriteToStreamAsync(_stream, value, cancellationToken);
-                    await _stream.CommitAsync(cancellationToken);
+
+                    if (!_stream.HasCommitted)
+                    {
+                        await _stream.CommitAsync(cancellationToken);
+                    }
+
                     _stream.Dispose();
                 }
 

--- a/src/Microsoft.Azure.WebJobs.Host/Blobs/Bindings/WatchableCloudBlobStream.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Blobs/Bindings/WatchableCloudBlobStream.cs
@@ -35,6 +35,11 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
             }
         }
 
+        public bool HasCommitted
+        {
+            get { return _committed; }
+        }
+
         public override ICancellableAsyncResult BeginFlush(AsyncCallback callback, object state)
         {
             CancellationTokenSource cancellationSource = new CancellationTokenSource();


### PR DESCRIPTION
Check before committing blob bound to T (fixes #307).
