### PR TITLE
Adding extensibility for Table bindings 

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Indexers/DefaultBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Indexers/DefaultBindingProvider.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
             List<IBindingProvider> innerProviders = new List<IBindingProvider>();
             innerProviders.Add(new QueueAttributeBindingProvider(nameResolver, storageAccountProvider, messageEnqueuedWatcherGetter));
             innerProviders.Add(new BlobAttributeBindingProvider(nameResolver, storageAccountProvider, extensionTypeLocator, blobWrittenWatcherGetter));
-            innerProviders.Add(new TableAttributeBindingProvider(nameResolver, storageAccountProvider));
+            innerProviders.Add(new TableAttributeBindingProvider(nameResolver, storageAccountProvider, extensions));
 
             // add any registered extension binding providers
             foreach (IBindingProvider provider in extensions.GetExtensions(typeof(IBindingProvider)))

--- a/src/Microsoft.Azure.WebJobs.Host/Tables/AsyncCollectorArgumentBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Tables/AsyncCollectorArgumentBindingProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Storage.Table;
@@ -12,15 +13,15 @@ namespace Microsoft.Azure.WebJobs.Host.Tables
 {
     internal class AsyncCollectorArgumentBindingProvider : ITableArgumentBindingProvider
     {
-        public ITableArgumentBinding TryCreate(Type parameterType)
+        public ITableArgumentBinding TryCreate(ParameterInfo parameter)
         {
-            if (!parameterType.IsGenericType ||
-                (parameterType.GetGenericTypeDefinition() != typeof(IAsyncCollector<>)))
+            if (!parameter.ParameterType.IsGenericType ||
+                (parameter.ParameterType.GetGenericTypeDefinition() != typeof(IAsyncCollector<>)))
             {
                 return null;
             }
 
-            Type entityType = GetCollectorItemType(parameterType);
+            Type entityType = GetCollectorItemType(parameter.ParameterType);
 
             if (!TableClient.ImplementsOrEqualsITableEntity(entityType))
             {

--- a/src/Microsoft.Azure.WebJobs.Host/Tables/CloudTableArgumentBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Tables/CloudTableArgumentBindingProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Storage.Table;
@@ -12,9 +13,9 @@ namespace Microsoft.Azure.WebJobs.Host.Tables
 {
     internal class CloudTableArgumentBindingProvider : ITableArgumentBindingProvider
     {
-        public ITableArgumentBinding TryCreate(Type parameterType)
+        public ITableArgumentBinding TryCreate(ParameterInfo parameter)
         {
-            if (parameterType != typeof(CloudTable))
+            if (parameter.ParameterType != typeof(CloudTable))
             {
                 return null;
             }

--- a/src/Microsoft.Azure.WebJobs.Host/Tables/CollectorArgumentBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Tables/CollectorArgumentBindingProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Storage.Table;
@@ -12,15 +13,15 @@ namespace Microsoft.Azure.WebJobs.Host.Tables
 {
     internal class CollectorArgumentBindingProvider : ITableArgumentBindingProvider
     {
-        public ITableArgumentBinding TryCreate(Type parameterType)
+        public ITableArgumentBinding TryCreate(ParameterInfo parameter)
         {
-            if (!parameterType.IsGenericType ||
-                (parameterType.GetGenericTypeDefinition() != typeof(ICollector<>)))
+            if (!parameter.ParameterType.IsGenericType ||
+                (parameter.ParameterType.GetGenericTypeDefinition() != typeof(ICollector<>)))
             {
                 return null;
             }
 
-            Type entityType = GetCollectorItemType(parameterType);
+            Type entityType = GetCollectorItemType(parameter.ParameterType);
 
             if (!TableClient.ImplementsOrEqualsITableEntity(entityType))
             {

--- a/src/Microsoft.Azure.WebJobs.Host/Tables/CompositeArgumentBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Tables/CompositeArgumentBindingProvider.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using Microsoft.Azure.WebJobs.Host.Bindings;
-using Microsoft.WindowsAzure.Storage.Table;
+using System.Reflection;
 
 namespace Microsoft.Azure.WebJobs.Host.Tables
 {
@@ -17,11 +15,11 @@ namespace Microsoft.Azure.WebJobs.Host.Tables
             _providers = providers;
         }
 
-        public ITableArgumentBinding TryCreate(Type parameterType)
+        public ITableArgumentBinding TryCreate(ParameterInfo parameter)
         {
             foreach (ITableArgumentBindingProvider provider in _providers)
             {
-                ITableArgumentBinding binding = provider.TryCreate(parameterType);
+                ITableArgumentBinding binding = provider.TryCreate(parameter);
 
                 if (binding != null)
                 {

--- a/src/Microsoft.Azure.WebJobs.Host/Tables/CompositeEntityArgumentBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Tables/CompositeEntityArgumentBindingProvider.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
+using System.Reflection;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 
 namespace Microsoft.Azure.WebJobs.Host.Tables
@@ -16,11 +16,11 @@ namespace Microsoft.Azure.WebJobs.Host.Tables
             _providers = providers;
         }
 
-        public IArgumentBinding<TableEntityContext> TryCreate(Type parameterType)
+        public IArgumentBinding<TableEntityContext> TryCreate(ParameterInfo parameter)
         {
             foreach (ITableEntityArgumentBindingProvider provider in _providers)
             {
-                IArgumentBinding<TableEntityContext> binding = provider.TryCreate(parameterType);
+                IArgumentBinding<TableEntityContext> binding = provider.TryCreate(parameter);
 
                 if (binding != null)
                 {

--- a/src/Microsoft.Azure.WebJobs.Host/Tables/ITableArgumentBindingExtension.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Tables/ITableArgumentBindingExtension.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.WindowsAzure.Storage.Table;
+
+namespace Microsoft.Azure.WebJobs.Host.Tables
+{
+    /// <summary>
+    /// Defines an interface for Table argument binding extensions.
+    /// </summary>
+    [CLSCompliant(false)]
+    public interface ITableArgumentBindingExtension : IArgumentBinding<CloudTable>
+    {
+        /// <summary>
+        /// Gets the <see cref="FileAccess"/> value indicating what types of storage
+        /// operations this binding supports.
+        /// </summary>
+        FileAccess Access { get; }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Tables/ITableArgumentBindingExtensionProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Tables/ITableArgumentBindingExtensionProvider.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+
+namespace Microsoft.Azure.WebJobs.Host.Tables
+{
+    /// <summary>
+    /// Defines an interface for providing binding extensions for Table bindings.
+    /// Extensions can be registered using the <see cref="IExtensionRegistry"/> service
+    /// from the <see cref="JobHostConfiguration"/>.
+    /// </summary>
+    [CLSCompliant(false)]
+    public interface ITableArgumentBindingExtensionProvider
+    {
+        /// <summary>
+        /// Attempts to create a <see cref="ITableArgumentBindingExtension"/> for the specified parameter type.
+        /// </summary>
+        /// <param name="parameter">The parameter to attempt to bind to.</param>
+        /// <returns>A <see cref="ITableArgumentBindingExtension"/> if the bind was successful, otherwise null.</returns>
+        ITableArgumentBindingExtension TryCreate(ParameterInfo parameter);
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Tables/ITableArgumentBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Tables/ITableArgumentBindingProvider.cs
@@ -1,14 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-using Microsoft.Azure.WebJobs.Host.Bindings;
-using Microsoft.WindowsAzure.Storage.Table;
+using System.Reflection;
 
 namespace Microsoft.Azure.WebJobs.Host.Tables
 {
     internal interface ITableArgumentBindingProvider
     {
-        ITableArgumentBinding TryCreate(Type parameterType);
+        ITableArgumentBinding TryCreate(ParameterInfo parameter);
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Tables/ITableEntityArgumentBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Tables/ITableEntityArgumentBindingProvider.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
+using System.Reflection;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 
 namespace Microsoft.Azure.WebJobs.Host.Tables
 {
     internal interface ITableEntityArgumentBindingProvider
     {
-        IArgumentBinding<TableEntityContext> TryCreate(Type parameterType);
+        IArgumentBinding<TableEntityContext> TryCreate(ParameterInfo parameter);
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Tables/PocoEntityArgumentBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Tables/PocoEntityArgumentBindingProvider.cs
@@ -2,27 +2,28 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Reflection;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 
 namespace Microsoft.Azure.WebJobs.Host.Tables
 {
     internal class PocoEntityArgumentBindingProvider : ITableEntityArgumentBindingProvider
     {
-        public IArgumentBinding<TableEntityContext> TryCreate(Type parameterType)
+        public IArgumentBinding<TableEntityContext> TryCreate(ParameterInfo parameter)
         {
-            if (parameterType.IsByRef)
+            if (parameter.ParameterType.IsByRef)
             {
                 return null;
             }
 
-            if (parameterType.ContainsGenericParameters)
+            if (parameter.ParameterType.ContainsGenericParameters)
             {
                 return null;
             }
 
-            TableClient.VerifyDefaultConstructor(parameterType);
+            TableClient.VerifyDefaultConstructor(parameter.ParameterType);
 
-            return CreateBinding(parameterType);
+            return CreateBinding(parameter.ParameterType);
         }
 
         private static IArgumentBinding<TableEntityContext> CreateBinding(Type entityType)

--- a/src/Microsoft.Azure.WebJobs.Host/Tables/QueryableArgumentBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Tables/QueryableArgumentBindingProvider.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Storage.Table;
@@ -13,14 +14,14 @@ namespace Microsoft.Azure.WebJobs.Host.Tables
 {
     internal class QueryableArgumentBindingProvider : ITableArgumentBindingProvider
     {
-        public ITableArgumentBinding TryCreate(Type parameterType)
+        public ITableArgumentBinding TryCreate(ParameterInfo parameter)
         {
-            if (!parameterType.IsGenericType || parameterType.GetGenericTypeDefinition() != typeof(IQueryable<>))
+            if (!parameter.ParameterType.IsGenericType || parameter.ParameterType.GetGenericTypeDefinition() != typeof(IQueryable<>))
             {
                 return null;
             }
 
-            Type entityType = GetQueryableItemType(parameterType);
+            Type entityType = GetQueryableItemType(parameter.ParameterType);
 
             if (!TableClient.ImplementsITableEntity(entityType))
             {

--- a/src/Microsoft.Azure.WebJobs.Host/Tables/StorageTableArgumentBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Tables/StorageTableArgumentBindingProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Storage.Table;
@@ -11,9 +12,9 @@ namespace Microsoft.Azure.WebJobs.Host.Tables
 {
     internal class StorageTableArgumentBindingProvider : ITableArgumentBindingProvider
     {
-        public ITableArgumentBinding TryCreate(Type parameterType)
+        public ITableArgumentBinding TryCreate(ParameterInfo parameter)
         {
-            if (parameterType != typeof(IStorageTable))
+            if (parameter.ParameterType != typeof(IStorageTable))
             {
                 return null;
             }

--- a/src/Microsoft.Azure.WebJobs.Host/Tables/TableArgumentBindingExtensionProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Tables/TableArgumentBindingExtensionProvider.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Azure.WebJobs.Host.Storage.Table;
+using Microsoft.WindowsAzure.Storage.Table;
+
+namespace Microsoft.Azure.WebJobs.Host.Tables
+{
+    /// <summary>
+    /// This binding provider loads any <see cref="ITableArgumentBindingExtensionProvider"/> instances
+    /// registered with the <see cref="IExtensionRegistry"/>. When it binds, it delegates to those
+    /// providers.
+    /// </summary>
+    internal class TableArgumentBindingExtensionProvider : ITableArgumentBindingProvider
+    {
+        private IEnumerable<ITableArgumentBindingExtensionProvider> _bindingExtensionsProviders;
+
+        public TableArgumentBindingExtensionProvider(IExtensionRegistry extensions)
+        {
+            _bindingExtensionsProviders = extensions.GetExtensions<ITableArgumentBindingExtensionProvider>();
+        }
+
+        public ITableArgumentBinding TryCreate(ParameterInfo parameter)
+        {
+            // see if there are any registered binding extension providers that can
+            // bind to this parameter type
+            foreach (ITableArgumentBindingExtensionProvider provider in _bindingExtensionsProviders)
+            {
+                ITableArgumentBindingExtension bindingExtension = provider.TryCreate(parameter);
+                if (bindingExtension != null)
+                {
+                    // if an extension is able to bind, wrap the binding
+                    return new TableArgumentBindingExtension(bindingExtension);
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// This binding wraps the actual extension binding and delegates to it.
+        /// It exists solely to convert from our internal IStorageTable type
+        /// to CloudTable.
+        /// </summary>
+        internal class TableArgumentBindingExtension : ITableArgumentBinding
+        {
+            private ITableArgumentBindingExtension _bindingExtension;
+
+            public TableArgumentBindingExtension(ITableArgumentBindingExtension bindingExtension)
+            {
+                _bindingExtension = bindingExtension;
+            }
+
+            public FileAccess Access
+            {
+                get { return _bindingExtension.Access; }
+            }
+
+            public Type ValueType
+            {
+                get { return _bindingExtension.ValueType; }
+            }
+
+            public Task<IValueProvider> BindAsync(IStorageTable value, ValueBindingContext context)
+            {
+                CloudTable table = null;
+                if (value != null)
+                {
+                    table = value.SdkObject;
+                }
+                return _bindingExtension.BindAsync(table, context);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Tables/TableBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Tables/TableBinding.cs
@@ -21,8 +21,7 @@ namespace Microsoft.Azure.WebJobs.Host.Tables
         private readonly IBindableTablePath _path;
         private readonly IObjectToTypeConverter<IStorageTable> _converter;
 
-        public TableBinding(string parameterName, ITableArgumentBinding argumentBinding, IStorageTableClient client,
-            IBindableTablePath path)
+        public TableBinding(string parameterName, ITableArgumentBinding argumentBinding, IStorageTableClient client, IBindableTablePath path)
         {
             _parameterName = parameterName;
             _argumentBinding = argumentBinding;
@@ -50,8 +49,7 @@ namespace Microsoft.Azure.WebJobs.Host.Tables
             }
         }
 
-        private static IObjectToTypeConverter<IStorageTable> CreateConverter(IStorageTableClient client,
-            IBindableTablePath path)
+        private static IObjectToTypeConverter<IStorageTable> CreateConverter(IStorageTableClient client, IBindableTablePath path)
         {
             return new CompositeObjectToTypeConverter<IStorageTable>(
                 new OutputConverter<IStorageTable>(new IdentityConverter<IStorageTable>()),

--- a/src/Microsoft.Azure.WebJobs.Host/Tables/TableEntityArgumentBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Tables/TableEntityArgumentBindingProvider.cs
@@ -2,27 +2,28 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Reflection;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 
 namespace Microsoft.Azure.WebJobs.Host.Tables
 {
     internal class TableEntityArgumentBindingProvider : ITableEntityArgumentBindingProvider
     {
-        public IArgumentBinding<TableEntityContext> TryCreate(Type parameterType)
+        public IArgumentBinding<TableEntityContext> TryCreate(ParameterInfo parameter)
         {
-            if (parameterType.ContainsGenericParameters)
+            if (parameter.ParameterType.ContainsGenericParameters)
             {
                 return null;
             }
 
-            if (!TableClient.ImplementsITableEntity(parameterType))
+            if (!TableClient.ImplementsITableEntity(parameter.ParameterType))
             {
                 return null;
             }
 
-            TableClient.VerifyDefaultConstructor(parameterType);
+            TableClient.VerifyDefaultConstructor(parameter.ParameterType);
 
-            return CreateBinding(parameterType);
+            return CreateBinding(parameter.ParameterType);
         }
 
         private static IArgumentBinding<TableEntityContext> CreateBinding(Type entityType)

--- a/src/Microsoft.Azure.WebJobs.Host/Tables/TableEntityBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Tables/TableEntityBinding.cs
@@ -50,8 +50,7 @@ namespace Microsoft.Azure.WebJobs.Host.Tables
             get { return _path.RowKeyPattern; }
         }
 
-        private static IObjectToTypeConverter<TableEntityContext> CreateConverter(IStorageTableClient client,
-            IBindableTableEntityPath path)
+        private static IObjectToTypeConverter<TableEntityContext> CreateConverter(IStorageTableClient client, IBindableTableEntityPath path)
         {
             return new CompositeObjectToTypeConverter<TableEntityContext>(
                 new EntityOutputConverter<TableEntityContext>(new IdentityConverter<TableEntityContext>()),

--- a/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
+++ b/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
@@ -595,6 +595,9 @@
     <Compile Include="Queues\Triggers\StorageQueueMessageToCloudQueueMessageConverter.cs" />
     <Compile Include="Queues\Triggers\CloudQueueMessageToStorageQueueMessageConverter.cs" />
     <Compile Include="Tables\AsyncCollectorArgumentBindingProvider.cs" />
+    <Compile Include="Tables\TableArgumentBindingExtensionProvider.cs" />
+    <Compile Include="Tables\ITableArgumentBindingExtension.cs" />
+    <Compile Include="Tables\ITableArgumentBindingExtensionProvider.cs" />
     <Compile Include="Tables\StorageTableArgumentBindingProvider.cs" />
     <Compile Include="Tables\ConverterPropertyGetter.cs" />
     <Compile Include="Tables\ConverterPropertySetter.cs" />
@@ -646,6 +649,7 @@
     <Compile Include="Tables\PocoEntityWriter.cs" />
     <Compile Include="Tables\PocoToTableEntityConverter.cs" />
     <Compile Include="Tables\PropertyInfoExtensions.cs" />
+    <Compile Include="Tables\TableEntityArgumentBindingProvider.cs" />
     <Compile Include="Tables\TableEntityCollectorBinder.cs" />
     <Compile Include="Tables\TableEntityToPocoConverter.cs" />
     <Compile Include="Tables\TableEntityValueBinder.cs" />
@@ -809,7 +813,6 @@
     <Compile Include="Tables\PocoEntityArgumentBindingProvider.cs" />
     <Compile Include="Tables\TableEntityBinding.cs" />
     <Compile Include="Tables\TableBinding.cs" />
-    <Compile Include="Tables\TableEntityArgumentBindingProvider.cs" />
     <Compile Include="Tables\QueryableArgumentBindingProvider.cs" />
     <Compile Include="Tables\CloudTableArgumentBindingProvider.cs" />
     <Compile Include="Tables\CompositeEntityArgumentBindingProvider.cs" />

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
@@ -130,7 +130,9 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 "IQueueProcessorFactory",
                 "QueueProcessorFactoryContext",
                 "QueueProcessor",
-                "FunctionResult"
+                "FunctionResult",
+                "ITableArgumentBindingExtensionProvider",
+                "ITableArgumentBindingExtension"
             };
 
             AssertPublicTypes(expected, assembly);

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Tables/PocoEntityArgumentBindingProviderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Tables/PocoEntityArgumentBindingProviderTests.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
+using System.Reflection;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Tables;
 using Xunit;
@@ -11,6 +11,13 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Tables
 {
     public class PocoEntityArgumentBindingProviderTests
     {
+        private ParameterInfo[] _parameters;
+
+        public PocoEntityArgumentBindingProviderTests()
+        {
+            _parameters = this.GetType().GetMethod("Parameters", BindingFlags.NonPublic | BindingFlags.Static).GetParameters();
+        }
+
         [Fact]
         public void Create_ReturnsNull_IfByRefParameter()
         {
@@ -20,22 +27,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Tables
             Type parameterType = typeof(SimpleTableEntity).MakeByRefType();
 
             // Act
-            IArgumentBinding<TableEntityContext> binding = product.TryCreate(parameterType);
-
-            // Assert
-            Assert.Null(binding);
-        }
-
-        [Fact]
-        public void Create_ReturnsNull_IfContainsUnresolvedGenericParameter()
-        {
-            // Arrange
-            ITableEntityArgumentBindingProvider product = new PocoEntityArgumentBindingProvider();
-
-            Type parameterType = typeof(GenericClass<>);
-
-            // Act
-            IArgumentBinding<TableEntityContext> binding = product.TryCreate(parameterType);
+            IArgumentBinding<TableEntityContext> binding = product.TryCreate(_parameters[0]);
 
             // Assert
             Assert.Null(binding);
@@ -50,11 +42,13 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Tables
             Type parameterType = typeof(GenericClass<SimpleTableEntity>);
             
             // Act
-            IArgumentBinding<TableEntityContext> binding = product.TryCreate(parameterType);
+            IArgumentBinding<TableEntityContext> binding = product.TryCreate(_parameters[1]);
 
             // Assert
             Assert.NotNull(binding);
         }
+
+        private static void Parameters(ref SimpleTableEntity byRef, GenericClass<SimpleTableEntity> generic) { }
 
         private class SimpleTableEntity
         {

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Tables/TableArgumentBindingExtensionProviderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Tables/TableArgumentBindingExtensionProviderTests.cs
@@ -1,0 +1,185 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Azure.WebJobs.Host.Storage.Table;
+using Microsoft.Azure.WebJobs.Host.Tables;
+using Microsoft.WindowsAzure.Storage.Table;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Host.UnitTests.Tables
+{
+    public class TableArgumentBindingExtensionProviderTests
+    {
+        private static CloudTable BoundTable = null;
+
+        private ParameterInfo[] _parameters;
+
+        public TableArgumentBindingExtensionProviderTests()
+        {
+            _parameters = this.GetType().GetMethod("Parameters", BindingFlags.NonPublic | BindingFlags.Static).GetParameters();
+        }
+
+        [Fact]
+        public void TryCreate_DelegatesToExtensions()
+        {
+            DefaultExtensionRegistry extensions = new DefaultExtensionRegistry();
+            TableArgumentBindingExtensionProvider provider = new TableArgumentBindingExtensionProvider(extensions);
+
+            // before binding extensions are registered for these types,
+            // the provider returns null
+            
+            Assert.Null(provider.TryCreate(_parameters[0]));
+            Assert.Null(provider.TryCreate(_parameters[1]));
+            Assert.Null(provider.TryCreate(_parameters[2]));
+
+            // register the binding extensions
+            FooBarTableArgumentBindingExtensionProvider fooBarExtensionProvider = new FooBarTableArgumentBindingExtensionProvider();
+            BazTableArgumentBindingExtensionProvider bazExtensionProvider = new BazTableArgumentBindingExtensionProvider();
+            extensions.RegisterExtension<ITableArgumentBindingExtensionProvider>(fooBarExtensionProvider);
+            extensions.RegisterExtension<ITableArgumentBindingExtensionProvider>(bazExtensionProvider);
+            provider = new TableArgumentBindingExtensionProvider(extensions);
+
+            ITableArgumentBinding binding = provider.TryCreate(_parameters[0]);
+            Assert.Same(typeof(IFoo), binding.ValueType);
+
+            binding = provider.TryCreate(_parameters[1]);
+            Assert.Same(typeof(IBar), binding.ValueType);
+
+            binding = provider.TryCreate(_parameters[2]);
+            Assert.Same(typeof(IBaz), binding.ValueType);
+        }
+
+        [Fact]
+        public async Task TryCreate_ReturnsTableArgumentBindingExtensionWrapper()
+        {
+            DefaultExtensionRegistry extensions = new DefaultExtensionRegistry();
+            FooBarTableArgumentBindingExtensionProvider fooBarExtensionProvider = new FooBarTableArgumentBindingExtensionProvider();
+            extensions.RegisterExtension<ITableArgumentBindingExtensionProvider>(fooBarExtensionProvider);
+
+            TableArgumentBindingExtensionProvider provider = new TableArgumentBindingExtensionProvider(extensions);
+
+            ITableArgumentBinding binding = provider.TryCreate(_parameters[0]);
+            Assert.Equal(typeof(TableArgumentBindingExtensionProvider.TableArgumentBindingExtension), binding.GetType());
+
+            Assert.Null(BoundTable);
+            CloudTable table = new CloudTable(new Uri("http://localhost:10000/test/table"));
+            IStorageTable storageTable = new StorageTable(table);
+            FunctionBindingContext functionContext = new FunctionBindingContext(Guid.NewGuid(), CancellationToken.None, new StringWriter());
+            ValueBindingContext context = new ValueBindingContext(functionContext, CancellationToken.None);
+            IValueProvider valueProvider = await binding.BindAsync(storageTable, context);
+            Assert.NotNull(valueProvider);
+            Assert.Same(table, BoundTable);
+        }
+
+        private static void Parameters(IFoo foo, IBar bar, IBaz baz) { }
+
+        private interface IFoo
+        {
+        }
+
+        private interface IBar
+        {
+        }
+
+        private interface IBaz
+        {
+        }
+
+        private class FooBarTableArgumentBindingExtensionProvider : ITableArgumentBindingExtensionProvider
+        {
+            public ITableArgumentBindingExtension TryCreate(ParameterInfo parameter)
+            {
+                if (parameter.ParameterType == typeof(IFoo) ||
+                    parameter.ParameterType == typeof(IBar))
+                {
+                    return new FooBarTableArgumentBinding(parameter.ParameterType);
+                }
+
+                return null;
+            }
+
+            internal class FooBarTableArgumentBinding : ITableArgumentBindingExtension
+            {
+                private Type _valueType;
+
+                public FooBarTableArgumentBinding(Type valueType)
+                {
+                    _valueType = valueType;
+                }
+
+                public FileAccess Access
+                {
+                    get { return FileAccess.ReadWrite; }
+                }
+
+                public Type ValueType
+                {
+                    get { return _valueType; }
+                }
+
+                public static object BindValue { get; set; }
+
+                public Task<IValueProvider> BindAsync(CloudTable value, ValueBindingContext context)
+                {
+                    BoundTable = value;
+                    return Task.FromResult<IValueProvider>(new FooBarValueProvider());
+                }
+            }
+
+            internal class FooBarValueProvider : IValueProvider
+            {
+                public Type Type
+                {
+                    get { throw new NotImplementedException(); }
+                }
+
+                public object GetValue()
+                {
+                    throw new NotImplementedException();
+                }
+
+                public string ToInvokeString()
+                {
+                    throw new NotImplementedException();
+                }
+            }
+        }
+
+        private class BazTableArgumentBindingExtensionProvider : ITableArgumentBindingExtensionProvider
+        {
+            public ITableArgumentBindingExtension TryCreate(ParameterInfo parameter)
+            {
+                if (parameter.ParameterType == typeof(IBaz))
+                {
+                    return new BazTableArgumentBinding();
+                }
+
+                return null;
+            }
+
+            internal class BazTableArgumentBinding : ITableArgumentBindingExtension
+            {
+                public FileAccess Access
+                {
+                    get { return FileAccess.ReadWrite; }
+                }
+
+                public Type ValueType
+                {
+                    get { return typeof(IBaz); }
+                }
+
+                public Task<IValueProvider> BindAsync(CloudTable value, ValueBindingContext context)
+                {
+                    throw new NotImplementedException();
+                }
+            }
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Tables/TableEntityArgumentBindingProviderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Tables/TableEntityArgumentBindingProviderTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Reflection;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Tables;
 using Microsoft.WindowsAzure.Storage.Table;
@@ -11,6 +12,13 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Tables
 {
     public class TableEntityArgumentBindingProviderTests
     {
+        private ParameterInfo[] _parameters;
+
+        public TableEntityArgumentBindingProviderTests()
+        {
+            _parameters = this.GetType().GetMethod("Parameters", BindingFlags.NonPublic | BindingFlags.Static).GetParameters();
+        }
+
         [Fact]
         public void Create_ReturnsNull_IfByRefParameter()
         {
@@ -20,22 +28,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Tables
             Type parameterType = typeof(SimpleTableEntity).MakeByRefType();
 
             // Act
-            IArgumentBinding<TableEntityContext> binding = product.TryCreate(parameterType);
-
-            // Assert
-            Assert.Null(binding);
-        }
-
-        [Fact]
-        public void Create_ReturnsNull_IfContainsUnresolvedGenericParameter()
-        {
-            // Arrange
-            ITableEntityArgumentBindingProvider product = new TableEntityArgumentBindingProvider();
-
-            Type parameterType = typeof(GenericClass<>);
-
-            // Act
-            IArgumentBinding<TableEntityContext> binding = product.TryCreate(parameterType);
+            IArgumentBinding<TableEntityContext> binding = product.TryCreate(_parameters[0]);
 
             // Assert
             Assert.Null(binding);
@@ -50,11 +43,13 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Tables
             Type parameterType = typeof(GenericClass<int>);
 
             // Act
-            IArgumentBinding<TableEntityContext> binding = product.TryCreate(parameterType);
+            IArgumentBinding<TableEntityContext> binding = product.TryCreate(_parameters[1]);
 
             // Assert
             Assert.NotNull(binding);
         }
+
+        private static void Parameters(ref SimpleTableEntity byRef, GenericClass<int> generic) {}
 
         private class SimpleTableEntity : TableEntity
         {

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
@@ -160,6 +160,7 @@
     <Compile Include="PropertyAccessorFactoryTests.cs" />
     <Compile Include="Tables\PocoEntityArgumentBindingProviderTests.cs" />
     <Compile Include="Tables\PocoEntityCollectorBinderTests.cs" />
+    <Compile Include="Tables\TableArgumentBindingExtensionProviderTests.cs" />
     <Compile Include="Tables\TableEntityCollectorBinderTests.cs" />
     <Compile Include="Tables\PocoToTableEntityConverterTests.cs" />
     <Compile Include="Tables\TableEntityToPocoConverterTests.cs" />


### PR DESCRIPTION
These changes allow users (or extension authors) to create their own custom Table bindings (e.g. a Table to IDictionary binding). This addresses the scenario discussed in #517. The way it works is, you author a ITableArgumentBindingExtensionProvider and register it with the JobHostConfiguration. We'll then pick up any extension bindings when binding functions.

```
JobHostConfiguration config = new JobHostConfiguration();
IExtensionRegistry extensions = config.GetService<IExtensionRegistry>();
extensions.RegisterExtension<ITableArgumentBindingExtensionProvider>(new MyTableArgumentBindingProvider());
```