### PR TITLE
Rename storage interfaces

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
+++ b/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
@@ -236,17 +236,17 @@
     <Compile Include="..\Microsoft.Azure.WebJobs.Protocols\WriteBlobParameterLog.cs">
       <Link>Protocols\WriteBlobParameterLog.cs</Link>
     </Compile>
-    <Compile Include="..\Microsoft.Azure.WebJobs.Storage\ICloudStorageAccount.cs">
-      <Link>Storage\ICloudStorageAccount.cs</Link>
+    <Compile Include="..\Microsoft.Azure.WebJobs.Storage\IStorageAccount.cs">
+      <Link>Storage\IStorageAccount.cs</Link>
     </Compile>
-    <Compile Include="..\Microsoft.Azure.WebJobs.Storage\Queue\ICloudQueue.cs">
-      <Link>Storage\Queue\ICloudQueue.cs</Link>
+    <Compile Include="..\Microsoft.Azure.WebJobs.Storage\Queue\IStorageQueue.cs">
+      <Link>Storage\Queue\IStorageQueue.cs</Link>
     </Compile>
-    <Compile Include="..\Microsoft.Azure.WebJobs.Storage\Queue\ICloudQueueClient.cs">
-      <Link>Storage\Queue\ICloudQueueClient.cs</Link>
+    <Compile Include="..\Microsoft.Azure.WebJobs.Storage\Queue\IStorageQueueClient.cs">
+      <Link>Storage\Queue\IStorageQueueClient.cs</Link>
     </Compile>
-    <Compile Include="..\Microsoft.Azure.WebJobs.Storage\SdkCloudStorageAccount.cs">
-      <Link>Storage\SdkCloudStorageAccount.cs</Link>
+    <Compile Include="..\Microsoft.Azure.WebJobs.Storage\StorageAccount.cs">
+      <Link>Storage\StorageAccount.cs</Link>
     </Compile>
     <Compile Include="..\Microsoft.Azure.WebJobs.Storage\StorageExceptionExtensions.cs">
       <Link>Storage\StorageExceptionExtensions.cs</Link>
@@ -254,14 +254,14 @@
     <Compile Include="..\Microsoft.Azure.WebJobs.Storage\Table\CloudTableExtensions.cs">
       <Link>Storage\Table\CloudTableExtensions.cs</Link>
     </Compile>
-    <Compile Include="..\Microsoft.Azure.WebJobs.Storage\Table\ICloudTable.cs">
-      <Link>Storage\Table\ICloudTable.cs</Link>
-    </Compile>
-    <Compile Include="..\Microsoft.Azure.WebJobs.Storage\Table\ICloudTableClient.cs">
-      <Link>Storage\Table\ICloudTableClient.cs</Link>
-    </Compile>
     <Compile Include="..\Microsoft.Azure.WebJobs.Storage\Table\IQueryModifier.cs">
       <Link>Storage\Table\IQueryModifier.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.Azure.WebJobs.Storage\Table\IStorageTable.cs">
+      <Link>Storage\Table\IStorageTable.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.Azure.WebJobs.Storage\Table\IStorageTableClient.cs">
+      <Link>Storage\Table\IStorageTableClient.cs</Link>
     </Compile>
     <Compile Include="..\Microsoft.Azure.WebJobs.Storage\Table\PartitionKeyEqualsQueryModifier.cs">
       <Link>Storage\Table\PartitionKeyEqualsQueryModifier.cs</Link>

--- a/src/Microsoft.Azure.WebJobs.Storage/IStorageAccount.cs
+++ b/src/Microsoft.Azure.WebJobs.Storage/IStorageAccount.cs
@@ -19,18 +19,18 @@ namespace Microsoft.Azure.WebJobs.Host.Storage
 #if PUBLICSTORAGE
     /// <summary>Defines a cloud storage account.</summary>
     [CLSCompliant(false)]
-    public interface ICloudStorageAccount
+    public interface IStorageAccount
 #else
-    internal interface ICloudStorageAccount
+    internal interface IStorageAccount
 #endif
     {
         /// <summary>Creates a queue client.</summary>
         /// <returns>A queue client.</returns>
-        ICloudQueueClient CreateCloudQueueClient();
+        IStorageQueueClient CreateQueueClient();
 
         /// <summary>
         /// Creates a table client.</summary>
         /// <returns>A table client.</returns>
-        ICloudTableClient CreateCloudTableClient();
+        IStorageTableClient CreateTableClient();
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Storage/Queue/IStorageQueue.cs
+++ b/src/Microsoft.Azure.WebJobs.Storage/Queue/IStorageQueue.cs
@@ -13,9 +13,9 @@ namespace Microsoft.Azure.WebJobs.Host.Storage.Queue
     /// <summary>Defines a queue.</summary>
 #if PUBLICSTORAGE
     [CLSCompliant(false)]
-    public interface ICloudQueue
+    public interface IStorageQueue
 #else
-    internal interface ICloudQueue
+    internal interface IStorageQueue
 #endif
     {
         /// <summary>Adds a message to the queue.</summary>

--- a/src/Microsoft.Azure.WebJobs.Storage/Queue/IStorageQueueClient.cs
+++ b/src/Microsoft.Azure.WebJobs.Storage/Queue/IStorageQueueClient.cs
@@ -12,14 +12,14 @@ namespace Microsoft.Azure.WebJobs.Host.Storage.Queue
     /// <summary>Defines a queue client.</summary>
 #if PUBLICSTORAGE
     [CLSCompliant(false)]
-    public interface ICloudQueueClient
+    public interface IStorageQueueClient
 #else
-    internal interface ICloudQueueClient
+    internal interface IStorageQueueClient
 #endif
     {
         /// <summary>Gets a queue reference.</summary>
         /// <param name="queueName">The queue name.</param>
         /// <returns>A queue reference.</returns>
-        ICloudQueue GetQueueReference(string queueName);
+        IStorageQueue GetQueueReference(string queueName);
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Storage/StorageAccount.cs
+++ b/src/Microsoft.Azure.WebJobs.Storage/StorageAccount.cs
@@ -22,58 +22,58 @@ namespace Microsoft.Azure.WebJobs.Storage
 namespace Microsoft.Azure.WebJobs.Host.Storage
 #endif
 {
-    /// <summary>Represents a cloud storage account.</summary>
+    /// <summary>Represents a storage account.</summary>
 #if PUBLICSTORAGE
     [CLSCompliant(false)]
-    public class SdkCloudStorageAccount : ICloudStorageAccount
+    public class StorageAccount : IStorageAccount
 #else
-    internal class SdkCloudStorageAccount : ICloudStorageAccount
+    internal class StorageAccount : IStorageAccount
 #endif
     {
         private readonly CloudStorageAccount _sdkAccount;
 
-        /// <summary>Initializes a new instance of the <see cref="SdkCloudStorageAccount"/> class.</summary>
+        /// <summary>Initializes a new instance of the <see cref="StorageAccount"/> class.</summary>
         /// <param name="sdkAccount">The underlying SDK cloud storage account.</param>
-        public SdkCloudStorageAccount(CloudStorageAccount sdkAccount)
+        public StorageAccount(CloudStorageAccount sdkAccount)
         {
             _sdkAccount = sdkAccount;
         }
 
         /// <inheritdoc />
-        public ICloudQueueClient CreateCloudQueueClient()
+        public IStorageQueueClient CreateQueueClient()
         {
             CloudQueueClient sdkClient = _sdkAccount.CreateCloudQueueClient();
-            return new QueueClient(sdkClient);
+            return new StorageQueueClient(sdkClient);
         }
 
         /// <inheritdoc />
-        public ICloudTableClient CreateCloudTableClient()
+        public IStorageTableClient CreateTableClient()
         {
             CloudTableClient sdkClient = _sdkAccount.CreateCloudTableClient();
-            return new TableClient(sdkClient);
+            return new StorageTableClient(sdkClient);
         }
 
-        private class QueueClient : ICloudQueueClient
+        private class StorageQueueClient : IStorageQueueClient
         {
             private readonly CloudQueueClient _sdk;
 
-            public QueueClient(CloudQueueClient sdk)
+            public StorageQueueClient(CloudQueueClient sdk)
             {
                 _sdk = sdk;
             }
 
-            public ICloudQueue GetQueueReference(string queueName)
+            public IStorageQueue GetQueueReference(string queueName)
             {
                 CloudQueue sdkQueue = _sdk.GetQueueReference(queueName);
-                return new Queue(sdkQueue);
+                return new StorageQueue(sdkQueue);
             }
         }
 
-        private class Queue : ICloudQueue
+        private class StorageQueue : IStorageQueue
         {
             private readonly CloudQueue _sdk;
 
-            public Queue(CloudQueue sdk)
+            public StorageQueue(CloudQueue sdk)
             {
                 _sdk = sdk;
             }
@@ -89,27 +89,27 @@ namespace Microsoft.Azure.WebJobs.Host.Storage
             }
         }
 
-        private class TableClient : ICloudTableClient
+        private class StorageTableClient : IStorageTableClient
         {
             private readonly CloudTableClient _sdk;
 
-            public TableClient(CloudTableClient sdk)
+            public StorageTableClient(CloudTableClient sdk)
             {
                 _sdk = sdk;
             }
 
-            public ICloudTable GetTableReference(string tableName)
+            public IStorageTable GetTableReference(string tableName)
             {
                 CloudTable sdkTable = _sdk.GetTableReference(tableName);
-                return new Table(sdkTable);
+                return new StorageTable(sdkTable);
             }
         }
 
-        private class Table : ICloudTable
+        private class StorageTable : IStorageTable
         {
             private readonly CloudTable _sdk;
 
-            public Table(CloudTable sdk)
+            public StorageTable(CloudTable sdk)
             {
                 _sdk = sdk;
             }
@@ -167,47 +167,6 @@ namespace Microsoft.Azure.WebJobs.Host.Storage
                     {
                         return Enumerable.Empty<TElement>();
                     }
-                }
-            }
-
-            public TElement GetOrInsert<TElement>(TElement entity) where TElement : ITableEntity, new()
-            {
-                if (entity == null)
-                {
-                    throw new ArgumentNullException("entity");
-                }
-
-                _sdk.CreateIfNotExists();
-
-                try
-                {
-                    // First, try to insert.
-                    _sdk.Execute(TableOperation.Insert(entity));
-                    return entity;
-                }
-                catch (StorageException exception)
-                {
-                    // If the insert failed because the entity already exists, try to get instead.
-                    if (exception.IsConflict())
-                    {
-                        IQueryable queryable = _sdk.CreateQuery<TElement>();
-                        Debug.Assert(queryable != null);
-                        IQueryable<TElement> query = from TElement item in queryable
-                                                     where item.PartitionKey == entity.PartitionKey
-                                                     && item.RowKey == entity.RowKey
-                                                     select item;
-                        TElement existingItem = query.FirstOrDefault();
-
-                        // The get can fail if the object existed at the time of insert but was deleted before
-                        // the get executed. At this point, give up. We already tried to insert once, and that
-                        // already failed, so just propogate the original exception.
-                        if (existingItem != null)
-                        {
-                            return existingItem;
-                        }
-                    }
-
-                    throw;
                 }
             }
         }

--- a/src/Microsoft.Azure.WebJobs.Storage/Table/CloudTableExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Storage/Table/CloudTableExtensions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.WebJobs.Storage.Table
 namespace Microsoft.Azure.WebJobs.Host.Storage.Table
 #endif
 {
-    /// <summary>Provides extension methods for <see cref="ICloudTable"/>.</summary>
+    /// <summary>Provides extension methods for <see cref="IStorageTable"/>.</summary>
 #if PUBLICSTORAGE
     [CLSCompliant(false)]
     public static class CloudTableExtensions
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.WebJobs.Host.Storage.Table
         /// <param name="partitionKey">The partition key by which to filter.</param>
         /// <param name="rowKeyPrefix">The row key prefix by which to filter.</param>
         /// <returns>The matching entities.</returns>
-        public static IEnumerable<TElement> QueryByRowKeyPrefix<TElement>(this ICloudTable table, string partitionKey,
+        public static IEnumerable<TElement> QueryByRowKeyPrefix<TElement>(this IStorageTable table, string partitionKey,
             string rowKeyPrefix)
             where TElement : ITableEntity, new()
         {
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.WebJobs.Host.Storage.Table
         /// <param name="rowKeyPrefix">The row key prefix by which to filter.</param>
         /// <param name="resolver">The entity resolver to use to resolve entities.</param>
         /// <returns>The matching entities.</returns>
-        public static IEnumerable<TElement> QueryByRowKeyPrefix<TElement>(this ICloudTable table, string partitionKey,
+        public static IEnumerable<TElement> QueryByRowKeyPrefix<TElement>(this IStorageTable table, string partitionKey,
             string rowKeyPrefix, EntityResolver<TElement> resolver)
             where TElement : ITableEntity, new()
         {

--- a/src/Microsoft.Azure.WebJobs.Storage/Table/IStorageTable.cs
+++ b/src/Microsoft.Azure.WebJobs.Storage/Table/IStorageTable.cs
@@ -14,9 +14,9 @@ namespace Microsoft.Azure.WebJobs.Host.Storage.Table
     /// <summary>Defines a table.</summary>
 #if PUBLICSTORAGE
     [CLSCompliant(false)]
-    public interface ICloudTable
+    public interface IStorageTable
 #else
-    internal interface ICloudTable
+    internal interface IStorageTable
 #endif
     {
         /// <summary>Inserts an entity into the table.</summary>
@@ -29,11 +29,5 @@ namespace Microsoft.Azure.WebJobs.Host.Storage.Table
         /// <param name="queryModifiers">The query modifiers.</param>
         /// <returns>The matching entities.</returns>
         IEnumerable<TElement> Query<TElement>(int? limit, params IQueryModifier[] queryModifiers) where TElement : ITableEntity, new();
-
-        /// <summary>Gets an existing entity or inserts a new entity into the table.</summary>
-        /// <typeparam name="TElement">The type of the entity.</typeparam>
-        /// <param name="entity">The entity to insert, if no existing entity exists.</param>
-        /// <returns>The existing entity found on the new entity inserted.</returns>
-        TElement GetOrInsert<TElement>(TElement entity) where TElement : ITableEntity, new();
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Storage/Table/IStorageTableClient.cs
+++ b/src/Microsoft.Azure.WebJobs.Storage/Table/IStorageTableClient.cs
@@ -12,14 +12,14 @@ namespace Microsoft.Azure.WebJobs.Host.Storage.Table
     /// <summary>Defines a table client.</summary>
 #if PUBLICSTORAGE
     [CLSCompliant(false)]
-    public interface ICloudTableClient
+    public interface IStorageTableClient
 #else
-    internal interface ICloudTableClient
+    internal interface IStorageTableClient
 #endif
     {
         /// <summary>Gets a table reference.</summary>
         /// <param name="tableName">The table name.</param>
         /// <returns>A table reference.</returns>
-        ICloudTable GetTableReference(string tableName);
+        IStorageTable GetTableReference(string tableName);
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Storage/WebJobs.Storage.csproj
+++ b/src/Microsoft.Azure.WebJobs.Storage/WebJobs.Storage.csproj
@@ -48,15 +48,15 @@
     <Compile Include="..\Common\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="ICloudStorageAccount.cs" />
+    <Compile Include="IStorageAccount.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Queue\ICloudQueue.cs" />
-    <Compile Include="Queue\ICloudQueueClient.cs" />
-    <Compile Include="SdkCloudStorageAccount.cs" />
+    <Compile Include="Queue\IStorageQueue.cs" />
+    <Compile Include="Queue\IStorageQueueClient.cs" />
+    <Compile Include="StorageAccount.cs" />
     <Compile Include="StorageExceptionExtensions.cs" />
     <Compile Include="Table\CloudTableExtensions.cs" />
-    <Compile Include="Table\ICloudTable.cs" />
-    <Compile Include="Table\ICloudTableClient.cs" />
+    <Compile Include="Table\IStorageTable.cs" />
+    <Compile Include="Table\IStorageTableClient.cs" />
     <Compile Include="Table\ResolverQueryModifier.cs" />
     <Compile Include="Table\RowKeyGreaterThanOrEqualQueryModifier.cs" />
     <Compile Include="Table\RowKeyGreaterThanQueryModifier.cs" />


### PR DESCRIPTION
Rename storage interfaces.

PR notes:
Per offline discussion with @Eilon, rename storage interfaces to allow for a more consistent & obvious naming convention.

(Also removing some dead code.)
