### PR TITLE
Fixed ObjectValueBinder to commit only when content's written (fixes #375).

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Blobs/Bindings/OutObjectArgumentBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Blobs/Bindings/OutObjectArgumentBindingProvider.cs
@@ -93,12 +93,11 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
                 {
                     await _objectBinder.WriteToStreamAsync((TValue)value, _stream, cancellationToken);
 
-                    if (!_stream.HasCommitted)
+                    // Determine whether or not to upload the blob.
+                    if (await _stream.CompleteAsync(cancellationToken))
                     {
-                        await _stream.CommitAsync(cancellationToken);
+                        _stream.Dispose(); // Can only dispose when committing; see note on class above.
                     }
-
-                    _stream.Dispose();
                 }
 
                 public string ToInvokeString()

--- a/test/Microsoft.Azure.WebJobs.Host.IntegrationTests/BlobBindingTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.IntegrationTests/BlobBindingTests.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Azure.WebJobs.Host.IntegrationTests
         [InlineData("FuncWithOutStringNull")]
         [InlineData("FuncWithStreamWriteNoop")]
         [InlineData("FuncWithT")]
+        [InlineData("FuncWithOutTNull")]
         [InlineData("FuncWithValueT")]
         public void Call_WhenMissingBlob_DoesntCreate(string functionName)
         {
@@ -48,7 +49,6 @@ namespace Microsoft.Azure.WebJobs.Host.IntegrationTests
         [InlineData("FuncWithTextWriter")]
         [InlineData("FuncWithStreamWrite")]
         [InlineData("FuncWithOutT")]
-        [InlineData("FuncWithOutTNull")]
         [InlineData("FuncWithOutValueT")]
         public void Call_WhenMissingBlob_Creates(string functionName)
         {


### PR DESCRIPTION
Replicated behavior of `WriteStreamValueBinder` to make `ObjectValueBinder` follow the same logic.
