### PR TITLE
Table helper rename

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingDataPath.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingDataPath.cs
@@ -38,6 +38,8 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
         /// <returns>Path compatible string representation of the given parameter or null if its type is not supported.</returns>
         public static string ConvertParameterValueToString(object parameterValue)
         {
+            // Consider unifying with TToStringConverterFactory, though that selects a fixed conveter at indexing time
+            // and this waits until invocation time to decide how to convert.
             if (parameterValue != null)
             {
                 switch (Type.GetTypeCode(parameterValue.GetType()))

--- a/src/Microsoft.Azure.WebJobs.Host/Tables/PocoEntityValueBinder.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Tables/PocoEntityValueBinder.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.WebJobs.Host.Tables
             _eTag = eTag;
             _value = value;
             _valueType = valueType;
-            _originalProperties = ObjectBinderHelpers.ConvertObjectToDict(value);
+            _originalProperties = PocoTableEntityConverter.ConvertObjectToDict(value);
         }
 
         public Type Type
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.WebJobs.Host.Tables
         {
             get
             {
-                IDictionary<string, string> newProperties = ObjectBinderHelpers.ConvertObjectToDict(_value);
+                IDictionary<string, string> newProperties = PocoTableEntityConverter.ConvertObjectToDict(_value);
 
                 if (_originalProperties.Keys.Count != newProperties.Keys.Count)
                 {

--- a/src/Microsoft.Azure.WebJobs.Host/Tables/PocoTableEntity.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Tables/PocoTableEntity.cs
@@ -13,12 +13,12 @@ namespace Microsoft.Azure.WebJobs.Host.Tables
         public static TValue ToPocoEntity<TValue>(DynamicTableEntity tableEntity) where TValue : new()
         {
             IDictionary<string, string> data = Normalize(tableEntity);
-            return ObjectBinderHelpers.ConvertDictToObject<TValue>(data);
+            return PocoTableEntityConverter.ConvertDictToObject<TValue>(data);
         }
 
         public static ITableEntity ToTableEntity(object pocoEntity)
         {
-            IDictionary<string, string> data = ObjectBinderHelpers.ConvertObjectToDict(pocoEntity);
+            IDictionary<string, string> data = PocoTableEntityConverter.ConvertObjectToDict(pocoEntity);
             if (!data.ContainsKey("PartitionKey"))
             {
                 throw new InvalidOperationException("Table entity types must implement the property PartitionKey.");
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.WebJobs.Host.Tables
 
         public static ITableEntity ToTableEntity(string partitionKey, string rowKey, object pocoEntity)
         {
-            IDictionary<string, string> data = ObjectBinderHelpers.ConvertObjectToDict(pocoEntity);
+            IDictionary<string, string> data = PocoTableEntityConverter.ConvertObjectToDict(pocoEntity);
             return ToTableEntity(partitionKey, rowKey, data);
         }
 

--- a/src/Microsoft.Azure.WebJobs.Host/Tables/PocoTableEntityConverter.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Tables/PocoTableEntityConverter.cs
@@ -9,16 +9,16 @@ using System.Globalization;
 using System.Reflection;
 using Microsoft.Azure.WebJobs.Host.Converters;
 
-namespace Microsoft.Azure.WebJobs.Host
+namespace Microsoft.Azure.WebJobs.Host.Tables
 {
-    internal static class ObjectBinderHelpers
+    internal static class PocoTableEntityConverter
     {
         // Beware, we deserializing, DateTimes may arbitrarily be Local or UTC time.
         // Callers can normalize via DateTime.ToUniversalTime()
         // Can't really normalize here because DateTimes could be embedded deep in the target type.
         private static object BindFromString(string input, Type target)
         {
-            MethodInfo method = typeof(ObjectBinderHelpers).GetMethod(
+            MethodInfo method = typeof(PocoTableEntityConverter).GetMethod(
                 "BindFromStringGeneric", BindingFlags.NonPublic | BindingFlags.Static);
             Debug.Assert(method != null);
             MethodInfo genericMethod = method.MakeGenericMethod(target);
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.WebJobs.Host
             return d;
         }
 
-        static MethodInfo methodConvertDict = typeof(ObjectBinderHelpers).GetMethod("ConvertDict", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+        static MethodInfo methodConvertDict = typeof(PocoTableEntityConverter).GetMethod("ConvertDict", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
 
         // Dictionary is a copy (immune if source object gets mutated)        
         public static IDictionary<string, string> ConvertObjectToDict(object obj)

--- a/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
+++ b/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
@@ -678,7 +678,7 @@
     <Compile Include="Indexers\FunctionIndexingException.cs" />
     <Compile Include="Blobs\BlobCausalityManager.cs" />
     <Compile Include="Queues\QueueCausalityManager.cs" />
-    <Compile Include="ObjectBinderHelpers.cs" />
+    <Compile Include="Tables\PocoTableEntityConverter.cs" />
     <Compile Include="Queues\QueueClient.cs" />
     <Compile Include="Tables\TableClient.cs" />
     <Compile Include="Executors\FunctionExecutor.cs" />

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Tables/PocoTableEntityConverterTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Tables/PocoTableEntityConverterTests.cs
@@ -5,16 +5,17 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Text;
+using Microsoft.Azure.WebJobs.Host.Tables;
 using Xunit;
 
-namespace Microsoft.Azure.WebJobs.Host.UnitTests
+namespace Microsoft.Azure.WebJobs.Host.UnitTests.Tables
 {
-    public class ObjectBinderHelpersTests
+    public class PocoTableEntityConverterTests
     {
         [Fact]
         public void ConvertAnonymousType()
         {
-            var d = ObjectBinderHelpers.ConvertObjectToDict(new { A = 'A', One = 1 });
+            var d = PocoTableEntityConverter.ConvertObjectToDict(new { A = 'A', One = 1 });
 
             Assert.Equal(2, d.Count);
             Assert.Equal("A", d["A"]);
@@ -46,7 +47,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         
         private static DateTime RoundTripDateTime(DateTime now)
         {
-            var d = ObjectBinderHelpers.ConvertObjectToDict(new DateWrapper { Value = now });
+            var d = PocoTableEntityConverter.ConvertObjectToDict(new DateWrapper { Value = now });
 
             Assert.Equal(1, d.Count);
 
@@ -55,7 +56,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             var dateRaw = DateTime.Parse(rawVal);
             Assert.Equal(now.ToUniversalTime(), dateRaw.ToUniversalTime());
             
-            DateTime val = ObjectBinderHelpers.ConvertDictToObject<DateWrapper>(d).Value;
+            DateTime val = PocoTableEntityConverter.ConvertDictToObject<DateWrapper>(d).Value;
 
             // should have normalized Kind to be UTC
             Assert.Equal(val.Kind, DateTimeKind.Utc);
@@ -69,7 +70,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         {
             // Empty
             var d = new Dictionary<string, string>();
-            var obj = ObjectBinderHelpers.ConvertDictToObject<NullableDateWrapper>(d);
+            var obj = PocoTableEntityConverter.ConvertDictToObject<NullableDateWrapper>(d);
 
             Assert.False(obj.Value.HasValue);
         }
@@ -79,7 +80,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         {
             // Empty
             NullableDateWrapper obj = new NullableDateWrapper();
-            var d = ObjectBinderHelpers.ConvertObjectToDict(obj);
+            var d = PocoTableEntityConverter.ConvertObjectToDict(obj);
 
             // Nullable field shouldn't be written
             Assert.Equal(0, d.Count);
@@ -91,13 +92,13 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             // Empty
             var now = DateTime.UtcNow;
             NullableDateWrapper obj = new NullableDateWrapper { Value = now };
-            var d = ObjectBinderHelpers.ConvertObjectToDict(obj);
+            var d = PocoTableEntityConverter.ConvertObjectToDict(obj);
 
             Assert.Equal(1, d.Count);
-            var obj2 = ObjectBinderHelpers.ConvertDictToObject<NullableDateWrapper>(d);
+            var obj2 = PocoTableEntityConverter.ConvertDictToObject<NullableDateWrapper>(d);
 
             // Verify structural type equivalance. 
-            var obj3 = ObjectBinderHelpers.ConvertDictToObject<DateWrapper>(d);
+            var obj3 = PocoTableEntityConverter.ConvertDictToObject<DateWrapper>(d);
 
             Assert.Equal(obj.Value, obj2.Value);
             Assert.Equal(obj.Value, obj3.Value);
@@ -124,7 +125,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             var d = new Dictionary<string, string>();
             d["Value"] = raw;
 
-            DateTime val = ObjectBinderHelpers.ConvertDictToObject<DateWrapper>(d).Value;
+            DateTime val = PocoTableEntityConverter.ConvertDictToObject<DateWrapper>(d).Value;
 
             Assert.Equal(now.Kind, val.Kind);
             Assert.Equal(raw, val.ToString());
@@ -137,7 +138,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             var source = new Dictionary<string, object>();
             source["A"] = 'A';
             source["One"] = 1;
-            var d = ObjectBinderHelpers.ConvertObjectToDict(source);
+            var d = PocoTableEntityConverter.ConvertObjectToDict(source);
 
             Assert.Equal(2, d.Count);
             Assert.Equal("A", d["A"]);
@@ -150,7 +151,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             var obj = new StringBuilder("A");
             var source = new Dictionary<string, object>();
             source["A"] = obj;
-            var d = ObjectBinderHelpers.ConvertObjectToDict(source);
+            var d = PocoTableEntityConverter.ConvertObjectToDict(source);
 
             Assert.True(!object.ReferenceEquals(source, d)); // different instances
             Assert.Equal("A", d["A"]);
@@ -165,7 +166,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         public void ConvertEnum()
         {
             var obj = new { Purchase = Fruit.Banana };
-            var d = ObjectBinderHelpers.ConvertObjectToDict(obj);
+            var d = PocoTableEntityConverter.ConvertObjectToDict(obj);
 
             Assert.Equal(1, d.Count);
             Assert.Equal("Banana", d["Purchase"]);
@@ -182,7 +183,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         [Fact]
         public void ConvertWithTypeDescriptor()
         {
-            TestEnum x = (TestEnum)ObjectBinderHelpers.BindFromStringGeneric<TestEnum>("Frown");
+            TestEnum x = (TestEnum)PocoTableEntityConverter.BindFromStringGeneric<TestEnum>("Frown");
 
             // Converter overrides parse functionality
             Assert.Equal(x, TestEnum.Smile);

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
@@ -145,7 +145,7 @@
     <Compile Include="Protocols\JsonTypeNameAttributeTests.cs" />
     <Compile Include="Timers\LinearSpeedupStrategyTests.cs" />
     <Compile Include="Indexers\NameResolverTests.cs" />
-    <Compile Include="ObjectBinderHelpersTests.cs" />
+    <Compile Include="Tables\PocoTableEntityConverterTests.cs" />
     <Compile Include="Protocols\PolymorphicJsonConverterTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PublicSurfaceTests.cs" />


### PR DESCRIPTION
Rename ObjectBinderHelpers to PocoTableEntityConverter (fixes #177).

(Last bit of work after reviewing this class to close the issue.)
