### PR TITLE
Adding AccessRight declaration to ServiceBus binding Attributes

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Listeners/ListenerFactoryContext.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Listeners/ListenerFactoryContext.cs
@@ -12,7 +12,11 @@ namespace Microsoft.Azure.WebJobs.Host.Listeners
     {
         private readonly CancellationToken _cancellationToken;
 
-        internal ListenerFactoryContext(CancellationToken cancellationToken)
+        /// <summary>
+        /// Constructs a new instance.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
+        public ListenerFactoryContext(CancellationToken cancellationToken)
         {
             _cancellationToken = cancellationToken;
         }

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/MessageSenderExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/MessageSenderExtensions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Bindings
     internal static class MessageSenderExtensions
     {
         public static async Task SendAndCreateQueueIfNotExistsAsync(this MessageSender sender, BrokeredMessage message,
-            Guid functionInstanceId, NamespaceManager namespaceManager, CancellationToken cancellationToken)
+            Guid functionInstanceId, NamespaceManager namespaceManager, AccessRights accessRights, CancellationToken cancellationToken)
         {
             if (sender == null)
             {
@@ -37,6 +37,13 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Bindings
             }
             catch (MessagingEntityNotFoundException)
             {
+                if (accessRights != AccessRights.Manage)
+                {
+                    // if we don't have the required rights to create the queue,
+                    // rethrow the exception
+                    throw;
+                }
+
                 threwMessgingEntityNotFoundException = true;
             }
 

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/ServiceBusAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/ServiceBusAttributeBindingProvider.cs
@@ -48,14 +48,14 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Bindings
             }
 
             ParameterInfo parameter = context.Parameter;
-            ServiceBusAttribute serviceBusAttribute = parameter.GetCustomAttribute<ServiceBusAttribute>(inherit: false);
+            ServiceBusAttribute attribute = parameter.GetCustomAttribute<ServiceBusAttribute>(inherit: false);
 
-            if (serviceBusAttribute == null)
+            if (attribute == null)
             {
                 return Task.FromResult<IBinding>(null);
             }
 
-            string queueOrTopicName = Resolve(serviceBusAttribute.QueueOrTopicName);
+            string queueOrTopicName = Resolve(attribute.QueueOrTopicName);
             IBindableServiceBusPath path = BindableServiceBusPath.Create(queueOrTopicName);
             ValidateContractCompatibility(path, context.BindingDataContract);
 
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Bindings
 
             ServiceBusAccount account = ServiceBusAccount.CreateFromConnectionString(_config.ConnectionString);
 
-            IBinding binding = new ServiceBusBinding(parameter.Name, argumentBinding, account, path);
+            IBinding binding = new ServiceBusBinding(parameter.Name, argumentBinding, account, path, attribute.Access);
             return Task.FromResult(binding);
         }
 

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/ServiceBusEntity.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/ServiceBusEntity.cs
@@ -14,11 +14,12 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Bindings
 
         public MessageSender MessageSender { get; set; }
 
-        public Task SendAndCreateQueueIfNotExistsAsync(BrokeredMessage message, Guid functionInstanceId,
-            CancellationToken cancellationToken)
+        public AccessRights AccessRights { get; set; }
+
+        public Task SendAndCreateQueueIfNotExistsAsync(BrokeredMessage message, Guid functionInstanceId, CancellationToken cancellationToken)
         {
             return MessageSender.SendAndCreateQueueIfNotExistsAsync(message, functionInstanceId,
-                Account.NamespaceManager, cancellationToken);
+                Account.NamespaceManager, AccessRights, cancellationToken);
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/StringToServiceBusEntityConverter.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/StringToServiceBusEntityConverter.cs
@@ -13,11 +13,13 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Bindings
     {
         private readonly ServiceBusAccount _account;
         private readonly IBindableServiceBusPath _defaultPath;
+        private readonly AccessRights _accessRights;
 
-        public StringToServiceBusEntityConverter(ServiceBusAccount account, IBindableServiceBusPath defaultPath)
+        public StringToServiceBusEntityConverter(ServiceBusAccount account, IBindableServiceBusPath defaultPath, AccessRights accessRights)
         {
             _account = account;
             _defaultPath = defaultPath;
+            _accessRights = accessRights;
         }
 
         public async Task<ServiceBusEntity> ConvertAsync(string input, CancellationToken cancellationToken)
@@ -40,7 +42,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Bindings
             return new ServiceBusEntity
             {
                 Account = _account,
-                MessageSender = messageSender
+                MessageSender = messageSender,
+                AccessRights = _accessRights
             };
         }
     }

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Listeners/NamespaceManagerExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Listeners/NamespaceManagerExtensions.cs
@@ -13,8 +13,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
     {
         private const string DeadLetterQueueSuffix = "$DeadLetterQueue";
 
-        public static async Task CreateQueueIfNotExistsAsync(this NamespaceManager manager, string path,
-            CancellationToken cancellationToken)
+        public static async Task CreateQueueIfNotExistsAsync(this NamespaceManager manager, string path, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -57,8 +56,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
             return new string[] { path };
         }
 
-        public static async Task CreateTopicIfNotExistsAsync(this NamespaceManager manager, string path,
-            CancellationToken cancellationToken)
+        public static async Task CreateTopicIfNotExistsAsync(this NamespaceManager manager, string path, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/ServiceBusAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/ServiceBusAttribute.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
+using Microsoft.ServiceBus.Messaging;
 
 namespace Microsoft.Azure.WebJobs
 {
@@ -25,19 +25,25 @@ namespace Microsoft.Azure.WebJobs
     [DebuggerDisplay("{QueueOrTopicName,nq}")]
     public sealed class ServiceBusAttribute : Attribute
     {
-        private readonly string _queueOrTopicName;
-
-        /// <summary>Initializes a new instance of the <see cref="ServiceBusAttribute"/> class.</summary>
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ServiceBusAttribute"/> class.
+        /// </summary>
         /// <param name="queueOrTopicName">The name of the queue or topic to which to bind.</param>
         public ServiceBusAttribute(string queueOrTopicName)
         {
-            _queueOrTopicName = queueOrTopicName;
+            QueueOrTopicName = queueOrTopicName;
+            Access = AccessRights.Manage;
         }
 
-        /// <summary>Gets the name of the queue or topic to which to bind.</summary>
-        public string QueueOrTopicName
-        {
-            get { return _queueOrTopicName; }
-        }
+        /// <summary>
+        /// Gets the name of the queue or topic to bind to.
+        /// </summary>
+        public string QueueOrTopicName { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="AccessRights"/> the client has to the queue or topic.
+        /// The default is "Manage".
+        /// </summary>
+        public AccessRights Access { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/ServiceBusTriggerAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/ServiceBusTriggerAttribute.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using Microsoft.ServiceBus.Messaging;
 
 namespace Microsoft.Azure.WebJobs
 {
@@ -32,6 +33,7 @@ namespace Microsoft.Azure.WebJobs
         public ServiceBusTriggerAttribute(string queueName)
         {
             _queueName = queueName;
+            Access = AccessRights.Manage;
         }
 
         /// <summary>Initializes a new instance of the <see cref="ServiceBusTriggerAttribute"/> class.</summary>
@@ -41,6 +43,7 @@ namespace Microsoft.Azure.WebJobs
         {
             _topicName = topicName;
             _subscriptionName = subscriptionName;
+            Access = AccessRights.Manage;
         }
 
         /// <summary>Gets the name of the queue to which to bind.</summary>
@@ -63,6 +66,12 @@ namespace Microsoft.Azure.WebJobs
         {
             get { return _subscriptionName; }
         }
+
+        /// <summary>
+        /// Gets or sets the <see cref="AccessRights"/> the client has to the queue or topic.
+        /// The default is "Manage".
+        /// </summary>
+        public AccessRights Access { get; set; }
 
         private string DebuggerDisplay
         {

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Triggers/ServiceBusTriggerAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Triggers/ServiceBusTriggerAttributeBindingProvider.cs
@@ -51,9 +51,9 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
             }
 
             ParameterInfo parameter = context.Parameter;
-            ServiceBusTriggerAttribute serviceBusTrigger = parameter.GetCustomAttribute<ServiceBusTriggerAttribute>(inherit: false);
+            ServiceBusTriggerAttribute attribute = parameter.GetCustomAttribute<ServiceBusTriggerAttribute>(inherit: false);
 
-            if (serviceBusTrigger == null)
+            if (attribute == null)
             {
                 return Task.FromResult<ITriggerBinding>(null);
             }
@@ -62,14 +62,14 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
             string topicName = null;
             string subscriptionName = null;
 
-            if (serviceBusTrigger.QueueName != null)
+            if (attribute.QueueName != null)
             {
-                queueName = Resolve(serviceBusTrigger.QueueName);
+                queueName = Resolve(attribute.QueueName);
             }
             else
             {
-                topicName = Resolve(serviceBusTrigger.TopicName);
-                subscriptionName = Resolve(serviceBusTrigger.SubscriptionName);
+                topicName = Resolve(attribute.TopicName);
+                subscriptionName = Resolve(attribute.SubscriptionName);
             }
 
             ITriggerDataArgumentBinding<BrokeredMessage> argumentBinding = InnerProvider.TryCreate(parameter);
@@ -84,13 +84,11 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
 
             if (queueName != null)
             {
-                binding = new ServiceBusTriggerBinding(parameter.Name, parameter.ParameterType, argumentBinding,
-                    account, queueName);
+                binding = new ServiceBusTriggerBinding(parameter.Name, parameter.ParameterType, argumentBinding, account, queueName, attribute.Access);
             }
             else
             {
-                binding = new ServiceBusTriggerBinding(parameter.Name, argumentBinding, account, topicName,
-                    subscriptionName);
+                binding = new ServiceBusTriggerBinding(parameter.Name, argumentBinding, account, topicName, subscriptionName, attribute.Access);
             }
 
             return Task.FromResult(binding);

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Triggers/ServiceBusTriggerBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Triggers/ServiceBusTriggerBinding.cs
@@ -28,9 +28,10 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
         private readonly string _topicName;
         private readonly string _subscriptionName;
         private readonly string _entityPath;
+        private readonly AccessRights _accessRights;
 
         public ServiceBusTriggerBinding(string parameterName, Type parameterType, 
-            ITriggerDataArgumentBinding<BrokeredMessage> argumentBinding, ServiceBusAccount account, string queueName)
+            ITriggerDataArgumentBinding<BrokeredMessage> argumentBinding, ServiceBusAccount account, string queueName, AccessRights accessRights)
         {
             _parameterName = parameterName;
             _converter = CreateConverter(parameterType);
@@ -39,10 +40,11 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
             _namespaceName = ServiceBusClient.GetNamespaceName(account);
             _queueName = queueName;
             _entityPath = queueName;
+            _accessRights = accessRights;
         }
 
-        public ServiceBusTriggerBinding(string parameterName, ITriggerDataArgumentBinding<BrokeredMessage> argumentBinding, 
-            ServiceBusAccount account, string topicName, string subscriptionName)
+        public ServiceBusTriggerBinding(string parameterName, ITriggerDataArgumentBinding<BrokeredMessage> argumentBinding,
+            ServiceBusAccount account, string topicName, string subscriptionName, AccessRights accessRights)
         {
             _parameterName = parameterName;
             _argumentBinding = argumentBinding;
@@ -51,6 +53,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
             _topicName = topicName;
             _subscriptionName = subscriptionName;
             _entityPath = SubscriptionClient.FormatSubscriptionPath(topicName, subscriptionName);
+            _accessRights = accessRights;
         }
 
         public Type TriggerValueType
@@ -113,11 +116,11 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
         {
             if (_queueName != null)
             {
-                return new ServiceBusQueueListenerFactory(_account, _queueName, executor);
+                return new ServiceBusQueueListenerFactory(_account, _queueName, executor, _accessRights);
             }
             else
             {
-                return new ServiceBusSubscriptionListenerFactory(_account, _topicName, _subscriptionName, executor);
+                return new ServiceBusSubscriptionListenerFactory(_account, _topicName, _subscriptionName, executor, _accessRights);
             }
         }
 

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ServiceBusEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ServiceBusEndToEndTests.cs
@@ -5,7 +5,6 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.Azure.WebJobs.ServiceBus;
 using Microsoft.ServiceBus;
@@ -31,55 +30,15 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         private static string _resultMessage2;
 
         private NamespaceManager _namespaceManager;
-
+        private ServiceBusConfiguration _serviceBusConfig;
         private RandomNameResolver _nameResolver;
+        private JobHost _host;
 
-        // Passes  service bus message from a queue to another queue
-        public static void SBQueue2SBQueue(
-            [ServiceBusTrigger(StartQueueName)] string start,
-            [ServiceBus(QueueNamePrefix + "1")] out string message)
+        public ServiceBusEndToEndTests()
         {
-            message = start + "-SBQueue2SBQueue";
-        }
-
-        // Passes a service bus message from a queue to topic using a brokered message
-        public static void SBQueue2SBTopic(
-            [ServiceBusTrigger(QueueNamePrefix + "1")] string message,
-            [ServiceBus(TopicName)] out BrokeredMessage output)
-        {
-            message = message + "-SBQueue2SBTopic";
-
-            Stream stream = new MemoryStream();
-            TextWriter writer = new StreamWriter(stream);
-            writer.Write(message);
-            writer.Flush();
-            stream.Position = 0;
-
-            output = new BrokeredMessage(stream)
-            {
-                ContentType = "text/plain"
-            };
-        }
-
-        // First listener for the topic
-        public static void SBTopicListener1(
-            [ServiceBusTrigger(TopicName, QueueNamePrefix + "topic-1")] string message)
-        {
-            _resultMessage1 = message + "-topic-1";
-            _topicSubscriptionCalled1.Set();
-        }
-
-        // Second listerner for the topic
-        public static void SBTopicListener2(
-            [ServiceBusTrigger(TopicName, QueueNamePrefix + "topic-2")] BrokeredMessage message)
-        {
-            using (Stream stream = message.GetBody<Stream>())
-            using (TextReader reader = new StreamReader(stream))
-            {
-                _resultMessage2 = reader.ReadToEnd() + "-topic-2";
-            }
-
-            _topicSubscriptionCalled2.Set();
+            _serviceBusConfig = new ServiceBusConfiguration();
+            _nameResolver = new RandomNameResolver();
+            _namespaceManager = NamespaceManager.CreateFromConnectionString(_serviceBusConfig.ConnectionString);
         }
 
         [Fact]
@@ -87,90 +46,139 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         {
             try
             {
-                ServiceBusEndToEndInternal();
+                ServiceBusEndToEndInternal(typeof(ServiceBusTestJobs));
             }
             finally
             {
-                // Cleanup
-                string elementName = ResolveName(StartQueueName);
-                if (_namespaceManager.QueueExists(elementName))
-                {
-                    _namespaceManager.DeleteQueue(elementName);
-                }
-
-                elementName = ResolveName(QueueNamePrefix + "1");
-                if (_namespaceManager.QueueExists(elementName))
-                {
-                    _namespaceManager.DeleteQueue(elementName);
-                }
-
-                elementName = ResolveName(TopicName);
-                if (_namespaceManager.TopicExists(elementName))
-                {
-                    _namespaceManager.DeleteTopic(elementName);
-                }
+                Cleanup();
             }
         }
 
-        private void ServiceBusEndToEndInternal()
+        [Fact]
+        public void ServiceBusEndToEnd_RestrictedAccess()
         {
-            StringWriter consoleOutput = new StringWriter();
-            Console.SetOut(consoleOutput);
+            try
+            {
+                // Try running the tests using jobs that declare restricted access
+                // levels. We expect a failure.
+                MessagingEntityNotFoundException expectedException = null;
+                try
+                {
+                    ServiceBusEndToEndInternal(typeof(ServiceBusTestJobs_RestrictedAccess));
+                }
+                catch (MessagingEntityNotFoundException e)
+                {
+                    expectedException = e;
+                }
+                Assert.NotNull(expectedException);
 
-            // Reinitialize the name resolver to avoid naming conflicts
-            _nameResolver = new RandomNameResolver();
+                // Now create the service bus entities
+                string queueName = ResolveName(QueueNamePrefix + "1");
+                _namespaceManager.CreateQueue(queueName);
+
+                string topicName = ResolveName(TopicName);
+                _namespaceManager.CreateTopic(topicName);
+
+                string subscription1 = ResolveName(QueueNamePrefix + "topic-1");
+                _namespaceManager.CreateSubscription(topicName, subscription1);
+
+                string subscription2 = ResolveName(QueueNamePrefix + "topic-2");
+                _namespaceManager.CreateSubscription(topicName, subscription2);
+
+                // Test should now succeed
+                ServiceBusEndToEndInternal(typeof(ServiceBusTestJobs_RestrictedAccess), verifyLogs: false);
+            }
+            finally
+            {
+                Cleanup();
+            }
+        }
+
+        private void Cleanup()
+        {
+            if (_host != null)
+            {
+                _host.Dispose();
+            }
+
+            string elementName = ResolveName(StartQueueName);
+            if (_namespaceManager.QueueExists(elementName))
+            {
+                _namespaceManager.DeleteQueue(elementName);
+            }
+
+            elementName = ResolveName(QueueNamePrefix + "1");
+            if (_namespaceManager.QueueExists(elementName))
+            {
+                _namespaceManager.DeleteQueue(elementName);
+            }
+
+            elementName = ResolveName(TopicName);
+            if (_namespaceManager.TopicExists(elementName))
+            {
+                _namespaceManager.DeleteTopic(elementName);
+            }
+        }
+
+        private void ServiceBusEndToEndInternal(Type jobContainerType, bool verifyLogs = true)
+        {
+            StringWriter consoleOutput = null;
+            if (verifyLogs)
+            {
+                consoleOutput = new StringWriter();
+                Console.SetOut(consoleOutput);
+            }
 
             JobHostConfiguration config = new JobHostConfiguration()
             {
                 NameResolver = _nameResolver,
-                TypeLocator = new FakeTypeLocator(this.GetType())
+                TypeLocator = new FakeTypeLocator(jobContainerType)
             };
-
-            ServiceBusConfiguration serviceBusConfig = new ServiceBusConfiguration();
-            config.UseServiceBus(serviceBusConfig);
-
-            _namespaceManager = NamespaceManager.CreateFromConnectionString(serviceBusConfig.ConnectionString);
+            config.UseServiceBus(_serviceBusConfig);
 
             string startQueueName = ResolveName(StartQueueName);
             string secondQueueName = startQueueName.Replace("start", "1");
             string queuePrefix = startQueueName.Replace("-queue-start", "");
             string firstTopicName = string.Format("{0}-topic/Subscriptions/{0}-queue-topic-1", queuePrefix);
             string secondTopicName = string.Format("{0}-topic/Subscriptions/{0}-queue-topic-2", queuePrefix);
-            CreateStartMessage(serviceBusConfig.ConnectionString, startQueueName);
+            CreateStartMessage(_serviceBusConfig.ConnectionString, startQueueName);
 
-            JobHost host = new JobHost(config);
+            _host = new JobHost(config);
 
             _topicSubscriptionCalled1 = new ManualResetEvent(initialState: false);
             _topicSubscriptionCalled2 = new ManualResetEvent(initialState: false);
 
-            host.Start();
+            _host.Start();
 
             int timeout = 1 * 60 * 1000;
             _topicSubscriptionCalled1.WaitOne(timeout);
             _topicSubscriptionCalled2.WaitOne(timeout);
 
             // Wait for the host to terminate
-            host.Stop();
+            _host.Stop();
 
             Assert.Equal("E2E-SBQueue2SBQueue-SBQueue2SBTopic-topic-1", _resultMessage1);
             Assert.Equal("E2E-SBQueue2SBQueue-SBQueue2SBTopic-topic-2", _resultMessage2);
 
-            string[] consoleOutputLines = consoleOutput.ToString().Trim().Split(new string[] { Environment.NewLine }, StringSplitOptions.None);
-            string[] expectedOutputLines = new string[]
+            if (verifyLogs)
+            {
+                string[] consoleOutputLines = consoleOutput.ToString().Trim().Split(new string[] { Environment.NewLine }, StringSplitOptions.None);
+                string[] expectedOutputLines = new string[]
                 {
                     "Found the following functions:",
-                    "Microsoft.Azure.WebJobs.Host.EndToEndTests.ServiceBusEndToEndTests.SBQueue2SBQueue",
-                    "Microsoft.Azure.WebJobs.Host.EndToEndTests.ServiceBusEndToEndTests.SBQueue2SBTopic",
-                    "Microsoft.Azure.WebJobs.Host.EndToEndTests.ServiceBusEndToEndTests.SBTopicListener1",
-                    "Microsoft.Azure.WebJobs.Host.EndToEndTests.ServiceBusEndToEndTests.SBTopicListener2",
+                    string.Format("{0}.SBQueue2SBQueue", jobContainerType.FullName),
+                    string.Format("{0}.SBQueue2SBTopic", jobContainerType.FullName),
+                    string.Format("{0}.SBTopicListener1", jobContainerType.FullName),
+                    string.Format("{0}.SBTopicListener2", jobContainerType.FullName),
                     "Job host started",
-                    string.Format("Executing: 'ServiceBusEndToEndTests.SBQueue2SBQueue' - Reason: 'New ServiceBus message detected on '{0}.'", startQueueName),
-                    string.Format("Executing: 'ServiceBusEndToEndTests.SBQueue2SBTopic' - Reason: 'New ServiceBus message detected on '{0}.'", secondQueueName),
-                    string.Format("Executing: 'ServiceBusEndToEndTests.SBTopicListener1' - Reason: 'New ServiceBus message detected on '{0}.'", firstTopicName),
-                    string.Format("Executing: 'ServiceBusEndToEndTests.SBTopicListener2' - Reason: 'New ServiceBus message detected on '{0}.'", secondTopicName),
+                    string.Format("Executing: '{0}.SBQueue2SBQueue' - Reason: 'New ServiceBus message detected on '{1}.'", jobContainerType.Name, startQueueName),
+                    string.Format("Executing: '{0}.SBQueue2SBTopic' - Reason: 'New ServiceBus message detected on '{1}.'", jobContainerType.Name, secondQueueName),
+                    string.Format("Executing: '{0}.SBTopicListener1' - Reason: 'New ServiceBus message detected on '{1}.'", jobContainerType.Name, firstTopicName),
+                    string.Format("Executing: '{0}.SBTopicListener2' - Reason: 'New ServiceBus message detected on '{1}.'", jobContainerType.Name, secondTopicName),
                     "Job host stopped"
                 };
-            Assert.True(consoleOutputLines.OrderBy(p => p).SequenceEqual(expectedOutputLines.OrderBy(p => p)));
+                Assert.True(expectedOutputLines.OrderBy(p => p).SequenceEqual(consoleOutputLines.OrderBy(p => p)));
+            }
         }
 
         private void CreateStartMessage(string serviceBusConnectionString, string queueName)
@@ -199,6 +207,120 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         private string ResolveName(string name)
         {
             return name.Replace("%rnd%", _nameResolver.Resolve("rnd"));
+        }
+
+        public abstract class ServiceBusTestJobsBase
+        {
+            protected static string SBQueue2SBQueue_GetOutputMessage(string input)
+            {
+                return input + "-SBQueue2SBQueue";
+            }
+
+            protected static BrokeredMessage SBQueue2SBTopic_GetOutputMessage(string input)
+            {
+                input = input + "-SBQueue2SBTopic";
+
+                Stream stream = new MemoryStream();
+                TextWriter writer = new StreamWriter(stream);
+                writer.Write(input);
+                writer.Flush();
+                stream.Position = 0;
+
+                BrokeredMessage output = new BrokeredMessage(stream)
+                {
+                    ContentType = "text/plain"
+                };
+
+                return output;
+            }
+
+            protected static void SBTopicListener1Impl(string input)
+            {
+                _resultMessage1 = input + "-topic-1";
+                _topicSubscriptionCalled1.Set();
+            }
+
+            protected static void SBTopicListener2Impl(BrokeredMessage message)
+            {
+                using (Stream stream = message.GetBody<Stream>())
+                using (TextReader reader = new StreamReader(stream))
+                {
+                    _resultMessage2 = reader.ReadToEnd() + "-topic-2";
+                }
+
+                _topicSubscriptionCalled2.Set();
+            }
+        }
+
+        public class ServiceBusTestJobs : ServiceBusTestJobsBase
+        {
+            // Passes  service bus message from a queue to another queue
+            public static void SBQueue2SBQueue(
+                [ServiceBusTrigger(StartQueueName)] string start,
+                [ServiceBus(QueueNamePrefix + "1")] out string message)
+            {
+                message = SBQueue2SBQueue_GetOutputMessage(start);
+            }
+
+            // Passes a service bus message from a queue to topic using a brokered message
+            public static void SBQueue2SBTopic(
+                [ServiceBusTrigger(QueueNamePrefix + "1")] string message,
+                [ServiceBus(TopicName)] out BrokeredMessage output)
+            {
+                output = SBQueue2SBTopic_GetOutputMessage(message);
+            }
+
+            // First listener for the topic
+            public static void SBTopicListener1(
+                [ServiceBusTrigger(TopicName, QueueNamePrefix + "topic-1")] string message)
+            {
+                SBTopicListener1Impl(message);
+            }
+
+            // Second listerner for the topic
+            public static void SBTopicListener2(
+                [ServiceBusTrigger(TopicName, QueueNamePrefix + "topic-2")] BrokeredMessage message)
+            {
+                SBTopicListener2Impl(message);
+            }
+        }
+
+        /// <summary>
+        /// This test class declares the same job functions, but with restricted AccessRights.
+        /// This means the framework will not create any SB queues/topics/subscriptions if they
+        /// don't already exist.
+        /// </summary>
+        public class ServiceBusTestJobs_RestrictedAccess : ServiceBusTestJobsBase
+        {
+            // Passes  service bus message from a queue to another queue
+            public static void SBQueue2SBQueue(
+                [ServiceBusTrigger(StartQueueName, Access = AccessRights.Listen)] string start,
+                [ServiceBus(QueueNamePrefix + "1", Access = AccessRights.Send)] out string message)
+            {
+                message = SBQueue2SBQueue_GetOutputMessage(start);
+            }
+
+            // Passes a service bus message from a queue to topic using a brokered message
+            public static void SBQueue2SBTopic(
+                [ServiceBusTrigger(QueueNamePrefix + "1", Access = AccessRights.Listen)] string message,
+                [ServiceBus(TopicName, Access = AccessRights.Send)] out BrokeredMessage output)
+            {
+                output = SBQueue2SBTopic_GetOutputMessage(message);
+            }
+
+            // First listener for the topic
+            public static void SBTopicListener1(
+                [ServiceBusTrigger(TopicName, QueueNamePrefix + "topic-1", Access = AccessRights.Listen)] string message)
+            {
+                SBTopicListener1Impl(message);
+            }
+
+            // Second listerner for the topic
+            public static void SBTopicListener2(
+                [ServiceBusTrigger(TopicName, QueueNamePrefix + "topic-2", Access = AccessRights.Listen)] BrokeredMessage message)
+            {
+                SBTopicListener2Impl(message);
+            }
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Listeners/ServiceBusQueueListenerFactoryTests.cs
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Listeners/ServiceBusQueueListenerFactoryTests.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Azure.WebJobs.Host.Listeners;
+using Microsoft.Azure.WebJobs.ServiceBus.Listeners;
+using Microsoft.ServiceBus.Messaging;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Listeners
+{
+    public class ServiceBusQueueListenerFactoryTests
+    {
+        [Theory]
+        [InlineData(AccessRights.Listen)]
+        [InlineData(AccessRights.Send)]
+        public async Task CreateAsync_AccessRightsNotManage_DoesNotCreateQueue(AccessRights accessRights)
+        {
+            ServiceBusAccount account = new ServiceBusAccount();
+            Mock<ITriggeredFunctionExecutor<BrokeredMessage>> mockExecutor = new Mock<ITriggeredFunctionExecutor<BrokeredMessage>>(MockBehavior.Strict);
+            ServiceBusQueueListenerFactory factory = new ServiceBusQueueListenerFactory(account, "testqueue", mockExecutor.Object, accessRights);
+        
+            ListenerFactoryContext context = new ListenerFactoryContext(CancellationToken.None);
+            IListener listener = await factory.CreateAsync(context);
+            Assert.NotNull(listener);
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Triggers/ServiceBusSubscriptionListenerFactoryTests.cs
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Triggers/ServiceBusSubscriptionListenerFactoryTests.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Azure.WebJobs.Host.Listeners;
+using Microsoft.Azure.WebJobs.ServiceBus.Listeners;
+using Microsoft.ServiceBus.Messaging;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Listeners
+{
+    public class ServiceBusSubscriptionListenerFactoryTests
+    {
+        [Theory]
+        [InlineData(AccessRights.Listen)]
+        [InlineData(AccessRights.Send)]
+        public async Task CreateAsync_AccessRightsNotManage_DoesNotCreateTopicOrSubscription(AccessRights accessRights)
+        {
+            ServiceBusAccount account = new ServiceBusAccount();
+            Mock<ITriggeredFunctionExecutor<BrokeredMessage>> mockExecutor = new Mock<ITriggeredFunctionExecutor<BrokeredMessage>>(MockBehavior.Strict);
+            ServiceBusSubscriptionListenerFactory factory = new ServiceBusSubscriptionListenerFactory(account, "testtopic", "testsubscription", mockExecutor.Object, accessRights);
+
+            ListenerFactoryContext context = new ListenerFactoryContext(CancellationToken.None);
+            IListener listener = await factory.CreateAsync(context);
+            Assert.NotNull(listener);
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Triggers/ServiceBusTriggerBindingIntegrationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Triggers/ServiceBusTriggerBindingIntegrationTests.cs
@@ -25,8 +25,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Triggers
             IQueueTriggerArgumentBindingProvider provider = new UserTypeArgumentBindingProvider();
             ParameterInfo pi = new StubParameterInfo("parameterName", typeof(UserDataType));
             var argumentBinding = provider.TryCreate(pi);
-            _binding = new ServiceBusTriggerBinding("parameterName", typeof(UserDataType), argumentBinding, null,
-                "queueName");
+            _binding = new ServiceBusTriggerBinding("parameterName", typeof(UserDataType), argumentBinding, null, "queueName", AccessRights.Manage);
         }
 
         [Theory]

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/WebJobs.ServiceBus.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/WebJobs.ServiceBus.UnitTests.csproj
@@ -100,8 +100,10 @@
     <Compile Include="Bindings\ParameterizedServiceBusPathTests.cs" />
     <Compile Include="Config\ServiceBusJobHostConfigurationExtensionsTests.cs" />
     <Compile Include="Config\ServiceBusExtensionConfigTests.cs" />
+    <Compile Include="Listeners\ServiceBusQueueListenerFactoryTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Listeners\NamespaceManagerExtensionsTests.cs" />
+    <Compile Include="Triggers\ServiceBusSubscriptionListenerFactoryTests.cs" />
     <Compile Include="Triggers\ServiceBusTriggerBindingIntegrationTests.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This addresses scenarios where a client might only have Listen/Send rights to queues/topics, in which case the SDK should not attempt to "CreateIfNotExists" (which requires AccessRights.Manage). The default will remain Manage. This addresses issue #501.

The service bus Access levels/restrictions are documented here: https://msdn.microsoft.com/en-us/library/azure/dn205160.aspx