### PR TITLE
Query Kudu Api if using Sdk in relevant controllers (fixes #78)

### DIFF
--- a/src/Dashboard/app/controllers/ContinuousJobController.js
+++ b/src/Dashboard/app/controllers/ContinuousJobController.js
@@ -6,6 +6,8 @@
             jobName = $routeParams.jobName,
             jobRunUrl = api.kudu.job('continuous', jobName);
 
+        isUsingSdk.findOut($scope);
+
         $scope.jobName = jobName;
         $scope.nonFinalInvocations = {};
 

--- a/src/Dashboard/app/controllers/TriggeredJobController.js
+++ b/src/Dashboard/app/controllers/TriggeredJobController.js
@@ -1,8 +1,10 @@
 ﻿angular.module('dashboard').controller('TriggeredJobController',
-  function ($scope, $routeParams, $interval, $http, JobRun, JobDefinition, api, urls) {
+  function ($scope, $routeParams, $interval, $http, JobRun, JobDefinition, api, urls, isUsingSdk) {
       var poll,
           pollInterval = 10 * 1000,
           lastPoll = 0;
+
+      isUsingSdk.findOut($scope);
 
       $scope.jobName = $routeParams.jobName;
 

--- a/src/Dashboard/app/controllers/TriggeredJobRunController.js
+++ b/src/Dashboard/app/controllers/TriggeredJobRunController.js
@@ -11,6 +11,8 @@
         $scope.runId = runId;
         $scope.nonFinalInvocations = {};
 
+        isUsingSdk.findOut($scope);
+
         $scope.breadcrumbs = [{
             url: urls.jobs(),
             title: 'WebJobs'

--- a/src/Dashboard/app/services/isUsingSdk.js
+++ b/src/Dashboard/app/services/isUsingSdk.js
@@ -7,17 +7,20 @@
     function setUsing(scope) {
         if (scope) {
             scope._usingSdk = true;
+            scope._usingSdkSet = true;
         } else {
             $rootScope._usingSdk = true;
+            $rootScope._usingSdkSet = true;
         }
     }
 
     function setNotUsing(scope) {
         scope._usingSdk = false;
+        scope._usingSdkSet = true;
     }
 
     function findOut(scope) {
-        if (isUsing(scope)) {
+        if (scope._usingSdkSet) {
             // this (or other) service already found out.
             return;
         }


### PR DESCRIPTION
`_usingSdk` is not initialized when Job details page is accessed first, i.e. before functions home.
Therefore the teaser appears on a Job details page.
The same happens if Ctrl-F5 refresh the details page.

To fix that I added `findOut` call to initialize `_usingSdk` scope variable in every job Angular controller.
