### PR TITLE
Fixed dashboard behavior when storage account is inaccessible.

### DIFF
--- a/src/Dashboard/Global.asax.cs
+++ b/src/Dashboard/Global.asax.cs
@@ -70,12 +70,12 @@ namespace Dashboard
                 try
                 {
                     _indexer.Update();
-
-                    Thread.Sleep(IndexerPollIntervalMilliseconds);
                 }
                 // Swallow any exceptions from the background thread to avoid killing the worker
                 // process. We should only get here if logging failed for indexer exceptions.
                 catch (Exception) { }
+
+                Thread.Sleep(IndexerPollIntervalMilliseconds);
             }
         }
     }


### PR DESCRIPTION
-=bug 1034324=-

Changed it to back off when connection attempts throw.
