### PR TITLE
Invariant Culture

### DIFF
--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -7,7 +7,6 @@
   <repository path="..\src\Microsoft.Azure.WebJobs.ServiceBus\packages.config" />
   <repository path="..\src\Microsoft.Azure.WebJobs.Storage\packages.config" />
   <repository path="..\src\Microsoft.Azure.WebJobs\packages.config" />
-  <repository path="..\src\Packages\packages.config" />
   <repository path="..\test\Dashboard.UnitTests\packages.config" />
   <repository path="..\test\Microsoft.Azure.WebJobs.Host.EndToEndTests\packages.config" />
   <repository path="..\test\Microsoft.Azure.WebJobs.Host.FunctionalTests\packages.config" />

--- a/test/Dashboard.UnitTests/Infrastructure/LogAnalysisTests.cs
+++ b/test/Dashboard.UnitTests/Infrastructure/LogAnalysisTests.cs
@@ -3,14 +3,13 @@
 
 using System;
 using System.Globalization;
-using System.Text;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.Azure.WebJobs.Protocols;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Dashboard.UnitTests.Infrastructure
 {
-    public class LogAnalysisTests
+    public class LogAnalysisTests : IClassFixture<InvariantCultureFixture>
     {
         [Fact]
         public void FormatTime_ZeroTime_NoOutput()

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/InvariantCultureFixture.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/InvariantCultureFixture.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Threading;
+
+namespace Microsoft.Azure.WebJobs.Host.TestCommon
+{
+    public class InvariantCultureFixture : IDisposable
+    {
+        private readonly CultureInfo _originalCultureInfo;
+
+        public InvariantCultureFixture()
+        {
+            _originalCultureInfo = Thread.CurrentThread.CurrentCulture;
+            Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+        }
+
+        public void Dispose()
+        {
+            Thread.CurrentThread.CurrentCulture = _originalCultureInfo;
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/WebJobs.Host.TestCommon.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/WebJobs.Host.TestCommon.csproj
@@ -94,6 +94,7 @@
     <Compile Include="AzureSdk\CloudQueueClientExtensions.cs" />
     <Compile Include="ExtensionTypeLocator.cs" />
     <Compile Include="FakeExtensionTypeLocator.cs" />
+    <Compile Include="InvariantCultureFixture.cs" />
     <Compile Include="NullConsoleProvider.cs" />
     <Compile Include="NullFunctionInstanceLogger.cs" />
     <Compile Include="NullFunctionOutputLoggerProvider.cs" />

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Queues/QueueTriggerBindingIntegrationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Queues/QueueTriggerBindingIntegrationTests.cs
@@ -8,17 +8,17 @@ using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Azure.WebJobs.Host.Queues;
 using Microsoft.Azure.WebJobs.Host.Queues.Triggers;
 using Microsoft.Azure.WebJobs.Host.Storage.Queue;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.Azure.WebJobs.Host.Timers;
 using Microsoft.Azure.WebJobs.Host.Triggers;
 using Microsoft.WindowsAzure.Storage.Queue;
 using Moq;
 using Newtonsoft.Json;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Microsoft.Azure.WebJobs.Host.UnitTests.Queues
 {
-    public class QueueTriggerBindingIntegrationTests
+    public class QueueTriggerBindingIntegrationTests : IClassFixture<InvariantCultureFixture>
     {
         private ITriggerBinding<IStorageQueueMessage> _binding;
 

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Triggers/ServiceBusTriggerBindingIntegrationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Triggers/ServiceBusTriggerBindingIntegrationTests.cs
@@ -7,16 +7,16 @@ using System.Reflection;
 using System.Text;
 using System.Threading;
 using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.Azure.WebJobs.Host.Triggers;
 using Microsoft.Azure.WebJobs.ServiceBus.Triggers;
 using Microsoft.ServiceBus.Messaging;
 using Newtonsoft.Json;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Triggers
 {
-    public class ServiceBusTriggerBindingIntegrationTests
+    public class ServiceBusTriggerBindingIntegrationTests : IClassFixture<InvariantCultureFixture>
     {
         private ITriggerBinding<BrokeredMessage> _binding;
 


### PR DESCRIPTION
I've added a fixture for forcing InvariantCulture on the current thread so that tests that are written expecting en-US date format or en-US decimal separator will not fail on non-American computers. I noticed this on my own computer which has nb-NO (Norwegian Bokmål) which uses 'dd.MM.yyyy HH:mm' as date format and comma (,) as decimal separator.