### PR TITLE
Resolved ambiguity of Blob to Stream binding (fixes #36).

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Blobs/StreamArgumentBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Blobs/StreamArgumentBindingProvider.cs
@@ -22,18 +22,24 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs
                 return null;
             }
 
-            if (access.HasValue && access.Value == FileAccess.ReadWrite)
+            if (!access.HasValue)
             {
-                throw new InvalidOperationException("Cannot bind blob to Stream using access ReadWrite.");
+                throw new InvalidOperationException(String.Format(
+                    "FileAccess must be specified when binding the parameter '{0}' to a blob Stream. " + 
+                    "Add a FileAccess argument to the BlobAttribute constructor " + 
+                    @"(for example, [Blob(""..."", FileAccess.Read)]).", 
+                    parameter.Name));
             }
 
-            if (!access.HasValue || access.Value == FileAccess.Read)
+            switch(access.Value)
             {
-                return new ReadStreamArgumentBinding();
-            }
-            else
-            {
-                return new WriteStreamArgumentBinding();
+                case FileAccess.ReadWrite:
+                    throw new InvalidOperationException("Cannot bind blob to Stream using access ReadWrite.");
+                case FileAccess.Read:
+                    return new ReadStreamArgumentBinding();
+                case FileAccess.Write:
+                default:
+                    return new WriteStreamArgumentBinding();
             }
         }
 

--- a/src/Microsoft.Azure.WebJobs.Host/Blobs/Triggers/BlobTriggerAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Blobs/Triggers/BlobTriggerAttributeBindingProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Bindings;
@@ -56,7 +57,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Triggers
             string resolvedCombinedPath = context.Resolve(blobTrigger.BlobPath);
             IBlobPathSource path = BlobPathSource.Create(resolvedCombinedPath);
 
-            IArgumentBinding<ICloudBlob> argumentBinding = _provider.TryCreate(parameter, access: null);
+            IArgumentBinding<ICloudBlob> argumentBinding = _provider.TryCreate(parameter, FileAccess.Read);
 
             if (argumentBinding == null)
             {

--- a/test/Microsoft.Azure.WebJobs.Host.IntegrationTests/LocalOrchestratorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.IntegrationTests/LocalOrchestratorTests.cs
@@ -297,7 +297,7 @@ namespace Microsoft.Azure.WebJobs.Host.IntegrationTests
 
             public static void FuncWithBlob(
                 [Blob(@"daas-test-input/blob.csv")] CloudBlockBlob blob,
-                [Blob(@"daas-test-input/blob.csv")] Stream stream
+                [Blob(@"daas-test-input/blob.csv", FileAccess.Read)] Stream stream
                 )
             {
                 Assert.NotNull(blob);
@@ -344,7 +344,7 @@ namespace Microsoft.Azure.WebJobs.Host.IntegrationTests
                 Assert.Equal("daas-test-input", blob.Container.Name);
             }
 
-            public static void FuncWithMissingBlobStream([Blob(@"daas-test-input/blob.csv")] Stream stream)
+            public static void FuncWithMissingBlobStream([Blob(@"daas-test-input/blob.csv", FileAccess.Read)] Stream stream)
             {
                 throw new InvalidOperationException();
             }


### PR DESCRIPTION
Require FileAccess value explicitly set for Blob to Stream binding (as requested by #36).
Enforcing FileAccess.Read for BlobTrigger bindings (not a behavioral change, as de facto that limitation was implied by the set of available triggering providers).
