### PR TITLE
Fixed broken cyclic dependency.

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Executors/DynamicHostIdProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/DynamicHostIdProvider.cs
@@ -19,23 +19,23 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
     internal class DynamicHostIdProvider : IHostIdProvider
     {
         private readonly IStorageAccountProvider _storageAccountProvider;
-        private readonly IFunctionIndexProvider _functionIndexProvider;
+        private readonly Func<IFunctionIndexProvider> _getFunctionIndexProvider;
 
         public DynamicHostIdProvider(IStorageAccountProvider storageAccountProvider,
-            IFunctionIndexProvider functionIndexProvider)
+            Func<IFunctionIndexProvider> getFunctionIndexProvider)
         {
             if (storageAccountProvider == null)
             {
                 throw new ArgumentNullException("storageAccountProvider");
             }
 
-            if (functionIndexProvider == null)
+            if (getFunctionIndexProvider == null)
             {
-                throw new ArgumentNullException("functionIndexProvider");
+                throw new ArgumentNullException("getFunctionIndexProvider");
             }
 
             _storageAccountProvider = storageAccountProvider;
-            _functionIndexProvider = functionIndexProvider;
+            _getFunctionIndexProvider = getFunctionIndexProvider;
         }
 
         public async Task<string> GetHostIdAsync(CancellationToken cancellationToken)
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
                     "connection string.", exception);
             }
 
-            IFunctionIndex index = await _functionIndexProvider.GetAsync(cancellationToken);
+            IFunctionIndex index = await _getFunctionIndexProvider.Invoke().GetAsync(cancellationToken);
             IEnumerable<MethodInfo> indexedMethods = index.ReadAllMethods();
 
             string sharedHostName = GetSharedHostName(indexedMethods, account);

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostContextFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostContextFactory.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
         {
             IFunctionIndexProvider functionIndexProvider = null;
             IHostIdProvider hostIdProvider = _hostId != null ? (IHostIdProvider)new FixedHostIdProvider(_hostId)
-                : new DynamicHostIdProvider(_storageAccountProvider, functionIndexProvider);
+                : new DynamicHostIdProvider(_storageAccountProvider, () => functionIndexProvider);
             IExtensionTypeLocator extensionTypeLocator = new ExtensionTypeLocator(_typeLocator);
             IBackgroundExceptionDispatcher backgroundExceptionDispatcher = BackgroundExceptionDispatcher.Instance;
             ContextAccessor<IMessageEnqueuedWatcher> messageEnqueuedWatcherAccessor =

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/DynamicHostIdProviderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/DynamicHostIdProviderTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             IStorageAccountProvider storageAccountProvider = storageAccountProviderMock.Object;
             IFunctionIndexProvider functionIndexProvider = CreateDummyFunctionIndexProvider();
 
-            IHostIdProvider product = new DynamicHostIdProvider(storageAccountProvider, functionIndexProvider);
+            IHostIdProvider product = new DynamicHostIdProvider(storageAccountProvider, () => functionIndexProvider);
             CancellationToken cancellationToken = CancellationToken.None;
 
             // Act & Assert


### PR DESCRIPTION
Replaced instance (which is null at the moment constructor is invoked) with a predicate retrieving the instance as it was before the David's last commit.
