### PR TITLE
Made storage account connection string optional (fixes #305.

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Executors/DefaultStorageCredentialsValidator.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/DefaultStorageCredentialsValidator.cs
@@ -14,6 +14,11 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
     {
         public async Task ValidateCredentialsAsync(IStorageAccount account, CancellationToken cancellationToken)
         {
+            if (account == null || account.SdkObject == null)
+            {
+                return;
+            }
+
             CloudStorageAccount sdkAccount = account.SdkObject;
 
             // Verify the credentials are correct.

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/MissingHostIdProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/MissingHostIdProvider.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.WebJobs.Host.Executors
+{
+    /// <summary>
+    /// Implementation of <see cref="IHostIdProvider"/> designed to defer throwing an exception till the first time
+    /// actual Host Id value is needed.
+    /// </summary>
+    /// <remarks>
+    /// Host Id is an optional feature of SDK and in some cases it may function correctly without it.
+    /// This strategy is used to detect missing configuration settings at places where this feature is actually consumed.
+    /// </remarks>
+    internal class MissingHostIdProvider : IHostIdProvider
+    {
+        /// <inheritdoc />
+        public Task<string> GetHostIdAsync(IEnumerable<MethodInfo> indexedMethods, CancellationToken cancellationToken)
+        {
+            const string errorMessage = "Using the AzureWebJobsDashboard connection string requires either " +
+                @"setting JobHostConfiguration.HostId or providing an ""AzureWebJobsStorage"" connection string.";
+            throw new InvalidOperationException(errorMessage);
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/NullStorageAccount.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/NullStorageAccount.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+#if PUBLICSTORAGE
+using Microsoft.Azure.WebJobs.Storage;
+using Microsoft.Azure.WebJobs.Storage.Blob;
+using Microsoft.Azure.WebJobs.Storage.Queue;
+using Microsoft.Azure.WebJobs.Storage.Table;
+#else
+using Microsoft.Azure.WebJobs.Host.Storage;
+using Microsoft.Azure.WebJobs.Host.Storage.Blob;
+using Microsoft.Azure.WebJobs.Host.Storage.Queue;
+using Microsoft.Azure.WebJobs.Host.Storage.Table;
+#endif
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Auth;
+
+namespace Microsoft.Azure.WebJobs.Host.Executors
+{
+    internal class NullStorageAccount : IStorageAccount
+    {
+        private readonly string _errorMessage;
+
+        public NullStorageAccount(string errorMessage)
+        {
+            _errorMessage = errorMessage;
+        }
+
+        public StorageCredentials Credentials
+        {
+            get { return null; }
+        }
+
+        public CloudStorageAccount SdkObject
+        {
+            get { return null; }
+        }
+
+        public IStorageBlobClient CreateBlobClient()
+        {
+            throw new InvalidOperationException(_errorMessage);
+        }
+
+        public IStorageQueueClient CreateQueueClient()
+        {
+            throw new InvalidOperationException(_errorMessage);
+        }
+
+        public IStorageTableClient CreateTableClient()
+        {
+            throw new InvalidOperationException(_errorMessage);
+        }
+
+        public string ToString(bool exportSecrets)
+        {
+            throw new InvalidOperationException(_errorMessage);
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/ValidateCachedHostIdProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/ValidateCachedHostIdProvider.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.WebJobs.Host.Executors
+{
+    internal class ValidateCachedHostIdProvider : IHostIdProvider
+    {
+        private readonly IHostIdProvider _innerProvider;
+        private string _cachedHostId;
+        private bool _isValueCached;
+
+        public ValidateCachedHostIdProvider(IHostIdProvider provider)
+        {
+            if (provider == null)
+            {
+                throw new ArgumentNullException("provider");
+            }
+
+            _innerProvider = provider;
+            _isValueCached = false;
+        }
+
+        /// <inheritdoc />
+        public async Task<string> GetHostIdAsync(IEnumerable<MethodInfo> indexedMethods, CancellationToken cancellationToken)
+        {
+            if (!_isValueCached)
+            {
+                string hostId = await _innerProvider.GetHostIdAsync(indexedMethods, cancellationToken);
+
+                if (!HostIdValidator.IsValid(hostId))
+                {
+                    throw new InvalidOperationException(HostIdValidator.ValidationMessage);
+                }
+
+                _cachedHostId = hostId;
+                _isValueCached = true;
+            }
+
+            return _cachedHostId;
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/JobHostConfiguration.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/JobHostConfiguration.cs
@@ -202,11 +202,15 @@ namespace Microsoft.Azure.WebJobs
             {
                 return new FixedHostIdProvider(_hostId);
             }
-            else
+
+            var storageAccount = _storageAccountProvider.GetAccount(ConnectionStringNames.Storage);
+            if (storageAccount != null && storageAccount.SdkObject != null)
             {
                 return new DynamicHostIdProvider(
                     _storageAccountProvider.GetAccount(ConnectionStringNames.Storage).SdkObject);
             }
+
+            return new MissingHostIdProvider();
         }
 
         // When running in Azure Web Sites, write out a manifest file.

--- a/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
+++ b/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
@@ -431,7 +431,10 @@
     <Compile Include="Executors\HostIdValidator.cs" />
     <Compile Include="Executors\IHostIdProvider.cs" />
     <Compile Include="Executors\DynamicHostIdProvider.cs" />
+    <Compile Include="Executors\MissingHostIdProvider.cs" />
+    <Compile Include="Executors\NullStorageAccount.cs" />
     <Compile Include="Executors\TaskInvoker.cs" />
+    <Compile Include="Executors\ValidateCachedHostIdProvider.cs" />
     <Compile Include="Executors\VoidInvoker.cs" />
     <Compile Include="ConnectionStringNames.cs" />
     <Compile Include="Converters\CompositeAsyncObjectToTypeConverter.cs" />


### PR DESCRIPTION
Using NullStorageAccount instance to defer throwing exception on missing storage connection string till the first time when it's actually needed. As of now it's any of trigger/binding provider call.
Using random FixedHostId when no storage connection string is provided.
Major adjustment to make whole thing work.
