### PR TITLE
Make file I/O actually async

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostContextFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostContextFactory.cs
@@ -270,8 +270,10 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
 
             const string filename = "WebJobsSdk.marker";
             var path = Path.Combine(jobDataPath, filename);
+            const int defaultBufferSize = 4096;
 
-            using (Stream stream = File.OpenWrite(path))
+            using (Stream stream = new FileStream(path, FileMode.OpenOrCreate, FileAccess.Write, FileShare.None,
+                defaultBufferSize, useAsync: true))
             using (TextWriter writer = new StreamWriter(stream))
             {
                 // content is not really important, this would help debugging though


### PR DESCRIPTION
Make file I/O actually async (#310).

PR notes:
I learned an important tidbit yesterday reading MSDN magazine - file streams don't actually work async unless you call a special constructor. By default, the async methods are just wrappers over the sync methods - yuck :(
