### PR TITLE
Allowed setting StorageConnectionString to null (fixes #305.

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Executors/IStorageAccountParser.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/IStorageAccountParser.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Azure.WebJobs.Host.Storage;
+
+namespace Microsoft.Azure.WebJobs.Host.Executors
+{
+    internal interface IStorageAccountParser
+    {
+        IStorageAccount ParseAccount(string connectionString, string connectionStringName);
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/StorageAccountParser.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/StorageAccountParser.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Globalization;
+using Microsoft.Azure.WebJobs.Host.Storage;
 using Microsoft.WindowsAzure.Storage;
 
 namespace Microsoft.Azure.WebJobs.Host.Executors
@@ -12,16 +13,16 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
     /// Utility class designed to parse given connection string and create instance of the 
     /// <see cref="CloudStorageAccount"/>.
     /// </summary>
-    internal sealed class StorageAccountParser
+    internal sealed class StorageAccountParser : IStorageAccountParser
     {
         /// <summary>
         /// Throwing version of parse account API. It calls TryParseAccount internally, analyzes returned result,
-        /// and throws an exception with formatted message in case of error
+        /// and throws an exception with formatted message in case of error.
         /// </summary>
         /// <param name="connectionString">A Storage account connection string as retrieved from the config</param>
         /// <param name="connectionStringName">Friendly connection string name used to format error message</param>
-        /// <returns>An instance of <see cref="CloudStorageAccount"/> associated with the given connection string</returns>
-        public static CloudStorageAccount ParseAccount(string connectionString, string connectionStringName)
+        /// <returns>An instance of <see cref="StorageAccount"/> associated with the given connection string</returns>
+        public IStorageAccount ParseAccount(string connectionString, string connectionStringName)
         {
             CloudStorageAccount account;
             StorageAccountParseResult result = TryParseAccount(connectionString, out account);
@@ -32,7 +33,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
                 throw new InvalidOperationException(message);
             }
 
-            return account;
+            return new StorageAccount(account);
         }
 
         /// <summary>

--- a/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
+++ b/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
@@ -397,6 +397,7 @@
     <Compile Include="Executors\DefaultHostIdProvider.cs" />
     <Compile Include="Executors\DefaultServiceBusAccountProvider.cs" />
     <Compile Include="Executors\IServiceBusAccountProvider.cs" />
+    <Compile Include="Executors\IStorageAccountParser.cs" />
     <Compile Include="Executors\StorageAccountProviderExtensions.cs" />
     <Compile Include="Indexers\ExtensionTypeLocator.cs" />
     <Compile Include="Indexers\FunctionIndexProvider.cs" />

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/DefaultStorageAccountProviderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/DefaultStorageAccountProviderTests.cs
@@ -1,0 +1,180 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Azure.WebJobs.Host.Storage;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Moq;
+using Xunit;
+using Xunit.Extensions;
+
+namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
+{
+    public class DefaultStorageAccountProviderTests
+    {
+        private readonly IConnectionStringProvider _connectionStringProvider = Mock.Of<IConnectionStringProvider>();
+        private readonly IStorageAccountParser _storageAccountParser = Mock.Of<IStorageAccountParser>();
+        private readonly IStorageCredentialsValidator _storageCredentialsValidator = Mock.Of<IStorageCredentialsValidator>();
+
+        [Theory]
+        [InlineData("Dashboard")]
+        [InlineData("Storage")]
+        public void GetAccountAsync_WhenReadFromConfig_ReturnsParsedAccount(string connectionStringName)
+        {
+            string connectionString = "valid-ignore";
+            IStorageAccount parsedAccount = Mock.Of<IStorageAccount>();
+            SetupConnectionStringProvider(connectionStringName, connectionString);
+            SetupStorageAccountParser(connectionStringName, connectionString, parsedAccount);
+            SetupStorageCredentialsValidator(parsedAccount);
+            IStorageAccountProvider provider = new DefaultStorageAccountProvider(_connectionStringProvider, 
+                _storageAccountParser, _storageCredentialsValidator);
+
+            IStorageAccount actualAccount = provider.GetAccountAsync(
+                connectionStringName, CancellationToken.None).GetAwaiter().GetResult();
+
+            Assert.Same(parsedAccount, actualAccount);
+            Mock.Get(_connectionStringProvider).Verify();
+            Mock.Get(_storageAccountParser).Verify();
+            Mock.Get(_storageCredentialsValidator).Verify();
+        }
+
+        [Theory]
+        [InlineData("Dashboard")]
+        [InlineData("Storage")]
+        public void GetAccountAsync_WhenInvalidConfig_PropagatesParserException(string connectionStringName)
+        {
+            string connectionString = "invalid-ignore";
+            Exception expectedException = new InvalidOperationException();
+            SetupConnectionStringProvider(connectionStringName, connectionString);
+            SetupStorageAccountParserFail(connectionStringName, connectionString, expectedException);
+            IStorageAccountProvider provider = new DefaultStorageAccountProvider(_connectionStringProvider,
+                _storageAccountParser, _storageCredentialsValidator);
+
+            Exception actualException = Assert.Throws<InvalidOperationException>(
+                () => provider.GetAccountAsync(connectionStringName, CancellationToken.None).GetAwaiter().GetResult());
+
+            Assert.Same(expectedException, actualException);
+        }
+
+        [Theory]
+        [InlineData("Dashboard")]
+        [InlineData("Storage")]
+        public void GetAccountAsync_WhenInvalidCredentials_PropagatesValidatorException(string connectionStringName)
+        {
+            string connectionString = "invalid-ignore";
+            IStorageAccount parsedAccount = Mock.Of<IStorageAccount>();
+            Exception expectedException = new InvalidOperationException();
+            SetupConnectionStringProvider(connectionStringName, connectionString);
+            SetupStorageAccountParser(connectionStringName, connectionString, parsedAccount);
+            SetupStorageCredentialsValidatorFail(parsedAccount, expectedException);
+            IStorageAccountProvider provider = new DefaultStorageAccountProvider(_connectionStringProvider,
+                _storageAccountParser, _storageCredentialsValidator);
+
+            Exception actualException = Assert.Throws<InvalidOperationException>(
+                () => provider.GetAccountAsync(connectionStringName, CancellationToken.None).GetAwaiter().GetResult());
+
+            Assert.Same(expectedException, actualException);
+        }
+
+        [Fact]
+        public void GetAccountAsync_WhenDashboardOverridden_ReturnsParsedAccount()
+        {
+            string connectionString = "valid-ignore";
+            IStorageAccount parsedAccount = Mock.Of<IStorageAccount>();
+            SetupStorageAccountParser(ConnectionStringNames.Dashboard, connectionString, parsedAccount);
+            SetupStorageCredentialsValidator(parsedAccount);
+            IStorageAccountProvider provider = new DefaultStorageAccountProvider(_connectionStringProvider,
+                _storageAccountParser, _storageCredentialsValidator) { DashboardConnectionString = connectionString };
+
+            IStorageAccount actualAccount = provider.GetAccountAsync(
+                ConnectionStringNames.Dashboard, CancellationToken.None).GetAwaiter().GetResult();
+
+            Assert.Same(parsedAccount, actualAccount);
+            Mock.Get(_storageAccountParser).Verify();
+            Mock.Get(_storageCredentialsValidator).Verify();
+        }
+
+        [Fact]
+        public void GetAccountAsync_WhenStorageOverridden_ReturnsParsedAccount()
+        {
+            string connectionString = "valid-ignore";
+            IStorageAccount parsedAccount = Mock.Of<IStorageAccount>();
+            SetupStorageAccountParser(ConnectionStringNames.Storage, connectionString, parsedAccount);
+            SetupStorageCredentialsValidator(parsedAccount);
+            IStorageAccountProvider provider = new DefaultStorageAccountProvider(_connectionStringProvider,
+                _storageAccountParser, _storageCredentialsValidator) { StorageConnectionString = connectionString };
+
+            IStorageAccount actualAccount = provider.GetAccountAsync(
+                ConnectionStringNames.Storage, CancellationToken.None).GetAwaiter().GetResult();
+
+            Assert.Same(parsedAccount, actualAccount);
+            Mock.Get(_storageAccountParser).Verify();
+            Mock.Get(_storageCredentialsValidator).Verify();
+        }
+
+        [Fact]
+        public void GetAccountAsync_WhenDashboardOverriddenWithNull_ReturnsNull()
+        {
+            IStorageAccountProvider provider = new DefaultStorageAccountProvider(_connectionStringProvider,
+                _storageAccountParser, _storageCredentialsValidator) { DashboardConnectionString = null };
+
+            IStorageAccount actualAccount = provider.GetAccountAsync(
+                ConnectionStringNames.Dashboard, CancellationToken.None).GetAwaiter().GetResult();
+
+            Assert.Null(actualAccount);
+        }
+
+        [Fact]
+        public void GetAccountAsync_WhenStorageOverriddenWithNull_Throws()
+        {
+            IStorageAccountProvider provider = new DefaultStorageAccountProvider(_connectionStringProvider,
+                _storageAccountParser, _storageCredentialsValidator) { StorageConnectionString = null };
+
+            ExceptionAssert.ThrowsInvalidOperation(() => provider.GetAccountAsync(
+                ConnectionStringNames.Storage, CancellationToken.None).GetAwaiter().GetResult(), 
+                @"Microsoft Azure WebJobs SDK Storage connection string is missing or empty. The Microsoft Azure Storage account connection string can be set in the following ways:" + 
+                Environment.NewLine +
+                @"1. Set the connection string named 'AzureWebJobsStorage' in the connectionStrings section of the .config file in the following format <add name=""AzureWebJobsStorage"" connectionString=""DefaultEndpointsProtocol=http|https;AccountName=NAME;AccountKey=KEY"" />, or" + 
+                Environment.NewLine +
+                @"2. Set the environment variable named 'AzureWebJobsStorage', or" + 
+                Environment.NewLine + 
+                @"3. Set corresponding property of JobHostConfiguration.");
+        }
+
+        private void SetupConnectionStringProvider(string connectionStringName, string connectionString)
+        {
+            Mock.Get(_connectionStringProvider).Setup(m => m.GetConnectionString(connectionStringName))
+                .Returns(connectionString)
+                .Verifiable("Must retrieve a connection string from the provider.");
+        }
+
+        private void SetupStorageAccountParser(string connectionStringName, string connectionString, IStorageAccount parsedAccount)
+        {
+            Mock.Get(_storageAccountParser).Setup(m => m.ParseAccount(connectionString, connectionStringName))
+                .Returns(parsedAccount)
+                .Verifiable("Must create parsed account via the parser.");
+        }
+
+        private void SetupStorageAccountParserFail(string connectionStringName, string connectionString, Exception exception)
+        {
+            Mock.Get(_storageAccountParser).Setup(m => m.ParseAccount(connectionString, connectionStringName))
+                .Throws(exception);
+        }
+
+        private void SetupStorageCredentialsValidator(IStorageAccount parsedAccount)
+        {
+            Mock.Get(_storageCredentialsValidator).Setup(m => m.ValidateCredentialsAsync(parsedAccount, It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(0))
+                .Verifiable("Must call the validator method to validate the parsed account");
+        }
+
+        private void SetupStorageCredentialsValidatorFail(IStorageAccount parsedAccount, Exception exception)
+        {
+            Mock.Get(_storageCredentialsValidator).Setup(m => m.ValidateCredentialsAsync(parsedAccount, It.IsAny<CancellationToken>()))
+                .Throws(exception);
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
@@ -116,6 +116,7 @@
     <Compile Include="Blobs\WatchableReadStreamTests.cs" />
     <Compile Include="ClassPropertyGetterTests.cs" />
     <Compile Include="EmptyFunctionIndexProvider.cs" />
+    <Compile Include="Executors\DefaultStorageAccountProviderTests.cs" />
     <Compile Include="Executors\DynamicHostIdProviderTests.cs" />
     <Compile Include="FunctionIndexerFactory.cs" />
     <Compile Include="NullExtensionTypeLocator.cs" />


### PR DESCRIPTION
Bypassing `ParseAccount` method when storage connection string is explicitly set to null.
