### PR TITLE
Fix non-SDK connection error

### DIFF
--- a/src/Dashboard/App_Start/AppModule.cs
+++ b/src/Dashboard/App_Start/AppModule.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Web;
 using System.Web.Caching;
 using System.Web.Mvc;
@@ -82,7 +83,7 @@ namespace Dashboard
 
             string connectionString = ConnectionStringProvider.GetConnectionString(
                 DashboardAccountContext.ConnectionStringName);
-            if (connectionString == null)
+            if (String.IsNullOrEmpty(connectionString))
             {
                 context.ConnectionStringState = ConnectionStringState.Missing;
                 return context;


### PR DESCRIPTION
Treat empty dashboard connection as missing (fixes #455).
