### PR TITLE
Fixed time precision in LogAnalysis statuses (fixes #94).

### DIFF
--- a/src/Dashboard/app/services/stringUtils.js
+++ b/src/Dashboard/app/services/stringUtils.js
@@ -43,7 +43,7 @@
             return plural("1 s", "{0} s", Math.round(totalSeconds));
 
         if (timeSpan > 0)
-            return plural("1 ms", "{0} ms", timeSpan);
+            return plural("1 ms", "{0} ms", Math.round(timeSpan));
 
         return "less than 1ms";
     }


### PR DESCRIPTION
- Used the shared timespan formatter (after refactoring) for blob and table logs.
- Added unit-test for `LogAnalysis` format methods.
