### PR TITLE
Per blob function index paging

### DIFF
--- a/src/Dashboard/App_Start/AppModule.cs
+++ b/src/Dashboard/App_Start/AppModule.cs
@@ -42,6 +42,7 @@ namespace Dashboard
             Bind<IFunctionInstanceLogger>().To<FunctionInstanceLogger>();
             Bind<IHostIndexManager>().To<HostIndexManager>();
             Bind<IFunctionIndexVersionManager>().To<FunctionIndexVersionManager>();
+            Bind<IFunctionIndexManager>().To<FunctionIndexManager>();
             Bind<IFunctionLookup>().To<FunctionLookup>();
             Bind<IFunctionIndexReader>().To<FunctionIndexReader>();
             Bind<IHeartbeatValidityMonitor>().To<HeartbeatValidityMonitor>();

--- a/src/Dashboard/Dashboard.csproj
+++ b/src/Dashboard/Dashboard.csproj
@@ -190,6 +190,9 @@
     <Compile Include="Data\Logs\IIndexerLogWriter.cs" />
     <Compile Include="Data\Logs\IndexerLogEntry.cs" />
     <Compile Include="Data\StorageCredentialsValidator.cs" />
+    <Compile Include="Data\FunctionIndexEntry.cs" />
+    <Compile Include="Data\FunctionIndexManager.cs" />
+    <Compile Include="Data\IFunctionIndexManager.cs" />
     <Compile Include="Data\VersionedMetadataDocument.cs" />
     <Compile Include="Data\VersionedMetadataText.cs" />
     <Compile Include="Data\VersionedTextStore.cs" />

--- a/src/Dashboard/Data/DashboardDirectoryNames.cs
+++ b/src/Dashboard/Data/DashboardDirectoryNames.cs
@@ -8,10 +8,11 @@ namespace Dashboard.Data
     {
         public const string AbortRequestLogs = "aborts";
 
+        public const string Functions = "functions";
+        public const string FunctionsFlat = "functions/flat";
         public const string FunctionStatistics = "functions/stats";
         public const string FunctionInstances = "functions/instances";
 
-        public const string Functions = "functions";
         public const string Hosts = "hosts";
 
         public const string RecentFunctionsByFunction = "functions/recent/by-function";

--- a/src/Dashboard/Data/FunctionIndexEntry.cs
+++ b/src/Dashboard/Data/FunctionIndexEntry.cs
@@ -1,0 +1,138 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+
+namespace Dashboard.Data
+{
+    public class FunctionIndexEntry
+    {
+        private const string IdKey = "Id";
+        private const string ShortNameKey = "ShortName";
+        private const string FullNameKey = "FullName";
+        private const string HeartbeatExpirationInSecondsKey = "HeartbeatExpirationInSeconds";
+        private const string HeartbeatSharedContainerNameKey = "HeartbeatSharedContainerName";
+        private const string HeartbeatSharedDirectoryNameKey = "HeartbeatSharedDirectoryName";
+
+        private readonly DateTimeOffset _hostVersion;
+        private readonly string _id;
+        private readonly string _fullName;
+        private readonly string _shortName;
+        private readonly int? _heartbeatExpirationInSeconds;
+        private readonly string _heartbeatSharedContainerName;
+        private readonly string _heartbeatSharedDirectoryName;
+
+        private FunctionIndexEntry(DateTimeOffset hostVersion, string id, string fullName, string shortName,
+            int? heartbeatExpirationInSeconds, string heartbeatSharedContainerName, string heartbeatSharedDirectoryName)
+        {
+            _hostVersion = hostVersion;
+            _id = id;
+            _fullName = fullName;
+            _shortName = shortName;
+            _heartbeatExpirationInSeconds = heartbeatExpirationInSeconds;
+            _heartbeatSharedContainerName = heartbeatSharedContainerName;
+            _heartbeatSharedDirectoryName = heartbeatSharedDirectoryName;
+        }
+
+        public DateTimeOffset HostVersion { get { return _hostVersion; } }
+
+        public string Id { get { return _id; } }
+
+        public string FullName { get { return _fullName; } }
+
+        public string ShortName { get { return _shortName; } }
+
+        public int? HeartbeatExpirationInSeconds { get { return _heartbeatExpirationInSeconds; } }
+
+        public string HeartbeatSharedContainerName { get { return _heartbeatSharedContainerName; } }
+
+        public string HeartbeatSharedDirectoryName { get { return _heartbeatSharedDirectoryName; } }
+
+        public static FunctionIndexEntry Create(IDictionary<string, string> metadata, DateTimeOffset version)
+        {
+            if (metadata == null)
+            {
+                throw new ArgumentNullException("metadata");
+            }
+
+            string id = GetMetadataString(metadata, IdKey);
+            string fullName = GetMetadataString(metadata, FullNameKey);
+            string shortName = GetMetadataString(metadata, ShortNameKey);
+            int? heartbeatExpirationInSeconds = GetMetadataNullableInt32(metadata, HeartbeatExpirationInSecondsKey);
+            string heartbeatSharedContainerName = GetMetadataString(metadata, HeartbeatSharedContainerNameKey);
+            string heartbeatSharedDirectoryName = GetMetadataString(metadata, HeartbeatSharedDirectoryNameKey);
+
+            return new FunctionIndexEntry(version, id, fullName, shortName, heartbeatExpirationInSeconds,
+                heartbeatSharedContainerName, heartbeatSharedDirectoryName);
+        }
+
+        public static IDictionary<string, string> CreateOtherMetadata(FunctionSnapshot snapshot)
+        {
+            if (snapshot == null)
+            {
+                throw new ArgumentNullException("snapshot");
+            }
+
+            Dictionary<string, string> metadata = new Dictionary<string, string>();
+            AddMetadataString(metadata, IdKey, snapshot.Id);
+            AddMetadataString(metadata, FullNameKey, snapshot.FullName);
+            AddMetadataString(metadata, ShortNameKey, snapshot.ShortName);
+            AddMetadataNullableInt32(metadata, HeartbeatExpirationInSecondsKey, snapshot.HeartbeatExpirationInSeconds);
+            AddMetadataString(metadata, HeartbeatSharedContainerNameKey, snapshot.HeartbeatSharedContainerName);
+            AddMetadataString(metadata, HeartbeatSharedDirectoryNameKey, snapshot.HeartbeatSharedDirectoryName);
+
+            return metadata;
+        }
+
+        private static void AddMetadataString(IDictionary<string, string> metadata, string key, string value)
+        {
+            if (value != null)
+            {
+                metadata.Add(key, value);
+            }
+        }
+
+        private static void AddMetadataNullableInt32(IDictionary<string, string> metadata, string key, int? value)
+        {
+            if (value.HasValue)
+            {
+                metadata.Add(key, value.Value.ToString("g", CultureInfo.InvariantCulture));
+            }
+        }
+
+        private static string GetMetadataString(IDictionary<string, string> metadata, string key)
+        {
+            Debug.Assert(metadata != null);
+
+            if (!metadata.ContainsKey(key))
+            {
+                return null;
+            }
+
+            return metadata[key];
+        }
+
+        private static int? GetMetadataNullableInt32(IDictionary<string, string> metadata, string key)
+        {
+            Debug.Assert(metadata != null);
+
+            if (!metadata.ContainsKey(key))
+            {
+                return null;
+            }
+
+            string unparsed = metadata[key];
+            int parsed;
+
+            if (!Int32.TryParse(unparsed, NumberStyles.None, CultureInfo.InvariantCulture, out parsed))
+            {
+                return null;
+            }
+
+            return parsed;
+        }
+    }
+}

--- a/src/Dashboard/Data/FunctionIndexManager.cs
+++ b/src/Dashboard/Data/FunctionIndexManager.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.WindowsAzure.Storage.Blob;
+
+namespace Dashboard.Data
+{
+    public class FunctionIndexManager : IFunctionIndexManager
+    {
+        private readonly IVersionedDocumentStore<FunctionSnapshot> _store;
+
+        [CLSCompliant(false)]
+        public FunctionIndexManager(CloudBlobClient client)
+            : this(VersionedDocumentStore.CreateJsonBlobStore<FunctionSnapshot>(
+                client, DashboardContainerNames.Dashboard, DashboardDirectoryNames.FunctionsFlat))
+        {
+        }
+
+        private FunctionIndexManager(IVersionedDocumentStore<FunctionSnapshot> store)
+        {
+            _store = store;
+        }
+
+        public IEnumerable<VersionedMetadata> List(string hostId)
+        {
+            // Blob name under function/flat dircetory is hostId_FunctionId.
+            return _store.List(hostId + "_");
+        }
+
+        public bool CreateOrUpdateIfLatest(FunctionSnapshot snapshot)
+        {
+            return _store.CreateOrUpdateIfLatest(snapshot.Id, snapshot.HostVersion, CreateOtherMetadata(snapshot),
+                snapshot);
+        }
+
+        public bool UpdateOrCreateIfLatest(FunctionSnapshot snapshot, string currentETag, DateTimeOffset currentVersion)
+        {
+            return _store.UpdateOrCreateIfLatest(snapshot.Id, snapshot.HostVersion, CreateOtherMetadata(snapshot),
+                snapshot, currentETag, currentVersion);
+        }
+
+        public bool DeleteIfLatest(string id, DateTimeOffset deleteThroughVersion)
+        {
+            return _store.DeleteIfLatest(id, deleteThroughVersion);
+        }
+
+        public bool DeleteIfLatest(string id, DateTimeOffset deleteThroughVersion, string currentETag,
+            DateTimeOffset currentVersion)
+        {
+            return _store.DeleteIfLatest(id, deleteThroughVersion, currentETag, currentVersion);
+        }
+
+        private IDictionary<string, string> CreateOtherMetadata(FunctionSnapshot snapshot)
+        {
+            return FunctionIndexEntry.CreateOtherMetadata(snapshot);
+        }
+    }
+}

--- a/src/Dashboard/Data/FunctionLookup.cs
+++ b/src/Dashboard/Data/FunctionLookup.cs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using Microsoft.Azure.WebJobs.Storage;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
@@ -17,7 +15,7 @@ namespace Dashboard.Data
 
         public FunctionLookup(CloudBlobClient blobClient)
             : this(blobClient.GetContainerReference(DashboardContainerNames.Dashboard)
-                .GetDirectoryReference(DashboardDirectoryNames.Hosts))
+                .GetDirectoryReference(DashboardDirectoryNames.FunctionsFlat))
         {
         }
 
@@ -33,16 +31,8 @@ namespace Dashboard.Data
 
         public FunctionSnapshot Read(string functionId)
         {
-            FunctionIdentifier functionIdentifier = FunctionIdentifier.Parse(functionId);
-            CloudBlockBlob blob = _directory.GetBlockBlobReference(functionIdentifier.HostId);
-            HostSnapshot hostSnapshot = ReadJson<HostSnapshot>(blob);
-
-            if (hostSnapshot == null)
-            {
-                return null;
-            }
-
-            return hostSnapshot.Functions.FirstOrDefault(f => f.Id == functionId);
+            CloudBlockBlob blob = _directory.GetBlockBlobReference(functionId);
+            return ReadJson<FunctionSnapshot>(blob);
         }
 
         internal static T ReadJson<T>(CloudBlockBlob blob)

--- a/src/Dashboard/Data/FunctionSnapshot.cs
+++ b/src/Dashboard/Data/FunctionSnapshot.cs
@@ -3,12 +3,13 @@
 
 using System;
 using System.Collections.Generic;
-using Newtonsoft.Json;
 
 namespace Dashboard.Data
 {
     public class FunctionSnapshot
     {
+        public DateTimeOffset HostVersion { get; set; }
+
         public string Id { get; set; }
 
         public string QueueName { get; set; }

--- a/src/Dashboard/Data/HostIndexManager.cs
+++ b/src/Dashboard/Data/HostIndexManager.cs
@@ -20,6 +20,18 @@ namespace Dashboard.Data
             _store = store;
         }
 
+        public HostSnapshot Read(string id)
+        {
+            VersionedMetadataDocument<HostSnapshot> versionedDocument = _store.Read(id);
+
+            if (versionedDocument == null)
+            {
+                return null;
+            }
+
+            return versionedDocument.Document;
+        }
+
         public bool UpdateOrCreateIfLatest(string id, HostSnapshot snapshot)
         {
             return _store.UpdateOrCreateIfLatest(id, snapshot.HostVersion, otherMetadata: null, document: snapshot);

--- a/src/Dashboard/Data/HostSnapshot.cs
+++ b/src/Dashboard/Data/HostSnapshot.cs
@@ -10,6 +10,6 @@ namespace Dashboard.Data
     {
         public DateTimeOffset HostVersion { get; set; }
 
-        public IEnumerable<FunctionSnapshot> Functions { get; set; }
+        public IEnumerable<string> FunctionIds { get; set; }
     }
 }

--- a/src/Dashboard/Data/IFunctionIndexManager.cs
+++ b/src/Dashboard/Data/IFunctionIndexManager.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Dashboard.Data
+{
+    public interface IFunctionIndexManager
+    {
+        IEnumerable<VersionedMetadata> List(string hostId);
+
+        bool CreateOrUpdateIfLatest(FunctionSnapshot snapshot);
+
+        bool UpdateOrCreateIfLatest(FunctionSnapshot snapshot, string currentETag, DateTimeOffset currentVersion);
+
+        bool DeleteIfLatest(string id, DateTimeOffset deleteThroughVersion);
+
+        bool DeleteIfLatest(string id, DateTimeOffset deleteThroughVersion, string currentETag,
+            DateTimeOffset currentVersion);
+    }
+}

--- a/src/Dashboard/Data/IFunctionIndexReader.cs
+++ b/src/Dashboard/Data/IFunctionIndexReader.cs
@@ -9,6 +9,6 @@ namespace Dashboard.Data
     {
         DateTimeOffset GetCurrentVersion();
 
-        IResultSegment<FunctionSnapshot> Read(int maximumResults, string continuationToken);
+        IResultSegment<FunctionIndexEntry> Read(int maximumResults, string continuationToken);
     }
 }

--- a/src/Dashboard/Data/IFunctionIndexVersionManager.cs
+++ b/src/Dashboard/Data/IFunctionIndexVersionManager.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Dashboard.Data
 {
-    internal interface IFunctionIndexVersionManager
+    public interface IFunctionIndexVersionManager
     {
         void UpdateOrCreateIfLatest(DateTimeOffset version);
     }

--- a/src/Dashboard/Data/IHostIndexManager.cs
+++ b/src/Dashboard/Data/IHostIndexManager.cs
@@ -3,8 +3,10 @@
 
 namespace Dashboard.Data
 {
-    internal interface IHostIndexManager
+    public interface IHostIndexManager
     {
+        HostSnapshot Read(string id);
+
         bool UpdateOrCreateIfLatest(string id, HostSnapshot snapshot);
     }
 }

--- a/src/Dashboard/Indexers/UpgradeIndexer.cs
+++ b/src/Dashboard/Indexers/UpgradeIndexer.cs
@@ -32,7 +32,7 @@ namespace Dashboard.Indexers
         {
             _dashboardVersionManager = dashboardVersionReader;
             _client = client;
-            _functionsStore = ConcurrentTextStore.CreateBlobStore(_client, DashboardContainerNames.Dashboard, DashboardDirectoryNames.Functions);
+            _functionsStore = ConcurrentTextStore.CreateBlobStore(_client, DashboardContainerNames.Dashboard, DashboardDirectoryNames.FunctionsFlat);
             _logsStore = ConcurrentTextStore.CreateBlobStore(_client, DashboardContainerNames.Dashboard, DashboardDirectoryNames.Logs);
 
             // From archive back to output

--- a/test/Dashboard.UnitTests/Dashboard.UnitTests.csproj
+++ b/test/Dashboard.UnitTests/Dashboard.UnitTests.csproj
@@ -42,6 +42,10 @@
     <Compile Include="..\Common\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Indexers\FakeFunctionIndexManager.cs" />
+    <Compile Include="Indexers\FakeFunctionIndexVersionManager.cs" />
+    <Compile Include="Indexers\FakeHostIndexManager.cs" />
+    <Compile Include="Indexers\HostIndexerTests.cs" />
     <Compile Include="Infrastructure\LogAnalysisTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Data\VersionedMetadataTextStoreTests.cs" />

--- a/test/Dashboard.UnitTests/Indexers/FakeFunctionIndexManager.cs
+++ b/test/Dashboard.UnitTests/Indexers/FakeFunctionIndexManager.cs
@@ -1,0 +1,139 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Dashboard.Data;
+
+namespace Dashboard.UnitTests.Indexers
+{
+    internal class FakeFunctionIndexManager : IFunctionIndexManager
+    {
+        private readonly IList<StoreItem> _store = new List<StoreItem>();
+
+        public IEnumerable<VersionedMetadata> List(string hostId)
+        {
+            IEnumerable<StoreItem> matches = _store.Where(i => i.FunctionSnapshot.QueueName == hostId)
+                .OrderBy(i => i.FunctionSnapshot.HostFunctionId);
+            List<VersionedMetadata> results = new List<VersionedMetadata>();
+
+            foreach (StoreItem item in matches)
+            {
+                IDictionary<string, string> metadata = new Dictionary<string, string>();
+                results.Add(new VersionedMetadata(item.FunctionSnapshot.HostFunctionId, item.ETag, metadata,
+                    item.FunctionSnapshot.HostVersion));
+            }
+
+            return results;
+        }
+
+        public bool CreateOrUpdateIfLatest(FunctionSnapshot snapshot)
+        {
+            if (snapshot == null)
+            {
+                throw new ArgumentNullException("snapshot");
+            }
+
+            StoreItem existing = _store.Where(i => i.FunctionSnapshot.Id == snapshot.Id).FirstOrDefault();
+
+            if (existing == null)
+            {
+                _store.Add(CreateStoreItem(snapshot));
+                return true;
+            }
+            else if (existing.FunctionSnapshot.HostVersion < snapshot.HostVersion)
+            {
+                _store.Remove(existing);
+                _store.Add(CreateStoreItem(snapshot));
+                return true;
+            }
+            else
+            {
+                // Tell callers when they have the latest version, even if it was already present.
+                return existing.FunctionSnapshot.HostVersion == snapshot.HostVersion;
+            }
+        }
+
+        public bool UpdateOrCreateIfLatest(FunctionSnapshot snapshot, string currentETag, DateTimeOffset currentVersion)
+        {
+            if (snapshot == null)
+            {
+                throw new ArgumentNullException("snapshot");
+            }
+
+            StoreItem existing = _store.Where(i => i.FunctionSnapshot.Id == snapshot.Id).FirstOrDefault();
+
+            if (existing == null)
+            {
+                _store.Add(CreateStoreItem(snapshot));
+                return true;
+            }
+            else if (currentETag == existing.ETag && currentVersion < snapshot.HostVersion)
+            {
+                Debug.Assert(currentVersion == existing.FunctionSnapshot.HostVersion);
+                _store.Remove(existing);
+                _store.Add(CreateStoreItem(snapshot));
+                return true;
+            }
+            else
+            {
+                // Tell callers when they have the latest version, even if it was already present.
+                return existing.FunctionSnapshot.HostVersion == snapshot.HostVersion;
+            }
+        }
+
+        public bool DeleteIfLatest(string id, DateTimeOffset deleteThroughVersion)
+        {
+            StoreItem existing = _store.Where(i => i.FunctionSnapshot.Id == id).FirstOrDefault();
+
+            if (existing == null)
+            {
+                return true;
+            }
+
+            if (existing.FunctionSnapshot.HostVersion <= deleteThroughVersion)
+            {
+                _store.Remove(existing);
+                return true;
+            }
+
+            return false;
+        }
+
+        public bool DeleteIfLatest(string id, DateTimeOffset deleteThroughVersion, string currentETag, DateTimeOffset currentVersion)
+        {
+            StoreItem existing = _store.Where(i => i.FunctionSnapshot.Id == id).FirstOrDefault();
+
+            if (existing == null)
+            {
+                return true;
+            }
+
+            if (currentETag == existing.ETag && existing.FunctionSnapshot.HostVersion <= deleteThroughVersion)
+            {
+                Debug.Assert(currentVersion == existing.FunctionSnapshot.HostVersion);
+                _store.Remove(existing);
+                return true;
+            }
+
+            return false;
+        }
+
+        private static StoreItem CreateStoreItem(FunctionSnapshot snapshot)
+        {
+            return new StoreItem
+            {
+                FunctionSnapshot = snapshot,
+                ETag = Guid.NewGuid().ToString()
+            };
+        }
+
+        private class StoreItem
+        {
+            public FunctionSnapshot FunctionSnapshot { get; set; }
+            public string ETag { get; set; }
+        }
+    }
+}

--- a/test/Dashboard.UnitTests/Indexers/FakeFunctionIndexVersionManager.cs
+++ b/test/Dashboard.UnitTests/Indexers/FakeFunctionIndexVersionManager.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Dashboard.Data;
+
+namespace Dashboard.UnitTests.Indexers
+{
+    internal class FakeFunctionIndexVersionManager : IFunctionIndexVersionManager
+    {
+        public DateTimeOffset Current { get; set; }
+
+        public void UpdateOrCreateIfLatest(DateTimeOffset version)
+        {
+            if (version > Current)
+            {
+                Current = version;
+            }
+        }
+    }
+}

--- a/test/Dashboard.UnitTests/Indexers/FakeHostIndexManager.cs
+++ b/test/Dashboard.UnitTests/Indexers/FakeHostIndexManager.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Dashboard.Data;
+
+namespace Dashboard.UnitTests.Indexers
+{
+    internal class FakeHostIndexManager : IHostIndexManager
+    {
+        private readonly IDictionary<string, HostSnapshot> _store = new Dictionary<string, HostSnapshot>();
+
+        public HostSnapshot Read(string id)
+        {
+            if (!_store.ContainsKey(id))
+            {
+                return null;
+            }
+
+            return _store[id];
+        }
+
+        public bool UpdateOrCreateIfLatest(string id, HostSnapshot snapshot)
+        {
+            if (snapshot == null)
+            {
+                throw new ArgumentNullException("snapshot");
+            }
+
+            if (!_store.ContainsKey(id))
+            {
+                _store.Add(id, snapshot);
+                return true;
+            }
+            else
+            {
+                HostSnapshot existing = _store[id];
+
+                if (snapshot.HostVersion > existing.HostVersion)
+                {
+                    _store[id] = snapshot;
+                    return true;
+                }
+                else
+                {
+                    // Tell callers when they have the latest version, even if it was already present.
+                    return snapshot.HostVersion == existing.HostVersion;
+                }
+            }
+        }
+    }
+}

--- a/test/Dashboard.UnitTests/Indexers/HostIndexerTests.cs
+++ b/test/Dashboard.UnitTests/Indexers/HostIndexerTests.cs
@@ -1,0 +1,384 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Dashboard.Data;
+using Dashboard.Indexers;
+using Microsoft.Azure.WebJobs.Protocols;
+using Moq;
+using Xunit;
+
+namespace Dashboard.UnitTests.Indexers
+{
+    public class HostIndexerTests
+    {
+        [Fact]
+        public void ProcessHostStarted_UpdatesOrCreatesHostSnapshotIfLatest()
+        {
+            // Arrange
+            const string hostId = "abc";
+            string[] expectedFunctionIds = new string[] { "a", "b" };
+            DateTimeOffset expectedHostVersion = DateTimeOffset.Now;
+            IHostIndexManager hostIndexManager = CreateFakeHostIndexManager();
+            IHostIndexer product = CreateProductUnderTest(hostIndexManager);
+            HostStartedMessage message = new HostStartedMessage
+            {
+                SharedQueueName = hostId,
+                EnqueuedOn = expectedHostVersion,
+                Functions = new FunctionDescriptor[]
+                {
+                    new FunctionDescriptor { Id = expectedFunctionIds[0]},
+                    new FunctionDescriptor { Id = expectedFunctionIds[1]}
+                }
+            };
+
+            // Act
+            product.ProcessHostStarted(message);
+
+            // Assert
+            HostSnapshot hostSnapshot = hostIndexManager.Read(hostId);
+            Assert.NotNull(hostSnapshot);
+            Assert.Equal(expectedHostVersion, hostSnapshot.HostVersion);
+            Assert.Equal(expectedFunctionIds, hostSnapshot.FunctionIds);
+        }
+
+        [Fact]
+        public void ProcessHostStarted_UpdatesOrCreatesFunctionIndexVersionIfLatest()
+        {
+            // Arrange
+            DateTimeOffset expectedVersion = DateTimeOffset.Now;
+            FakeFunctionIndexVersionManager functionIndexVersionManager = new FakeFunctionIndexVersionManager();
+            IHostIndexer product = CreateProductUnderTest(functionIndexVersionManager);
+            HostStartedMessage message = new HostStartedMessage
+            {
+                EnqueuedOn = expectedVersion
+            };
+
+            // Act
+            product.ProcessHostStarted(message);
+
+            // Assert
+            Assert.Equal(expectedVersion, functionIndexVersionManager.Current);
+        }
+
+        [Fact]
+        public void ProcessHostStarted_DeletesRemovedFunctionsIfLatest()
+        {
+            // Arrange
+            const string hostId = "host";
+            DateTimeOffset hostVersion = DateTimeOffset.Now;
+            string[] expectedFunctionIds = new string[] { "a", "c" };
+            IHostIndexManager hostIndexManager = CreateStubHostIndexManager(
+                CreateHostSnapshot(hostVersion, expectedFunctionIds), persistSucceeds: true);
+            IFunctionIndexManager functionIndexManager = CreateFakeFunctionIndexManager();
+            DateTimeOffset earlierHostVersion = DateTimeOffset.MinValue;
+            AddFunctionToIndex(functionIndexManager, hostId, expectedFunctionIds[0], earlierHostVersion);
+            AddFunctionToIndex(functionIndexManager, hostId, "b", earlierHostVersion);
+            AddFunctionToIndex(functionIndexManager, hostId, expectedFunctionIds[1], earlierHostVersion);
+            IHostIndexer product = CreateProductUnderTest(hostIndexManager, functionIndexManager);
+            HostStartedMessage message = new HostStartedMessage
+            {
+                SharedQueueName = hostId,
+                EnqueuedOn = hostVersion,
+                Functions = new FunctionDescriptor[]
+                {
+                    new FunctionDescriptor { Id = expectedFunctionIds[0] },
+                    new FunctionDescriptor { Id = expectedFunctionIds[1] },
+                }
+            };
+
+            // Act
+            product.ProcessHostStarted(message);
+
+            // Assert
+            IEnumerable<VersionedMetadata> functions = functionIndexManager.List(hostId);
+            Assert.NotNull(functions); // Guard
+            IEnumerable<string> functionIds = functions.Select(f => f.Id).ToArray();
+            Assert.Equal(expectedFunctionIds, functionIds);
+        }
+
+        [Fact]
+        public void ProcessHostStarted_CreatesNewFunctionsIfLatest()
+        {
+            // Arrange
+            const string hostId = "host";
+            DateTimeOffset hostVersion = DateTimeOffset.Now;
+            string[] expectedFunctionIds = new string[] { "a", "b", "c" };
+            IHostIndexManager hostIndexManager = CreateStubHostIndexManager(
+                CreateHostSnapshot(hostVersion, expectedFunctionIds), persistSucceeds: true);
+            IFunctionIndexManager functionIndexManager = CreateFakeFunctionIndexManager();
+            DateTimeOffset earlierHostVersion = DateTimeOffset.MinValue;
+            AddFunctionToIndex(functionIndexManager, hostId, expectedFunctionIds[0], earlierHostVersion);
+            AddFunctionToIndex(functionIndexManager, hostId, expectedFunctionIds[2], earlierHostVersion);
+            IHostIndexer product = CreateProductUnderTest(hostIndexManager, functionIndexManager);
+            HostStartedMessage message = new HostStartedMessage
+            {
+                SharedQueueName = hostId,
+                EnqueuedOn = hostVersion,
+                Functions = new FunctionDescriptor[]
+                {
+                    new FunctionDescriptor { Id = expectedFunctionIds[0] },
+                    new FunctionDescriptor { Id = expectedFunctionIds[1] },
+                    new FunctionDescriptor { Id = expectedFunctionIds[2] }
+                }
+            };
+
+            // Act
+            product.ProcessHostStarted(message);
+
+            // Assert
+            IEnumerable<VersionedMetadata> functions = functionIndexManager.List(hostId);
+            Assert.NotNull(functions); // Guard
+            IEnumerable<string> functionIds = functions.Select(f => f.Id).ToArray();
+            Assert.Equal(expectedFunctionIds, functionIds);
+        }
+
+        [Fact]
+        public void ProcessHostStarted_UpdatesExistingFunctionsIfLatest()
+        {
+            // Arrange
+            const string hostId = "host";
+            DateTimeOffset expectedVersion = DateTimeOffset.Now;
+            string[] expectedFunctionIds = new string[] { "a", "b", "c" };
+            IHostIndexManager hostIndexManager = CreateStubHostIndexManager(
+                CreateHostSnapshot(expectedVersion, expectedFunctionIds), persistSucceeds: true);
+            IFunctionIndexManager functionIndexManager = CreateFakeFunctionIndexManager();
+            DateTimeOffset earlierHostVersion = DateTimeOffset.MinValue;
+            AddFunctionToIndex(functionIndexManager, hostId, expectedFunctionIds[0], earlierHostVersion);
+            AddFunctionToIndex(functionIndexManager, hostId, expectedFunctionIds[1], earlierHostVersion);
+            AddFunctionToIndex(functionIndexManager, hostId, expectedFunctionIds[2], earlierHostVersion);
+            IHostIndexer product = CreateProductUnderTest(hostIndexManager, functionIndexManager);
+            HostStartedMessage message = new HostStartedMessage
+            {
+                SharedQueueName = hostId,
+                EnqueuedOn = expectedVersion,
+                Functions = new FunctionDescriptor[]
+                {
+                    new FunctionDescriptor { Id = expectedFunctionIds[0] },
+                    new FunctionDescriptor { Id = expectedFunctionIds[1] },
+                    new FunctionDescriptor { Id = expectedFunctionIds[2] }
+                }
+            };
+
+            // Act
+            product.ProcessHostStarted(message);
+
+            // Assert
+            IEnumerable<VersionedMetadata> functions = functionIndexManager.List(hostId);
+            Assert.NotNull(functions); // Guard
+            IEnumerable<string> functionIds = functions.Select(f => f.Id).ToArray();
+            Assert.Equal(expectedFunctionIds, functionIds);
+            IEnumerable<DateTimeOffset> versions = functions.Select(f => f.Version).ToArray();
+            Assert.Equal(new DateTimeOffset[] { expectedVersion, expectedVersion, expectedVersion }, versions);
+        }
+
+        [Fact]
+        public void ProcessHostStarted_IfHostConcurrentlyRemoved_DeletesKnownFunctionsIfLatest()
+        {
+            // Arrange
+            const string hostId = "host";
+            string[] originalFunctionIds = new string[] { "a", "b" };
+            IHostIndexManager concurrentlyRemoveFunctionsHostIndexManager = CreateStubHostIndexManager(
+                existingSnapshot: null, persistSucceeds: true);
+            IFunctionIndexManager functionIndexManager = CreateFakeFunctionIndexManager();
+            DateTimeOffset earlierHostVersion = DateTimeOffset.MinValue;
+            AddFunctionToIndex(functionIndexManager, hostId, originalFunctionIds[0], earlierHostVersion);
+            AddFunctionToIndex(functionIndexManager, hostId, originalFunctionIds[1], earlierHostVersion);
+            IHostIndexer product = CreateProductUnderTest(concurrentlyRemoveFunctionsHostIndexManager,
+                functionIndexManager);
+            HostStartedMessage message = new HostStartedMessage
+            {
+                SharedQueueName = hostId,
+                EnqueuedOn = DateTimeOffset.Now,
+                Functions = new FunctionDescriptor[]
+                {
+                    new FunctionDescriptor { Id = originalFunctionIds[0] },
+                    new FunctionDescriptor { Id = originalFunctionIds[1] },
+                    new FunctionDescriptor { Id = "c" }
+                }
+            };
+
+            // Act
+            product.ProcessHostStarted(message);
+
+            // Assert
+            IEnumerable<VersionedMetadata> functions = functionIndexManager.List(hostId);
+            Assert.NotNull(functions); // Guard
+            IEnumerable<string> functionIds = functions.Select(f => f.Id).ToArray();
+            Assert.Equal(new string[0], functionIds);
+        }
+
+        [Fact]
+        public void ProcessHostStarted_IfHostConcurrentlyUpdated_DeletesKnownFunctionsIfLatest()
+        {
+            // Arrange
+            const string hostId = "host";
+            string[] originalFunctionIds = new string[] { "a", "b" };
+            string[] finalFunctionIds = new string[] { "b", "d" };
+            IHostIndexManager concurrentlyRemoveFunctionsHostIndexManager = CreateStubHostIndexManager(
+                existingSnapshot: CreateHostSnapshot(DateTimeOffset.MaxValue, finalFunctionIds), persistSucceeds: true);
+            IFunctionIndexManager functionIndexManager = CreateFakeFunctionIndexManager();
+            DateTimeOffset earlierHostVersion = DateTimeOffset.MinValue;
+            AddFunctionToIndex(functionIndexManager, hostId, originalFunctionIds[0], earlierHostVersion);
+            AddFunctionToIndex(functionIndexManager, hostId, originalFunctionIds[1], earlierHostVersion);
+            IHostIndexer product = CreateProductUnderTest(concurrentlyRemoveFunctionsHostIndexManager,
+                functionIndexManager);
+            HostStartedMessage message = new HostStartedMessage
+            {
+                SharedQueueName = hostId,
+                EnqueuedOn = DateTimeOffset.Now,
+                Functions = new FunctionDescriptor[]
+                {
+                    new FunctionDescriptor { Id = originalFunctionIds[0] },
+                    new FunctionDescriptor { Id = originalFunctionIds[1] },
+                    new FunctionDescriptor { Id = "c" },
+                    new FunctionDescriptor { Id = "d" }
+                }
+            };
+
+            // Act
+            product.ProcessHostStarted(message);
+
+            // Assert
+            IEnumerable<VersionedMetadata> functions = functionIndexManager.List(hostId);
+            Assert.NotNull(functions); // Guard
+            IEnumerable<string> functionIds = functions.Select(f => f.Id).ToArray();
+            Assert.Equal(finalFunctionIds, functionIds);
+        }
+
+        [Fact]
+        public void ProcessHostStarted_IfHostPreviouslyRemovedButProcessingAborted_DeletesKnownFunctionsIfLatest()
+        {
+            // Arrange
+            const string hostId = "host";
+            DateTimeOffset hostVersion = DateTimeOffset.Now;
+            string[] previouslyProcessedFunctionIds = new string[] { "a", "b", "c" };
+            IHostIndexManager concurrentlyRemoveFunctionsHostIndexManager = CreateStubHostIndexManager(
+                existingSnapshot: null, persistSucceeds: false);
+            IFunctionIndexManager functionIndexManager = CreateFakeFunctionIndexManager();
+            AddFunctionToIndex(functionIndexManager, hostId, previouslyProcessedFunctionIds[0], hostVersion);
+            AddFunctionToIndex(functionIndexManager, hostId, previouslyProcessedFunctionIds[1], hostVersion);
+            AddFunctionToIndex(functionIndexManager, hostId, previouslyProcessedFunctionIds[2], hostVersion);
+            IHostIndexer product = CreateProductUnderTest(concurrentlyRemoveFunctionsHostIndexManager,
+                functionIndexManager);
+            HostStartedMessage message = new HostStartedMessage
+            {
+                SharedQueueName = hostId,
+                EnqueuedOn = hostVersion,
+                Functions = new FunctionDescriptor[]
+                {
+                    new FunctionDescriptor { Id = previouslyProcessedFunctionIds[0] },
+                    new FunctionDescriptor { Id = previouslyProcessedFunctionIds[1] },
+                    new FunctionDescriptor { Id = previouslyProcessedFunctionIds[2] }
+                }
+            };
+
+            // Act
+            product.ProcessHostStarted(message);
+
+            // Assert
+            IEnumerable<VersionedMetadata> functions = functionIndexManager.List(hostId);
+            Assert.NotNull(functions); // Guard
+            IEnumerable<string> functionIds = functions.Select(f => f.Id).ToArray();
+            Assert.Equal(new string[0], functionIds);
+        }
+
+        private static void AddFunctionToIndex(IFunctionIndexManager functionIndexManager, string hostId,
+            string hostFunctionId, DateTimeOffset hostVersion)
+        {
+            Assert.True(functionIndexManager.CreateOrUpdateIfLatest(new FunctionSnapshot
+            {
+                Id = hostId + "_" + hostFunctionId,
+                HostFunctionId = hostFunctionId,
+                QueueName = hostId,
+                HostVersion = hostVersion
+            }));
+        }
+
+        private static IFunctionIndexManager CreateFakeFunctionIndexManager()
+        {
+            return new FakeFunctionIndexManager();
+        }
+
+        private static IHostIndexManager CreateFakeHostIndexManager()
+        {
+            return new FakeHostIndexManager();
+        }
+
+        private static HostSnapshot CreateHostSnapshot(DateTimeOffset hostVersion, IEnumerable<string> functionIds)
+        {
+            return new HostSnapshot
+            {
+                HostVersion = hostVersion,
+                FunctionIds = functionIds
+            };
+        }
+
+        private static HostIndexer CreateProductUnderTest(IFunctionIndexVersionManager functionIndexVersionManager)
+        {
+            IHostIndexManager hostIndexManager = CreateStubHostIndexManager(existingSnapshot: null,
+                persistSucceeds: false);
+            IFunctionIndexManager functionIndexManager = CreateStubFunctionIndexManager();
+            return CreateProductUnderTest(hostIndexManager, functionIndexManager, functionIndexVersionManager);
+        }
+
+        private static HostIndexer CreateProductUnderTest(IHostIndexManager hostIndexManager)
+        {
+            IFunctionIndexManager functionIndexManager = CreateStubFunctionIndexManager();
+            IFunctionIndexVersionManager functionIndexVersionManager = CreateStubFunctionIndexVersionManager();
+            return CreateProductUnderTest(hostIndexManager, functionIndexManager, functionIndexVersionManager);
+        }
+
+        private static HostIndexer CreateProductUnderTest(IHostIndexManager hostIndexManager,
+            IFunctionIndexManager functionIndexManager)
+        {
+            IFunctionIndexVersionManager functionIndexVersionManager = CreateStubFunctionIndexVersionManager();
+            return CreateProductUnderTest(hostIndexManager, functionIndexManager, functionIndexVersionManager);
+        }
+
+        private static HostIndexer CreateProductUnderTest(IHostIndexManager hostIndexManager,
+            IFunctionIndexManager functionIndexManager, IFunctionIndexVersionManager functionIndexVersionManager)
+        {
+            return new HostIndexer(hostIndexManager, functionIndexManager, functionIndexVersionManager);
+        }
+
+        private static IFunctionIndexManager CreateStubFunctionIndexManager()
+        {
+            Mock<IFunctionIndexManager> mock = new Mock<IFunctionIndexManager>(MockBehavior.Strict);
+            mock.Setup(m => m.List(It.IsAny<string>()))
+                .Returns(Enumerable.Empty<VersionedMetadata>());
+            mock.Setup(m => m.CreateOrUpdateIfLatest(It.IsAny<FunctionSnapshot>()))
+                .Returns(false);
+            mock.Setup(m => m.UpdateOrCreateIfLatest(It.IsAny<FunctionSnapshot>(), It.IsAny<string>(),
+                    It.IsAny<DateTimeOffset>()))
+                .Returns(false);
+            mock.Setup(m => m.DeleteIfLatest(It.IsAny<string>(), It.IsAny<DateTimeOffset>()))
+                .Returns(false);
+            mock.Setup(m => m.DeleteIfLatest(It.IsAny<string>(), It.IsAny<DateTimeOffset>(), It.IsAny<string>(),
+                    It.IsAny<DateTimeOffset>()))
+                .Returns(false);
+            return mock.Object;
+        }
+
+        private static IFunctionIndexVersionManager CreateStubFunctionIndexVersionManager()
+        {
+            Mock<IFunctionIndexVersionManager> mock = new Mock<IFunctionIndexVersionManager>(MockBehavior.Strict);
+            mock.Setup(m => m.UpdateOrCreateIfLatest(It.IsAny<DateTimeOffset>()));
+            return mock.Object;
+        }
+
+        private static IHostIndexManager CreateStubHostIndexManager(HostSnapshot existingSnapshot, bool persistSucceeds)
+        {
+            Mock<IHostIndexManager> mock = new Mock<IHostIndexManager>(MockBehavior.Strict);
+            mock.Setup(m => m.Read(It.IsAny<string>()))
+                .Returns(existingSnapshot);
+            mock.Setup(m => m.UpdateOrCreateIfLatest(It.IsAny<string>(), It.IsAny<HostSnapshot>()))
+                .Returns(persistSucceeds);
+            return mock.Object;
+        }
+    }
+}


### PR DESCRIPTION
Page function index using one blob per function (fixes #255).

PR notes:
Most of the changes are plumbing related to having a concrete "function index entry" data structure. The most interesting bits are in HostIndexer (indexing to one blob per function is harder) and FunctionIndexReader (reading one blob per function is easier).
