### PR TITLE
Disabled replay of incompatible function instance (fixes #105).

### DIFF
--- a/src/Dashboard/Views/Function/Replay.cshtml
+++ b/src/Dashboard/Views/Function/Replay.cshtml
@@ -23,7 +23,14 @@
     </div>
 </div>
 
-@using (Html.BeginForm("Replay", "Function", new { parentId = Model.ParentId }, FormMethod.Post, new Dictionary<string, object> { { "class", "form" }, { "role", "form" } }))
+@if (ViewBag.CanReplay)
 {
-    Html.RenderPartial("_Invoke", Model);
+    using (Html.BeginForm("Replay", "Function", new { parentId = Model.ParentId }, FormMethod.Post, new Dictionary<string, object> { { "class", "form" }, { "role", "form" } }))
+    {
+        Html.RenderPartial("_Invoke", Model);
+    }
+}
+else
+{
+    <p class="alert alert-danger">The function cannot be replayed because its function definition has changed.</p>
 }


### PR DESCRIPTION
Show "Replay" button only when current invocation instance matches the most recent function's signature.
Display warning message otherwise.
Replay GET action will redirect to the parent invocation details page when unable to resolve parameters (no match). Needed when URL is manually crafted or action is invoked through a stale link.
