### PR TITLE
Making Queues "NewBatchThreshold" configurable

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/JobHostQueuesConfiguration.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/JobHostQueuesConfiguration.cs
@@ -19,12 +19,16 @@ namespace Microsoft.Azure.WebJobs.Host
         private const int MaxBatchSize = 32;
 
         private int _batchSize = DefaultBatchSize;
+        private int _newBatchThreshold = DefaultBatchSize;
         private TimeSpan _maxPollingInterval = QueuePollingIntervals.DefaultMaximum;
         private int _maxDequeueCount = DefaultMaxDequeueCount;
 
-        /// <summary>Initializes a new instance of the <see cref="JobHostQueuesConfiguration"/> class.</summary>
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JobHostQueuesConfiguration"/> class.
+        /// </summary>
         internal JobHostQueuesConfiguration()
         {
+            _newBatchThreshold = -1;
             QueueProcessorFactory = new DefaultQueueProcessorFactory();
         }
 
@@ -48,6 +52,32 @@ namespace Microsoft.Azure.WebJobs.Host
                 }
 
                 _batchSize = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the threshold at which a new batch of messages will be fetched.
+        /// </summary>
+        public int NewBatchThreshold
+        {
+            get 
+            { 
+                if (_newBatchThreshold == -1)
+                {
+                    // if this hasn't been set explicitly, default it
+                    return _batchSize / 2;
+                }
+                return _newBatchThreshold; 
+            }
+
+            set
+            {
+                if (value <= 0)
+                {
+                    throw new ArgumentOutOfRangeException("value");
+                }
+
+                _newBatchThreshold = value;
             }
         }
 

--- a/src/Microsoft.Azure.WebJobs.Host/Queues/IQueueConfiguration.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Queues/IQueueConfiguration.cs
@@ -9,6 +9,8 @@ namespace Microsoft.Azure.WebJobs.Host.Queues
     {
         int BatchSize { get; }
 
+        int NewBatchThreshold { get; }
+
         TimeSpan MaxPollingInterval { get; }
 
         int MaxDequeueCount { get; }

--- a/src/Microsoft.Azure.WebJobs.Host/Queues/QueueProcessor.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Queues/QueueProcessor.cs
@@ -43,12 +43,24 @@ namespace Microsoft.Azure.WebJobs.Host.Queues
             _poisonQueue = context.PoisonQueue;
             _log = context.Log;
             _maxDequeueCount = context.MaxDequeueCount;
+            BatchSize = context.BatchSize;
+            NewBatchThreshold = context.NewBatchThreshold;
         }
 
         /// <summary>
         /// Event raised when a message is added to the poison queue.
         /// </summary>
         public event EventHandler MessageAddedToPoisonQueue;
+
+        /// <summary>
+        /// Gets or sets the number of queue messages to retrieve and process in parallel.
+        /// </summary>
+        public int BatchSize { get; private set; }
+
+        /// <summary>
+        /// Gets the threshold at which a new batch of messages will be fetched.
+        /// </summary>
+        public int NewBatchThreshold { get; private set; }
 
         /// <summary>
         /// This method is called when there is a new message to process, before the job function is invoked.

--- a/src/Microsoft.Azure.WebJobs.Host/Queues/QueueProcessorFactoryContext.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Queues/QueueProcessorFactoryContext.cs
@@ -18,10 +18,8 @@ namespace Microsoft.Azure.WebJobs.Host.Queues
         /// </summary>
         /// <param name="queue">The <see cref="CloudQueue"/> the <see cref="QueueProcessor"/> will operate on.</param>
         /// <param name="log">The log to write to.</param>
-        /// <param name="maxDequeueCount">The maximum number of times to try processing a message before moving
-        /// it to the poison queue (if a poison queue is configured for the queue).</param>
         /// <param name="poisonQueue">The queue to move messages to when unable to process a message after the maximum dequeue count has been exceeded. May be null.</param>
-        public QueueProcessorFactoryContext(CloudQueue queue, TextWriter log, int maxDequeueCount, CloudQueue poisonQueue = null)
+        public QueueProcessorFactoryContext(CloudQueue queue, TextWriter log, CloudQueue poisonQueue = null)         
         {
             if (queue == null)
             {
@@ -35,7 +33,21 @@ namespace Microsoft.Azure.WebJobs.Host.Queues
             Queue = queue;
             PoisonQueue = poisonQueue;
             Log = log;
-            MaxDequeueCount = maxDequeueCount;
+        }
+
+        /// <summary>
+        /// Constructs a new instance
+        /// </summary>
+        /// <param name="queue">The <see cref="CloudQueue"/> the <see cref="QueueProcessor"/> will operate on.</param>
+        /// <param name="log">The log to write to.</param>
+        /// <param name="queueConfiguration">The queue configuration.</param>
+        /// <param name="poisonQueue">The queue to move messages to when unable to process a message after the maximum dequeue count has been exceeded. May be null.</param>
+        internal QueueProcessorFactoryContext(CloudQueue queue, TextWriter log, IQueueConfiguration queueConfiguration, CloudQueue poisonQueue = null)
+            : this(queue, log, poisonQueue)
+        {
+            BatchSize = queueConfiguration.BatchSize;
+            MaxDequeueCount = queueConfiguration.MaxDequeueCount;
+            NewBatchThreshold = queueConfiguration.NewBatchThreshold;
         }
 
         /// <summary>
@@ -57,9 +69,19 @@ namespace Microsoft.Azure.WebJobs.Host.Queues
         public TextWriter Log { get; private set; }
 
         /// <summary>
+        /// Gets or sets the number of queue messages to retrieve and process in parallel (per job method).
+        /// </summary>
+        public int BatchSize { get; set; }
+
+        /// <summary>
         /// Gets or sets the maximum number of times to try processing a message before moving
         /// it to the poison queue (if a poison queue is configured for the queue).
         /// </summary>
-        public int MaxDequeueCount { get; private set; }
+        public int MaxDequeueCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the threshold at which a new batch of messages will be fetched.
+        /// </summary>
+        public int NewBatchThreshold { get; set; }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncChainEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncChainEndToEndTests.cs
@@ -201,6 +201,10 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 // demonstrates how queue options can be customized
                 context.Queue.EncodeMessage = true;
 
+                // demonstrates how batch processing behavior can be customized
+                context.BatchSize = 30;
+                context.NewBatchThreshold = 100;
+
                 return new CustomQueueProcessor(context);
             }
         }

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ParallelExecutionTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ParallelExecutionTests.cs
@@ -70,6 +70,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 TypeLocator = new FakeTypeLocator(typeof(ParallelExecutionTests)),
             };
             hostConfiguration.Queues.BatchSize = batchSize;
+            //hostConfiguration.Queues.NewBatchThreshold = Math.Max(1, batchSize / 2);
 
             CloudStorageAccount storageAccount = CloudStorageAccount.Parse(hostConfiguration.StorageConnectionString);
             _queueClient = storageAccount.CreateCloudQueueClient();

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/Queues/QueueProcessorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/Queues/QueueProcessorTests.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
         private CloudQueue _poisonQueue;
         private QueueProcessor _processor;
         private TextWriter _log;
+        private JobHostQueuesConfiguration _queuesConfig;
 
         public QueueProcessorTests(TestFixture fixture)
         {
@@ -27,8 +28,18 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
             _queue = fixture.Queue;
             _poisonQueue = fixture.PoisonQueue;
 
-            QueueProcessorFactoryContext context = new QueueProcessorFactoryContext(_queue, _log, 5);
+            _queuesConfig = new JobHostQueuesConfiguration();
+            QueueProcessorFactoryContext context = new QueueProcessorFactoryContext(_queue, _log, _queuesConfig);
             _processor = new QueueProcessor(context);
+        }
+
+        [Fact]
+        public void Constructor_DefaultsValues()
+        {
+            QueueProcessorFactoryContext context = new QueueProcessorFactoryContext(_queue, _log, _queuesConfig);
+            QueueProcessor localProcessor = new QueueProcessor(context);
+            Assert.Equal(_queuesConfig.BatchSize, localProcessor.BatchSize);
+            Assert.Equal(_queuesConfig.NewBatchThreshold, localProcessor.NewBatchThreshold);
         }
 
         [Fact]
@@ -69,7 +80,7 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
         [Fact]
         public async Task CompleteProcessingMessageAsync_MaxDequeueCountExceeded_MovesMessageToPoisonQueue()
         {
-            QueueProcessorFactoryContext context = new QueueProcessorFactoryContext(_queue, _log, 3, _poisonQueue);
+            QueueProcessorFactoryContext context = new QueueProcessorFactoryContext(_queue, _log, _queuesConfig, _poisonQueue);
             QueueProcessor localProcessor = new QueueProcessor(context);
 
             bool poisonMessageHandlerCalled = false;

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/TestDoubles/FakeQueueConfiguration.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/TestDoubles/FakeQueueConfiguration.cs
@@ -26,6 +26,14 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests.TestDoubles
             get { return 2; }
         }
 
+        public int NewBatchThreshold
+        {
+            get
+            {
+                return BatchSize / 2;
+            }
+        }
+
         public TimeSpan MaxPollingInterval
         {
             get { return TimeSpan.FromSeconds(10); }

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/SimpleQueueConfiguration.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/SimpleQueueConfiguration.cs
@@ -20,6 +20,14 @@ namespace Microsoft.Azure.WebJobs.Host.TestCommon
             get { return 16; }
         }
 
+        public int NewBatchThreshold
+        {
+            get
+            {
+                return BatchSize / 2;
+            }
+        }
+
         public TimeSpan MaxPollingInterval
         {
             get { return TimeSpan.FromMinutes(10); }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostQueuesConfigurationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostQueuesConfigurationTests.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.WebJobs.Host.Queues;
+using Microsoft.Azure.WebJobs.Host.Queues.Listeners;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Host.UnitTests
+{
+    public class JobHostQueuesConfigurationTests
+    {
+        [Fact]
+        public void Constructor_Defaults()
+        {
+            // Arrange
+            JobHostQueuesConfiguration config = new JobHostQueuesConfiguration();
+
+            // Act & Assert
+            Assert.Equal(16, config.BatchSize);
+            Assert.Equal(8, config.NewBatchThreshold);
+            Assert.Equal(typeof(DefaultQueueProcessorFactory), config.QueueProcessorFactory.GetType());
+            Assert.Equal(QueuePollingIntervals.DefaultMaximum, config.MaxPollingInterval);
+        }
+
+        [Fact]
+        public void NewBatchThreshold_CanSetAndGetValue()
+        {
+            // Arrange
+            JobHostQueuesConfiguration config = new JobHostQueuesConfiguration();
+
+            config.NewBatchThreshold = 1000;
+            Assert.Equal(1000, config.NewBatchThreshold);
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Queues/QueueListenerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Queues/QueueListenerTests.cs
@@ -35,7 +35,9 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Queues
             Mock<IBackgroundExceptionDispatcher> mockExceptionDispatcher = new Mock<IBackgroundExceptionDispatcher>(MockBehavior.Strict);
             TextWriter log = new StringWriter();
             Mock<IQueueProcessorFactory> mockQueueProcessorFactory = new Mock<IQueueProcessorFactory>(MockBehavior.Strict);
-            QueueProcessorFactoryContext context = new QueueProcessorFactoryContext(queue, log, 5);
+            JobHostQueuesConfiguration queuesConfig = new JobHostQueuesConfiguration();
+            QueueProcessorFactoryContext context = new QueueProcessorFactoryContext(queue, log, queuesConfig);
+
             _mockQueueProcessor = new Mock<QueueProcessor>(MockBehavior.Strict, context);
             JobHostQueuesConfiguration queueConfig = new JobHostQueuesConfiguration
             {

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Queues/QueueProcessorFactoryContextTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Queues/QueueProcessorFactoryContextTests.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using Microsoft.Azure.WebJobs.Host.Queues;
+using Microsoft.WindowsAzure.Storage.Queue;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Host.UnitTests.Queues
+{
+    public class QueueProcessorFactoryContextTests
+    {
+        [Fact]
+        public void Constructor_DefaultsValues()
+        {
+            CloudQueue queue = new CloudQueue(new Uri("https://test.queue.core.windows.net/testqueue"));
+            CloudQueue poisonQueue = new CloudQueue(new Uri("https://test.queue.core.windows.net/poisonqueue"));
+            TextWriter log = new StringWriter();
+            JobHostQueuesConfiguration queuesConfig = new JobHostQueuesConfiguration();
+
+            QueueProcessorFactoryContext context = new QueueProcessorFactoryContext(queue, log, queuesConfig, poisonQueue);
+
+            Assert.Same(queue, context.Queue);
+            Assert.Same(log, context.Log);
+            Assert.Same(poisonQueue, context.PoisonQueue);
+
+            Assert.Equal(queuesConfig.BatchSize, context.BatchSize);
+            Assert.Equal(queuesConfig.NewBatchThreshold, context.NewBatchThreshold);
+            Assert.Equal(queuesConfig.MaxDequeueCount, context.MaxDequeueCount);
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
@@ -135,10 +135,12 @@
     <Compile Include="Executors\FunctionResultTests.cs" />
     <Compile Include="Executors\NullInstanceFactoryTests.cs" />
     <Compile Include="FunctionIndexerFactory.cs" />
+    <Compile Include="JobHostQueuesConfigurationTests.cs" />
     <Compile Include="NullExtensionTypeLocator.cs" />
     <Compile Include="Protocols\FunctionStartedMessageExtensionsTests.cs" />
     <Compile Include="Protocols\ProtocolSerializationTests.cs" />
     <Compile Include="Queues\QueueListenerTests.cs" />
+    <Compile Include="Queues\QueueProcessorFactoryContextTests.cs" />
     <Compile Include="StructPropertySetterTests.cs" />
     <Compile Include="StructPropertyGetterTests.cs" />
     <Compile Include="Converters\CultureInfoContext.cs" />


### PR DESCRIPTION
Allowing Queues "NewBatchThreshold" to be configured both globally as well as per queue (via QueueProcessor). We had a customer request for this, the scenario being that they want to experiment with higher levels of concurrency to increase throughput.