### PR TITLE
Made storage account connection string optional (fixes #305.

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostContextFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostContextFactory.cs
@@ -25,7 +25,6 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
     internal class JobHostContextFactory
     {
         private readonly IStorageAccountProvider _storageAccountProvider;
-        private readonly IServiceBusAccountProvider _serviceBusAccountProvider;
         private readonly IFunctionIndexProvider _functionIndexProvider;
         private readonly INameResolver _nameResolver;
         private readonly IBindingProvider _bindingProvider;
@@ -37,7 +36,6 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
         private readonly CancellationToken _shutdownToken;
 
         public JobHostContextFactory(IStorageAccountProvider storageAccountProvider,
-            IServiceBusAccountProvider serviceBusAccountProvider,
             IFunctionIndexProvider functionIndexProvider,
             INameResolver nameResolver,
             IBindingProvider bindingProvider,
@@ -49,7 +47,6 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             CancellationToken shutdownToken)
         {
             _storageAccountProvider = storageAccountProvider;
-            _serviceBusAccountProvider = serviceBusAccountProvider;
             _functionIndexProvider = functionIndexProvider;
             _nameResolver = nameResolver;
             _bindingProvider = bindingProvider;
@@ -68,11 +65,8 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             {
                 CancellationToken combinedCancellationToken = combinedCancellationSource.Token;
 
-                IStorageAccount storageAccount = await _storageAccountProvider.GetStorageAccountAsync(
-                    combinedCancellationToken);
                 IStorageAccount dashboardAccount = await _storageAccountProvider.GetDashboardAccountAsync(
                     combinedCancellationToken);
-                string serviceBusConnectionString = _serviceBusAccountProvider.ConnectionString;
                 CloudStorageAccount sdkDashboardAccount = dashboardAccount != null ? dashboardAccount.SdkObject : null;
 
                 IHostInstanceLogger hostInstanceLogger = await _hostInstanceLoggerProvider.GetAsync(

--- a/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexProvider.cs
@@ -16,8 +16,6 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
     {
         private readonly ITypeLocator _typeLocator;
         private readonly INameResolver _nameResolver;
-        private readonly IStorageAccountProvider _storageAccountProvider;
-        private readonly IServiceBusAccountProvider _serviceBusAccountProvider;
         private readonly ITriggerBindingProvider _triggerBindingProvider;
         private readonly IBindingProvider _bindingProvider;
 
@@ -25,15 +23,11 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
 
         public FunctionIndexProvider(ITypeLocator typeLocator,
             INameResolver nameResolver,
-            IStorageAccountProvider storageAccountProvider,
-            IServiceBusAccountProvider serviceBusAccountProvider,
             ITriggerBindingProvider triggerBindingProvider,
             IBindingProvider bindingProvider)
         {
             _typeLocator = typeLocator;
             _nameResolver = nameResolver;
-            _storageAccountProvider = storageAccountProvider;
-            _serviceBusAccountProvider = serviceBusAccountProvider;
             _triggerBindingProvider = triggerBindingProvider;
             _bindingProvider = bindingProvider;
         }
@@ -50,12 +44,8 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
 
         private async Task<IFunctionIndex> CreateAsync(CancellationToken cancellationToken)
         {
-            IStorageAccount storageAccount = await _storageAccountProvider.GetStorageAccountAsync(cancellationToken);
-            string serviceBusConnectionString = _serviceBusAccountProvider.ConnectionString;
-
             FunctionIndex index = new FunctionIndex();
-            FunctionIndexer indexer = new FunctionIndexer(_nameResolver, storageAccount, serviceBusConnectionString,
-                _triggerBindingProvider, _bindingProvider);
+            FunctionIndexer indexer = new FunctionIndexer(_nameResolver, _triggerBindingProvider, _bindingProvider);
             IReadOnlyList<Type> types = _typeLocator.GetTypes();
 
             foreach (Type type in types)

--- a/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexer.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexer.cs
@@ -25,21 +25,15 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
         private static readonly Func<MethodInfo, bool> _hasServiceBusAttributeDefault = _ => false;
 
         private readonly INameResolver _nameResolver;
-        private readonly IStorageAccount _storageAccount;
-        private readonly string _serviceBusConnectionString;
         private readonly ITriggerBindingProvider _triggerBindingProvider;
         private readonly IBindingProvider _bindingProvider;
         private readonly Func<MethodInfo, bool> _hasServiceBusAttribute;
 
         public FunctionIndexer(INameResolver nameResolver,
-            IStorageAccount storageAccount,
-            string serviceBusConnectionString,
             ITriggerBindingProvider triggerBindingProvider,
             IBindingProvider bindingProvider)
         {
             _nameResolver = nameResolver;
-            _storageAccount = storageAccount;
-            _serviceBusConnectionString = serviceBusConnectionString;
             _triggerBindingProvider = triggerBindingProvider;
             _bindingProvider = bindingProvider;
 
@@ -130,8 +124,7 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
             foreach (ParameterInfo parameter in parameters)
             {
                 ITriggerBinding possibleTriggerBinding = await _triggerBindingProvider.TryCreateAsync(
-                    new TriggerBindingProviderContext(_nameResolver, _storageAccount, _serviceBusConnectionString,
-                        parameter, cancellationToken));
+                    new TriggerBindingProviderContext(_nameResolver, parameter, cancellationToken));
 
                 if (possibleTriggerBinding != null)
                 {

--- a/src/Microsoft.Azure.WebJobs.Host/JobHost.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/JobHost.cs
@@ -80,7 +80,6 @@ namespace Microsoft.Azure.WebJobs
             }
 
             IStorageAccountProvider storageAccountProvider = serviceProvider.GetStorageAccountProvider();
-            IServiceBusAccountProvider serviceBusAccountProvider = serviceProvider.GetServiceBusAccountProvider();
             IFunctionIndexProvider functionIndexProvider = serviceProvider.GetFunctionIndexProvider();
             INameResolver nameResolver = serviceProvider.GetNameResolver();
             IBindingProvider bindingProvider = serviceProvider.GetBindingProvider();
@@ -96,7 +95,7 @@ namespace Microsoft.Azure.WebJobs
             _shutdownWatcher = WebJobsShutdownWatcher.Create(_shutdownTokenSource);
             _stoppingTokenSource = CancellationTokenSource.CreateLinkedTokenSource(_shutdownTokenSource.Token);
 
-            _contextFactory = new JobHostContextFactory(storageAccountProvider, serviceBusAccountProvider,
+            _contextFactory = new JobHostContextFactory(storageAccountProvider,
                 functionIndexProvider, nameResolver, bindingProvider, hostIdProvider, hostInstanceLoggerProvider,
                 functionInstanceLoggerProvider, queueConfiguration, backgroundExceptionDispatcher,
                 _shutdownTokenSource.Token);

--- a/src/Microsoft.Azure.WebJobs.Host/JobHostConfiguration.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/JobHostConfiguration.cs
@@ -185,8 +185,8 @@ namespace Microsoft.Azure.WebJobs
             {
                 if (_functionIndexProvider == null)
                 {
-                    _functionIndexProvider = new FunctionIndexProvider(TypeLocator, NameResolver,
-                        _storageAccountProvider, _serviceBusAccountProvider, TriggerBindingProvider, BindingProvider);
+                    _functionIndexProvider = new FunctionIndexProvider(TypeLocator, NameResolver, 
+                        TriggerBindingProvider, BindingProvider);
                 }
 
                 return _functionIndexProvider;
@@ -260,10 +260,6 @@ namespace Microsoft.Azure.WebJobs
             else if (serviceType == typeof(IQueueConfiguration))
             {
                 return _queueConfiguration;
-            }
-            else if (serviceType == typeof(IServiceBusAccountProvider))
-            {
-                return _serviceBusAccountProvider;
             }
             else if (serviceType == typeof(IStorageAccountProvider))
             {

--- a/src/Microsoft.Azure.WebJobs.Host/ServiceProviderExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/ServiceProviderExtensions.cs
@@ -25,11 +25,6 @@ namespace Microsoft.Azure.WebJobs.Host
             return GetService<IBindingProvider>(serviceProvider);
         }
 
-        public static IConnectionStringProvider GetConnectionStringProvider(this IServiceProvider serviceProvider)
-        {
-            return GetService<IConnectionStringProvider>(serviceProvider);
-        }
-
         public static IFunctionIndexProvider GetFunctionIndexProvider(this IServiceProvider serviceProvider)
         {
             return GetService<IFunctionIndexProvider>(serviceProvider);
@@ -59,11 +54,6 @@ namespace Microsoft.Azure.WebJobs.Host
         public static IQueueConfiguration GetQueueConfiguration(this IServiceProvider serviceProvider)
         {
             return GetService<IQueueConfiguration>(serviceProvider);
-        }
-
-        public static IServiceBusAccountProvider GetServiceBusAccountProvider(this IServiceProvider serviceProvider)
-        {
-            return GetService<IServiceBusAccountProvider>(serviceProvider);
         }
 
         public static IStorageAccountProvider GetStorageAccountProvider(this IServiceProvider serviceProvider)

--- a/src/Microsoft.Azure.WebJobs.Host/Triggers/TriggerBindingProviderContext.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Triggers/TriggerBindingProviderContext.cs
@@ -10,17 +10,13 @@ namespace Microsoft.Azure.WebJobs.Host.Triggers
     internal class TriggerBindingProviderContext
     {
         private readonly INameResolver _nameResolver;
-        private readonly IStorageAccount _storageAccount;
-        private readonly string _serviceBusConnectionString;
         private readonly ParameterInfo _parameter;
         private readonly CancellationToken _cancellationToken;
 
-        public TriggerBindingProviderContext(INameResolver nameResolver, IStorageAccount storageAccount,
-            string serviceBusConnectionString, ParameterInfo parameter, CancellationToken cancellationToken)
+        public TriggerBindingProviderContext(INameResolver nameResolver, ParameterInfo parameter, 
+            CancellationToken cancellationToken)
         {
             _nameResolver = nameResolver;
-            _storageAccount = storageAccount;
-            _serviceBusConnectionString = serviceBusConnectionString;
             _parameter = parameter;
             _cancellationToken = cancellationToken;
         }

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/FunctionalTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/FunctionalTest.cs
@@ -49,7 +49,6 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
             return new FakeServiceProvider
             {
                 FunctionIndexProvider = new FunctionIndexProvider(new FakeTypeLocator(programType), null,
-                    storageAccountProvider, serviceBusAccountProvider,
                     DefaultTriggerBindingProvider.Create(storageAccountProvider, serviceBusAccountProvider,
                         extensionTypeLocator),
                     DefaultBindingProvider.Create(storageAccountProvider, serviceBusAccountProvider,

--- a/test/Microsoft.Azure.WebJobs.Host.IntegrationTests/LocalExecutionContext.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.IntegrationTests/LocalExecutionContext.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.WebJobs.Host.IntegrationTests
             ITriggerBindingProvider triggerBindingProvider = DefaultTriggerBindingProvider.Create(
                 storageAccountProvider, serviceBusAccountProvider, extensionTypeLocator);
             IFunctionIndexProvider indexProvider = new FunctionIndexProvider(new FakeTypeLocator(type), null,
-                storageAccountProvider, serviceBusAccountProvider, triggerBindingProvider, bindingProvider);
+                triggerBindingProvider, bindingProvider);
             _index = indexProvider.GetAsync(CancellationToken.None).GetAwaiter().GetResult();
 
             _blobClient = account.CreateCloudBlobClient();

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/JobHostFactory.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/JobHostFactory.cs
@@ -39,7 +39,6 @@ namespace Microsoft.Azure.WebJobs.Host.TestCommon
             TestJobHostConfiguration configuration = new TestJobHostConfiguration
             {
                 FunctionIndexProvider = new FunctionIndexProvider(new FakeTypeLocator(typeof(TProgram)), null,
-                    storageAccountProvider, serviceBusAccountProvider,
                     DefaultTriggerBindingProvider.Create(storageAccountProvider, serviceBusAccountProvider,
                         extensionTypeLocator),
                     DefaultBindingProvider.Create(storageAccountProvider, serviceBusAccountProvider,

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/FunctionIndexerFactory.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/FunctionIndexerFactory.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             IBindingProvider bindingProvider = DefaultBindingProvider.Create(storageAccountProvider,
                 serviceBusAccountProvider, extensionTypeLocator);
 
-            return new FunctionIndexer(nameResolver, storageAccount, null, triggerBindingProvider, bindingProvider);
+            return new FunctionIndexer(nameResolver, triggerBindingProvider, bindingProvider);
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Indexers/FunctionIndexerIntegrationErrorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Indexers/FunctionIndexerIntegrationErrorTests.cs
@@ -22,8 +22,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Indexers
             foreach (var method in this.GetType().GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static))
             {
                 IFunctionIndexCollector stubIndex = new Mock<IFunctionIndexCollector>().Object;
-                FunctionIndexer indexer = new FunctionIndexer(null,
-                    new StorageAccount(CloudStorageAccount.DevelopmentStorageAccount), null, null, null);
+                FunctionIndexer indexer = new FunctionIndexer(null, null, null);
                 Assert.Throws<FunctionIndexingException>(() => indexer.IndexMethodAsync(method, stubIndex, CancellationToken.None).GetAwaiter().GetResult());
             }
         }


### PR DESCRIPTION
Removed redundant references to `StorageAccountProvider` and `ServiceBusAccountProvider` everywhere to let account validation happen when it's actually consumed.

Replaces #411.
