### PR TITLE
1.0.2-alpha

### DIFF
--- a/tools/NuGetProj.settings.targets
+++ b/tools/NuGetProj.settings.targets
@@ -5,6 +5,6 @@
     <WebJobsToolsPath>$(MSBuildThisFileDirectory)</WebJobsToolsPath>
     
     <WebJobsPackageEULA>http://www.microsoft.com/web/webpi/eula/aspnetcomponent_rtw_enu.htm</WebJobsPackageEULA>
-    <WebJobsPackageVersion>1.0.2</WebJobsPackageVersion>
+    <WebJobsPackageVersion>1.0.2-alpha</WebJobsPackageVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Mark packages as 1.0.2-alpha.

PR notes:
Supports taking a private package dependency that's version-distinct from (a potentially different later final) 1.0.2.
