### PR TITLE
Fix next level of host ID dependency

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Blobs/Triggers/BlobTriggerAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Blobs/Triggers/BlobTriggerAttributeBindingProvider.cs
@@ -94,8 +94,8 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Triggers
             }
 
             IStorageAccount account = await _accountProvider.GetStorageAccountAsync(context.CancellationToken);
-            string hostId = await _hostIdProvider.GetHostIdAsync(context.CancellationToken);
-            ITriggerBinding binding = new BlobTriggerBinding(parameter.Name, argumentBinding, account, path, hostId);
+            ITriggerBinding binding = new BlobTriggerBinding(parameter.Name, argumentBinding, account, path,
+                _hostIdProvider);
             return binding;
         }
     }

--- a/src/Microsoft.Azure.WebJobs.Host/Blobs/Triggers/BlobTriggerBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Blobs/Triggers/BlobTriggerBinding.cs
@@ -27,12 +27,12 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Triggers
         private readonly IStorageBlobClient _client;
         private readonly string _accountName;
         private readonly IBlobPathSource _path;
-        private readonly string _hostId;
+        private readonly IHostIdProvider _hostIdProvider;
         private readonly IAsyncObjectToTypeConverter<IStorageBlob> _converter;
         private readonly IReadOnlyDictionary<string, Type> _bindingDataContract;
 
         public BlobTriggerBinding(string parameterName, IArgumentBinding<IStorageBlob> argumentBinding,
-            IStorageAccount account, IBlobPathSource path, string hostId)
+            IStorageAccount account, IBlobPathSource path, IHostIdProvider hostIdProvider)
         {
             _parameterName = parameterName;
             _argumentBinding = argumentBinding;
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Triggers
             _client = account.CreateBlobClient();
             _accountName = BlobClient.GetAccountName(_client);
             _path = path;
-            _hostId = hostId;
+            _hostIdProvider = hostIdProvider;
             _converter = CreateConverter(_client);
             _bindingDataContract = CreateBindingDataContract(path);
         }
@@ -132,7 +132,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Triggers
             ITriggeredFunctionInstanceFactory<IStorageBlob> instanceFactory =
                 new TriggeredFunctionInstanceFactory<IStorageBlob>(functionBinding, invoker, functionDescriptor);
             IStorageBlobContainer container = _client.GetContainerReference(_path.ContainerNamePattern);
-            IListenerFactory listenerFactory = new BlobListenerFactory(_hostId, functionDescriptor.Id, _account,
+            IListenerFactory listenerFactory = new BlobListenerFactory(_hostIdProvider, functionDescriptor.Id, _account,
                 container.SdkObject, _path, instanceFactory);
             return new FunctionDefinition(instanceFactory, listenerFactory);
         }


### PR DESCRIPTION
Fix circular host ID dependency indexing functions (#305).

PR notes:
Delay host ID calculation until after indexing is completed to prevent a circular dependency.
