### PR TITLE
Support native Service Bus serialization

### DIFF
--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/ByteArrayArgumentBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/ByteArrayArgumentBinding.cs
@@ -88,6 +88,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Bindings
                 using (MemoryStream stream = new MemoryStream(bytes, writable: false))
                 using (BrokeredMessage message = new BrokeredMessage(stream))
                 {
+                    message.ContentType = ContentTypes.ApplicationOctetStream;
                     await _entity.SendAndCreateQueueIfNotExistsAsync(message, _functionInstanceId, cancellationToken);
                 }
             }

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/StringArgumentBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/StringArgumentBinding.cs
@@ -90,6 +90,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Bindings
                 using (MemoryStream stream = new MemoryStream(bytes, writable: false))
                 using (BrokeredMessage message = new BrokeredMessage(stream))
                 {
+                    message.ContentType = ContentTypes.TextPlain;
                     await _entity.SendAndCreateQueueIfNotExistsAsync(message, _functionInstanceId, cancellationToken);
                 }
             }

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/UserTypeArgumentBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/UserTypeArgumentBinding.cs
@@ -72,6 +72,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Bindings
                 using (MemoryStream stream = new MemoryStream(bytes, writable: false))
                 using (BrokeredMessage message = new BrokeredMessage(stream))
                 {
+                    message.ContentType = ContentTypes.ApplicationJson;
                     await _entity.SendAndCreateQueueIfNotExistsAsync(message, _functionInstanceId, cancellationToken);
                 }
             }

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/ContentTypes.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/ContentTypes.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.ServiceBus
+{
+    internal static class ContentTypes
+    {
+        public const string TextPlain = "text/plain";
+
+        public const string ApplicationJson = "application/json";
+
+        public const string ApplicationOctetStream = "application/octet-stream";
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Triggers/BrokeredMessageToByteArrayConverter.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Triggers/BrokeredMessageToByteArrayConverter.cs
@@ -13,17 +13,24 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
     {
         public async Task<byte[]> ConvertAsync(BrokeredMessage input, CancellationToken cancellationToken)
         {
-            using (MemoryStream outputStream = new MemoryStream())
-            using (Stream inputStream = input.GetBody<Stream>())
+            if (input.ContentType == ContentTypes.ApplicationOctetStream)
             {
-                if (inputStream == null)
+                using (MemoryStream outputStream = new MemoryStream())
+                using (Stream inputStream = input.GetBody<Stream>())
                 {
-                    return null;
-                }
+                    if (inputStream == null)
+                    {
+                        return null;
+                    }
 
-                const int defaultBufferSize = 4096;
-                await inputStream.CopyToAsync(outputStream, defaultBufferSize, cancellationToken);
-                return outputStream.ToArray();
+                    const int defaultBufferSize = 4096;
+                    await inputStream.CopyToAsync(outputStream, defaultBufferSize, cancellationToken);
+                    return outputStream.ToArray();
+                }
+            }
+            else
+            {
+                return input.GetBody<byte[]>();
             }
         }
     }

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Triggers/BrokeredMessageToStringConverter.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Triggers/BrokeredMessageToStringConverter.cs
@@ -13,18 +13,26 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
     {
         public Task<string> ConvertAsync(BrokeredMessage input, CancellationToken cancellationToken)
         {
-            using (Stream stream = input.GetBody<Stream>())
+            if (input.ContentType == ContentTypes.TextPlain)
             {
-                if (stream == null)
+                using (Stream stream = input.GetBody<Stream>())
                 {
-                    return Task.FromResult<string>(null);
-                }
+                    if (stream == null)
+                    {
+                        return Task.FromResult<string>(null);
+                    }
 
-                using (TextReader reader = new StreamReader(stream, StrictEncodings.Utf8))
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    return reader.ReadToEndAsync();
+                    using (TextReader reader = new StreamReader(stream, StrictEncodings.Utf8))
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        return reader.ReadToEndAsync();
+                    }
                 }
+            }
+            else
+            {
+                string contents = input.GetBody<string>();
+                return Task.FromResult(contents);
             }
         }
     }

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Triggers/ServiceBusTriggerAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Triggers/ServiceBusTriggerAttributeBindingProvider.cs
@@ -57,7 +57,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
 
             if (queueName != null)
             {
-                binding = new ServiceBusTriggerBinding(parameter.Name, argumentBinding, account, queueName);
+                binding = new ServiceBusTriggerBinding(parameter.Name, parameter.ParameterType, argumentBinding,
+                    account, queueName);
             }
             else
             {

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Triggers/StringToBinaryBrokeredMessageConverter.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Triggers/StringToBinaryBrokeredMessageConverter.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using Microsoft.Azure.WebJobs.Host.Converters;
+using Microsoft.ServiceBus.Messaging;
+
+namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
+{
+    internal class StringToBinaryBrokeredMessageConverter : IConverter<string, BrokeredMessage>
+    {
+        public BrokeredMessage Convert(string input)
+        {
+            byte[] contents = System.Convert.FromBase64String(input);
+
+            BrokeredMessage message = new BrokeredMessage(new MemoryStream(contents, writable: false));
+            message.ContentType = ContentTypes.ApplicationOctetStream;
+            return message;
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Triggers/StringToBrokeredMessageConverterFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Triggers/StringToBrokeredMessageConverterFactory.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs.Host.Converters;
+using Microsoft.ServiceBus.Messaging;
+
+namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
+{
+    internal class StringToBrokeredMessageConverterFactory
+    {
+        public static IConverter<string, BrokeredMessage> Create(Type parameterType)
+        {
+            if (parameterType == typeof(BrokeredMessage) || parameterType == typeof(string))
+            {
+                return new StringToTextBrokeredMessageConverter();
+            }
+            else if (parameterType == typeof(byte[]))
+            {
+                return new StringToBinaryBrokeredMessageConverter();
+            }
+            else
+            {
+                return new StringToJsonBrokeredMessageConverter();
+            }
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Triggers/StringToJsonBrokeredMessageConverter.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Triggers/StringToJsonBrokeredMessageConverter.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using Microsoft.Azure.WebJobs.Host.Converters;
+using Microsoft.ServiceBus.Messaging;
+
+namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
+{
+    internal class StringToJsonBrokeredMessageConverter : IConverter<string, BrokeredMessage>
+    {
+        public BrokeredMessage Convert(string input)
+        {
+            BrokeredMessage message = new BrokeredMessage(new MemoryStream(StrictEncodings.Utf8.GetBytes(input),
+                writable: false));
+            message.ContentType = ContentTypes.ApplicationJson;
+            return message;
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Triggers/StringToTextBrokeredMessageConverter.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Triggers/StringToTextBrokeredMessageConverter.cs
@@ -7,11 +7,14 @@ using Microsoft.ServiceBus.Messaging;
 
 namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
 {
-    internal class StringToBrokeredMessageConverter : IConverter<string, BrokeredMessage>
+    internal class StringToTextBrokeredMessageConverter : IConverter<string, BrokeredMessage>
     {
         public BrokeredMessage Convert(string input)
         {
-            return new BrokeredMessage(new MemoryStream(StrictEncodings.Utf8.GetBytes(input), writable: false));
+            BrokeredMessage message = new BrokeredMessage(new MemoryStream(StrictEncodings.Utf8.GetBytes(input),
+                writable: false));
+            message.ContentType = ContentTypes.TextPlain;
+            return message;
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Triggers/UserTypeArgumentBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Triggers/UserTypeArgumentBindingProvider.cs
@@ -20,23 +20,27 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
         {
             // At indexing time, attempt to bind all types.
             // (Whether or not actual binding is possible depends on the message shape at runtime.)
-            return new UserTypeArgumentBinding(parameter.ParameterType);
+            return CreateBinding(parameter.ParameterType);
         }
 
-        private class UserTypeArgumentBinding : ITriggerDataArgumentBinding<BrokeredMessage>
+        private static ITriggerDataArgumentBinding<BrokeredMessage> CreateBinding(Type itemType)
         {
-            private readonly Type _valueType;
+            Type genericType = typeof(UserTypeArgumentBinding<>).MakeGenericType(itemType);
+            return (ITriggerDataArgumentBinding<BrokeredMessage>)Activator.CreateInstance(genericType);
+        }
+
+        private class UserTypeArgumentBinding<TInput> : ITriggerDataArgumentBinding<BrokeredMessage>
+        {
             private readonly IBindingDataProvider _bindingDataProvider;
 
-            public UserTypeArgumentBinding(Type valueType)
+            public UserTypeArgumentBinding()
             {
-                _valueType = valueType;
-                _bindingDataProvider = BindingDataProvider.FromType(_valueType);
+                _bindingDataProvider = BindingDataProvider.FromType(typeof(TInput));
             }
 
             public Type ValueType
             {
-                get { return _valueType; }
+                get { return typeof(TInput); }
             }
 
             public IReadOnlyDictionary<string, Type> BindingDataContract
@@ -48,48 +52,64 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
             {
                 IValueProvider provider;
                 BrokeredMessage clone = value.Clone();
-                string contents;
 
-                using (Stream stream = value.GetBody<Stream>())
+                TInput contents = await GetBody(value, context);
+
+                if (contents == null)
                 {
-                    if (stream == null)
-                    {
-                        provider = await BrokeredMessageValueProvider.CreateAsync(clone, null, ValueType,
-                            context.CancellationToken);
-                        return new TriggerData(provider, null);
-                    }
-
-                    using (TextReader reader = new StreamReader(stream, StrictEncodings.Utf8))
-                    {
-                        context.CancellationToken.ThrowIfCancellationRequested();
-                        contents = await reader.ReadToEndAsync();
-                    }
+                    provider = await BrokeredMessageValueProvider.CreateAsync(clone, null, ValueType,
+                        context.CancellationToken);
+                    return new TriggerData(provider, null);
                 }
 
-                object convertedValue;
-
-                try
-                {
-                    convertedValue = JsonCustom.DeserializeObject(contents, ValueType);
-                }
-                catch (JsonException e)
-                {
-                    // Easy to have the queue payload not deserialize properly. So give a useful error. 
-                    string msg = string.Format(
-    @"Binding parameters to complex objects (such as '{0}') uses Json.NET serialization. 
-1. Bind the parameter type as 'string' instead of '{0}' to get the raw values and avoid JSON deserialization, or
-2. Change the queue payload to be valid json. The JSON parser failed: {1}
-", _valueType.Name, e.Message);
-                    throw new InvalidOperationException(msg);
-                }
-
-                provider = await BrokeredMessageValueProvider.CreateAsync(clone, convertedValue, ValueType,
+                provider = await BrokeredMessageValueProvider.CreateAsync(clone, contents, ValueType,
                     context.CancellationToken);
 
-                IReadOnlyDictionary<string, object> bindingData = (_bindingDataProvider != null) 
-                    ? _bindingDataProvider.GetBindingData(convertedValue) : null;
+                IReadOnlyDictionary<string, object> bindingData = (_bindingDataProvider != null)
+                    ? _bindingDataProvider.GetBindingData(contents) : null;
 
                 return new TriggerData(provider, bindingData);
+            }
+
+            private static async Task<TInput> GetBody(BrokeredMessage message, ValueBindingContext context)
+            {
+                if (message.ContentType == ContentTypes.ApplicationJson)
+                {
+                    string contents;
+
+                    using (Stream stream = message.GetBody<Stream>())
+                    {
+                        if (stream == null)
+                        {
+                            return default(TInput);
+                        }
+
+                        using (TextReader reader = new StreamReader(stream, StrictEncodings.Utf8))
+                        {
+                            context.CancellationToken.ThrowIfCancellationRequested();
+                            contents = await reader.ReadToEndAsync();
+                        }
+                    }
+
+                    try
+                    {
+                        return (TInput)JsonCustom.DeserializeObject(contents, typeof(TInput));
+                    }
+                    catch (JsonException e)
+                    {
+                        // Easy to have the queue payload not deserialize properly. So give a useful error. 
+                        string msg = string.Format(
+        @"Binding parameters to complex objects (such as '{0}') uses Json.NET serialization. 
+1. Bind the parameter type as 'string' instead of '{0}' to get the raw values and avoid JSON deserialization, or
+2. Change the queue payload to be valid json. The JSON parser failed: {1}
+", typeof(TInput).Name, e.Message);
+                        throw new InvalidOperationException(msg);
+                    }
+                }
+                else
+                {
+                    return message.GetBody<TInput>();
+                }
             }
         }
     }

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/WebJobs.ServiceBus.csproj
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/WebJobs.ServiceBus.csproj
@@ -102,6 +102,7 @@
     <Compile Include="Bindings\OutputConverter.cs" />
     <Compile Include="Bindings\ServiceBusBinding.cs" />
     <Compile Include="Bindings\ServiceBusAttributeBindingProvider.cs" />
+    <Compile Include="ContentTypes.cs" />
     <Compile Include="Listeners\NamespaceManagerExtensions.cs" />
     <Compile Include="Listeners\ServiceBusListener.cs" />
     <Compile Include="Listeners\ServiceBusSubscriptionListenerFactory.cs" />
@@ -120,7 +121,10 @@
     <Compile Include="Triggers\BrokeredMessageToByteArrayConverter.cs" />
     <Compile Include="Triggers\BrokeredMessageToStringConverter.cs" />
     <Compile Include="Listeners\ServiceBusTriggerExecutor.cs" />
-    <Compile Include="Triggers\StringToBrokeredMessageConverter.cs" />
+    <Compile Include="Triggers\StringToJsonBrokeredMessageConverter.cs" />
+    <Compile Include="Triggers\StringToBinaryBrokeredMessageConverter.cs" />
+    <Compile Include="Triggers\StringToBrokeredMessageConverterFactory.cs" />
+    <Compile Include="Triggers\StringToTextBrokeredMessageConverter.cs" />
     <Compile Include="Triggers\UserTypeArgumentBindingProvider.cs" />
     <Compile Include="Triggers\CompositeArgumentBindingProvider.cs" />
     <Compile Include="Triggers\ConverterArgumentBindingProvider.cs" />

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ServiceBusEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ServiceBusEndToEndTests.cs
@@ -57,7 +57,10 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             writer.Flush();
             stream.Position = 0;
 
-            output = new BrokeredMessage(stream);
+            output = new BrokeredMessage(stream)
+            {
+                ContentType = "text/plain"
+            };
         }
 
         // First listener for the topic
@@ -163,7 +166,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 writer.Flush();
                 stream.Position = 0;
 
-                queueClient.Send(new BrokeredMessage(stream));
+                queueClient.Send(new BrokeredMessage(stream) { ContentType = "text/plain" });
             }
 
             queueClient.Close();

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Triggers/ServiceBusTriggerBindingIntegrationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Triggers/ServiceBusTriggerBindingIntegrationTests.cs
@@ -25,7 +25,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Triggers
             IQueueTriggerArgumentBindingProvider provider = new UserTypeArgumentBindingProvider();
             ParameterInfo pi = new StubParameterInfo("parameterName", typeof(UserDataType));
             var argumentBinding = provider.TryCreate(pi);
-            _binding = new ServiceBusTriggerBinding("parameterName", argumentBinding, null, "queueName");
+            _binding = new ServiceBusTriggerBinding("parameterName", typeof(UserDataType), argumentBinding, null,
+                "queueName");
         }
 
         [Theory]
@@ -44,6 +45,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Triggers
             userProperty.SetValue(expectedObject, convertedPropertyValue);
             string messageContent = JsonCustom.SerializeObject(expectedObject);
             BrokeredMessage message = new BrokeredMessage(new MemoryStream(Encoding.UTF8.GetBytes(messageContent)), true);
+            message.ContentType = ContentTypes.ApplicationJson;
 
             ValueBindingContext context = new ValueBindingContext(null, CancellationToken.None);
 


### PR DESCRIPTION
Support native Service Bus serialization (fixes #321).

PR notes:
This change makes us incompatible with messages generated by our previous bits.
We now start emitting a ContentType on everything we produce, and we only consume messages in our custom/standard/JSON format if we see that content type. When the ContentType is absent or doesn't match our values, we default to Service Bus's built-in/custom/binaryXML serialization via `GetBody<T>()`.
