### PR TITLE
Added OnMessageOptions to ServiceBusConfiguration.

### DIFF
--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Config/ServiceBusConfiguration.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Config/ServiceBusConfiguration.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.ServiceBus.Messaging;
 
 namespace Microsoft.Azure.WebJobs.ServiceBus
 {
@@ -12,6 +13,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
     {
         private bool _connectionStringSet;
         private string _connectionString;
+        private OnMessageOptions _onMessageOptions = new OnMessageOptions();
 
         /// <summary>
         /// Gets or sets the Azure ServiceBus connection string.
@@ -33,6 +35,15 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
                 _connectionString = value;
                 _connectionStringSet = true;
             }
+        }
+
+        /// <summary>
+        /// Gets or sets OnMessageOptions to use when processing messages with <see cref="ServiceBusTriggerAttribute"/>.
+        /// </summary>
+        public OnMessageOptions OnMessageOptions
+        {
+            get { return _onMessageOptions; }
+            set { _onMessageOptions = value; }
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Listeners/ServiceBusListener.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Listeners/ServiceBusListener.cs
@@ -16,16 +16,18 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
         private readonly MessagingFactory _messagingFactory;
         private readonly string _entityPath;
         private readonly ServiceBusTriggerExecutor _triggerExecutor;
+        private readonly OnMessageOptions _onMessageOptions;
         private readonly CancellationTokenSource _cancellationTokenSource;
 
         private MessageReceiver _receiver;
         private bool _disposed;
 
-        public ServiceBusListener(MessagingFactory messagingFactory, string entityPath, ServiceBusTriggerExecutor triggerExecutor)
+        public ServiceBusListener(MessagingFactory messagingFactory, string entityPath, ServiceBusTriggerExecutor triggerExecutor, OnMessageOptions onMessageOptions)
         {
             _messagingFactory = messagingFactory;
             _entityPath = entityPath;
             _triggerExecutor = triggerExecutor;
+            _onMessageOptions = onMessageOptions ?? new OnMessageOptions();
             _cancellationTokenSource = new CancellationTokenSource();
         }
 
@@ -46,7 +48,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
             cancellationToken.ThrowIfCancellationRequested();
             _receiver = await _messagingFactory.CreateMessageReceiverAsync(_entityPath);
 
-            _receiver.OnMessageAsync(ProcessMessageAsync, new OnMessageOptions());
+            _receiver.OnMessageAsync(ProcessMessageAsync, _onMessageOptions);
         }
 
         public Task StopAsync(CancellationToken cancellationToken)

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Listeners/ServiceBusQueueListenerFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Listeners/ServiceBusQueueListenerFactory.cs
@@ -14,14 +14,16 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
     {
         private readonly NamespaceManager _namespaceManager;
         private readonly MessagingFactory _messagingFactory;
+        private readonly OnMessageOptions _onMessageOptions;
         private readonly string _queueName;
         private readonly ITriggeredFunctionExecutor<BrokeredMessage> _executor;
         private readonly AccessRights _accessRights;
 
-        public ServiceBusQueueListenerFactory(ServiceBusAccount account, string queueName, ITriggeredFunctionExecutor<BrokeredMessage> executor, AccessRights accessRights)
+        public ServiceBusQueueListenerFactory(ServiceBusAccount account, OnMessageOptions onMessageOptions, string queueName, ITriggeredFunctionExecutor<BrokeredMessage> executor, AccessRights accessRights)
         {
             _namespaceManager = account.NamespaceManager;
             _messagingFactory = account.MessagingFactory;
+            _onMessageOptions = onMessageOptions;
             _queueName = queueName;
             _executor = executor;
             _accessRights = accessRights;
@@ -38,7 +40,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
             }
 
             ServiceBusTriggerExecutor triggerExecutor = new ServiceBusTriggerExecutor(_executor);
-            return new ServiceBusListener(_messagingFactory, _queueName, triggerExecutor);
+            return new ServiceBusListener(_messagingFactory, _queueName, triggerExecutor, _onMessageOptions);
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Listeners/ServiceBusSubscriptionListenerFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Listeners/ServiceBusSubscriptionListenerFactory.cs
@@ -14,15 +14,17 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
     {
         private readonly NamespaceManager _namespaceManager;
         private readonly MessagingFactory _messagingFactory;
+        private readonly OnMessageOptions _onMessageOptions;
         private readonly string _topicName;
         private readonly string _subscriptionName;
         private readonly ITriggeredFunctionExecutor<BrokeredMessage> _executor;
         private readonly AccessRights _accessRights;
 
-        public ServiceBusSubscriptionListenerFactory(ServiceBusAccount account, string topicName, string subscriptionName, ITriggeredFunctionExecutor<BrokeredMessage> executor, AccessRights accessRights)
+        public ServiceBusSubscriptionListenerFactory(ServiceBusAccount account, OnMessageOptions onMessageOptions, string topicName, string subscriptionName, ITriggeredFunctionExecutor<BrokeredMessage> executor, AccessRights accessRights)
         {
             _namespaceManager = account.NamespaceManager;
             _messagingFactory = account.MessagingFactory;
+            _onMessageOptions = onMessageOptions;
             _topicName = topicName;
             _subscriptionName = subscriptionName;
             _executor = executor;
@@ -43,7 +45,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
             string entityPath = SubscriptionClient.FormatSubscriptionPath(_topicName, _subscriptionName);
 
             ServiceBusTriggerExecutor triggerExecutor = new ServiceBusTriggerExecutor(_executor);
-            return new ServiceBusListener(_messagingFactory, entityPath, triggerExecutor);
+            return new ServiceBusListener(_messagingFactory, entityPath, triggerExecutor, _onMessageOptions);
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Triggers/ServiceBusTriggerAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Triggers/ServiceBusTriggerAttributeBindingProvider.cs
@@ -6,11 +6,8 @@ using System.Globalization;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host;
-using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Converters;
-using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Triggers;
-using Microsoft.Azure.WebJobs.ServiceBus.Config;
 using Microsoft.ServiceBus.Messaging;
 
 namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
@@ -84,11 +81,11 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
 
             if (queueName != null)
             {
-                binding = new ServiceBusTriggerBinding(parameter.Name, parameter.ParameterType, argumentBinding, account, queueName, attribute.Access);
+                binding = new ServiceBusTriggerBinding(parameter.Name, parameter.ParameterType, argumentBinding, account, _config.OnMessageOptions, queueName, attribute.Access);
             }
             else
             {
-                binding = new ServiceBusTriggerBinding(parameter.Name, argumentBinding, account, topicName, subscriptionName, attribute.Access);
+                binding = new ServiceBusTriggerBinding(parameter.Name, argumentBinding, account, _config.OnMessageOptions, topicName, subscriptionName, attribute.Access);
             }
 
             return Task.FromResult(binding);

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Triggers/ServiceBusTriggerBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Triggers/ServiceBusTriggerBinding.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
         private readonly IObjectToTypeConverter<BrokeredMessage> _converter;
         private readonly ITriggerDataArgumentBinding<BrokeredMessage> _argumentBinding;
         private readonly ServiceBusAccount _account;
+        private readonly OnMessageOptions _onMessageOptions;
         private readonly string _namespaceName;
         private readonly string _queueName;
         private readonly string _topicName;
@@ -31,12 +32,13 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
         private readonly AccessRights _accessRights;
 
         public ServiceBusTriggerBinding(string parameterName, Type parameterType, 
-            ITriggerDataArgumentBinding<BrokeredMessage> argumentBinding, ServiceBusAccount account, string queueName, AccessRights accessRights)
+            ITriggerDataArgumentBinding<BrokeredMessage> argumentBinding, ServiceBusAccount account, OnMessageOptions onMessageOptions, string queueName, AccessRights accessRights)
         {
             _parameterName = parameterName;
             _converter = CreateConverter(parameterType);
             _argumentBinding = argumentBinding;
             _account = account;
+            _onMessageOptions = onMessageOptions;
             _namespaceName = ServiceBusClient.GetNamespaceName(account);
             _queueName = queueName;
             _entityPath = queueName;
@@ -44,11 +46,12 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
         }
 
         public ServiceBusTriggerBinding(string parameterName, ITriggerDataArgumentBinding<BrokeredMessage> argumentBinding,
-            ServiceBusAccount account, string topicName, string subscriptionName, AccessRights accessRights)
+            ServiceBusAccount account, OnMessageOptions onMessageOptions, string topicName, string subscriptionName, AccessRights accessRights)
         {
             _parameterName = parameterName;
             _argumentBinding = argumentBinding;
             _account = account;
+            _onMessageOptions = onMessageOptions;
             _namespaceName = ServiceBusClient.GetNamespaceName(account);
             _topicName = topicName;
             _subscriptionName = subscriptionName;
@@ -116,11 +119,11 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
         {
             if (_queueName != null)
             {
-                return new ServiceBusQueueListenerFactory(_account, _queueName, executor, _accessRights);
+                return new ServiceBusQueueListenerFactory(_account, _onMessageOptions, _queueName, executor, _accessRights);
             }
             else
             {
-                return new ServiceBusSubscriptionListenerFactory(_account, _topicName, _subscriptionName, executor, _accessRights);
+                return new ServiceBusSubscriptionListenerFactory(_account, _onMessageOptions, _topicName, _subscriptionName, executor, _accessRights);
             }
         }
 

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Listeners/ServiceBusQueueListenerFactoryTests.cs
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Listeners/ServiceBusQueueListenerFactoryTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Listeners
         {
             ServiceBusAccount account = new ServiceBusAccount();
             Mock<ITriggeredFunctionExecutor<BrokeredMessage>> mockExecutor = new Mock<ITriggeredFunctionExecutor<BrokeredMessage>>(MockBehavior.Strict);
-            ServiceBusQueueListenerFactory factory = new ServiceBusQueueListenerFactory(account, "testqueue", mockExecutor.Object, accessRights);
+            ServiceBusQueueListenerFactory factory = new ServiceBusQueueListenerFactory(account, null, "testqueue", mockExecutor.Object, accessRights);
         
             ListenerFactoryContext context = new ListenerFactoryContext(CancellationToken.None);
             IListener listener = await factory.CreateAsync(context);

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Triggers/ServiceBusSubscriptionListenerFactoryTests.cs
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Triggers/ServiceBusSubscriptionListenerFactoryTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Listeners
         {
             ServiceBusAccount account = new ServiceBusAccount();
             Mock<ITriggeredFunctionExecutor<BrokeredMessage>> mockExecutor = new Mock<ITriggeredFunctionExecutor<BrokeredMessage>>(MockBehavior.Strict);
-            ServiceBusSubscriptionListenerFactory factory = new ServiceBusSubscriptionListenerFactory(account, "testtopic", "testsubscription", mockExecutor.Object, accessRights);
+            ServiceBusSubscriptionListenerFactory factory = new ServiceBusSubscriptionListenerFactory(account, null, "testtopic", "testsubscription", mockExecutor.Object, accessRights);
 
             ListenerFactoryContext context = new ListenerFactoryContext(CancellationToken.None);
             IListener listener = await factory.CreateAsync(context);

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Triggers/ServiceBusTriggerBindingIntegrationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Triggers/ServiceBusTriggerBindingIntegrationTests.cs
@@ -12,7 +12,6 @@ using Microsoft.Azure.WebJobs.ServiceBus.Triggers;
 using Microsoft.ServiceBus.Messaging;
 using Newtonsoft.Json;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Triggers
 {
@@ -25,7 +24,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Triggers
             IQueueTriggerArgumentBindingProvider provider = new UserTypeArgumentBindingProvider();
             ParameterInfo pi = new StubParameterInfo("parameterName", typeof(UserDataType));
             var argumentBinding = provider.TryCreate(pi);
-            _binding = new ServiceBusTriggerBinding("parameterName", typeof(UserDataType), argumentBinding, null, "queueName", AccessRights.Manage);
+            _binding = new ServiceBusTriggerBinding("parameterName", typeof(UserDataType), argumentBinding, null, null, "queueName", AccessRights.Manage);
         }
 
         [Theory]


### PR DESCRIPTION
I've added this to ServiceBusConfiguration and implemented using it throughout.
```c#
    public class ServiceBusConfiguration
    {
        ...
        public OnMessageOptions OnMessageOptions
        {
            get { return _onMessageOptions; }
            set { _onMessageOptions = value; }
        }
    }
```

There's a "tight coupling" between ServiceBusConfiguration and ServiceBus by using OnMessageOptions directly, but by doing this we'll support any changes that might later be introduced in the base ServiceBus library by using this instead of separately adding the properties of OnMessageOptions (like MaxConcurrentCalls, AutoComplete and so on).

As I'm just passing the OnMessageOptions through to the internally used MessageReceiver.OnMessageAsync() method, I haven't made any new tests to explicitly test setting different properties of OnMessageOptions.