### PR TITLE
Shorten post-invoke error message

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionExecutor.cs
@@ -306,7 +306,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
                     catch (Exception exception)
                     {
                         string message = String.Format(CultureInfo.InvariantCulture,
-                            "Error while handling parameter {0} '{1}' after function returned:", name, argument);
+                            "Error while handling parameter {0} after function returned:", name);
                         throw new InvalidOperationException(message, exception);
                     }
                 }


### PR DESCRIPTION
Shorten exception message for post-invoke binding failures (#88).

This change also avoids generic object.ToString calls without specific
format information (including DateTime.ToString).
