### PR TITLE
Support for ServiceBus parallel execution + custom MessageProcessors

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Config/ExtensionConfigContext.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Config/ExtensionConfigContext.cs
@@ -10,8 +10,13 @@ namespace Microsoft.Azure.WebJobs.Host.Config
     public class ExtensionConfigContext
     {
         /// <summary>
-        /// Gets or sets the <see cref="JobHostConfiguration"/>
+        /// Gets or sets the <see cref="JobHostConfiguration"/>.
         /// </summary>
         public JobHostConfiguration Config { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="TraceWriter"/>.
+        /// </summary>
+        public TraceWriter Trace { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionResult.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionResult.cs
@@ -2,12 +2,14 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 
 namespace Microsoft.Azure.WebJobs.Host.Executors
 {
     /// <summary>
     /// Represents the result of a job function invocation.
     /// </summary>
+    [DebuggerDisplay("Succeeded = {Succeeded}")]
     public class FunctionResult
     {
         /// <summary>

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostContextFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostContextFactory.cs
@@ -95,7 +95,8 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
 
             ExtensionConfigContext context = new ExtensionConfigContext
             {
-                Config = config
+                Config = config,
+                Trace = trace
             };
             InvokeExtensionConfigProviders(context);
 

--- a/src/Microsoft.Azure.WebJobs.Host/JobHostQueuesConfiguration.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/JobHostQueuesConfiguration.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.WebJobs.Host
         private const int MaxBatchSize = 32;
 
         private int _batchSize = DefaultBatchSize;
-        private int _newBatchThreshold = DefaultBatchSize;
+        private int _newBatchThreshold;
         private TimeSpan _maxPollingInterval = QueuePollingIntervals.DefaultMaximum;
         private int _maxDequeueCount = DefaultMaxDequeueCount;
 

--- a/src/Microsoft.Azure.WebJobs.Protocols/SingletonParameterLog.cs
+++ b/src/Microsoft.Azure.WebJobs.Protocols/SingletonParameterLog.cs
@@ -20,15 +20,27 @@ namespace Microsoft.Azure.WebJobs.Host.Protocols
     internal class SingletonParameterLog : ParameterLog
 #endif
     {
+        /// <summary>
+        /// Gets or sets the time that has been spent waiting for the lock.
+        /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public TimeSpan? TimeToAcquireLock { get; set; }
 
+        /// <summary>
+        /// Gets or sets the total time the lock was held.
+        /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public TimeSpan? LockDuration { get; set; }
 
+        /// <summary>
+        /// Gets or sets the current lock owner.
+        /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string LockOwner { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether the lock has been acquired.
+        /// </summary>
         public bool LockAcquired { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Config/ServiceBusConfiguration.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Config/ServiceBusConfiguration.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Azure.WebJobs.ServiceBus.Listeners;
+using Microsoft.ServiceBus.Messaging;
 
 namespace Microsoft.Azure.WebJobs.ServiceBus
 {
@@ -12,6 +14,18 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
     {
         private bool _connectionStringSet;
         private string _connectionString;
+
+        /// <summary>
+        /// Constructs a new instance.
+        /// </summary>
+        public ServiceBusConfiguration()
+        {
+            MessageOptions = new OnMessageOptions
+            {
+                MaxConcurrentCalls = 16
+            };
+            MessageProcessorFactory = new DefaultMessageProcessorFactory();
+        }
 
         /// <summary>
         /// Gets or sets the Azure ServiceBus connection string.
@@ -33,6 +47,22 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
                 _connectionString = value;
                 _connectionStringSet = true;
             }
+        }
+
+        /// <summary>
+        /// Gets or sets the default <see cref="OnMessageOptions"/> that will be used by
+        /// message receivers.
+        /// </summary>
+        public OnMessageOptions MessageOptions { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="IMessageProcessorFactory"/> that will be used to create
+        /// <see cref="MessageProcessor"/> instances.
+        /// </summary>
+        public IMessageProcessorFactory MessageProcessorFactory
+        {
+            get;
+            set;
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Config/ServiceBusExtensionConfig.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Config/ServiceBusExtensionConfig.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Config
             IExtensionRegistry extensions = context.Config.GetService<IExtensionRegistry>();
 
             // register our trigger binding provider
-            ServiceBusTriggerAttributeBindingProvider triggerBindingProvider = new ServiceBusTriggerAttributeBindingProvider(nameResolver, _serviceBusConfig);
+            ServiceBusTriggerAttributeBindingProvider triggerBindingProvider = new ServiceBusTriggerAttributeBindingProvider(nameResolver, context.Trace, _serviceBusConfig);
             extensions.RegisterExtension<ITriggerBindingProvider>(triggerBindingProvider);
 
             // register our binding provider

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Listeners/DefaultMessageProcessorFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Listeners/DefaultMessageProcessorFactory.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
+{
+    internal class DefaultMessageProcessorFactory : IMessageProcessorFactory
+    {
+        public MessageProcessor Create(MessageProcessorFactoryContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+            return new MessageProcessor(context);
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Listeners/IMessageProcessorFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Listeners/IMessageProcessorFactory.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.ServiceBus
+{
+    /// <summary>
+    /// Factory for creating <see cref="MessageProcessor"/> instances.
+    /// </summary>
+    public interface IMessageProcessorFactory
+    {
+        /// <summary>
+        /// Creates a <see cref="MessageProcessor"/> using the specified context.
+        /// </summary>
+        /// <param name="context">The <see cref="MessageProcessorFactoryContext"/> to use.</param>
+        /// <returns>A <see cref="MessageProcessor"/> instance.</returns>
+        MessageProcessor Create(MessageProcessorFactoryContext context);
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Listeners/MessageProcessor.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Listeners/MessageProcessor.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.ServiceBus.Messaging;
+
+namespace Microsoft.Azure.WebJobs.ServiceBus
+{
+    /// <summary>
+    /// This class defines a strategy used for processing ServiceBus messages.
+    /// </summary>
+    /// <remarks>
+    /// Custom <see cref="MessageProcessor"/> implementations can be registered by implementing
+    /// a custom <see cref="IMessageProcessorFactory"/> and setting it on the <see cref="ServiceBusConfiguration"/>.
+    /// </remarks>
+    public class MessageProcessor
+    {
+        /// <summary>
+        /// Constructs a new instance.
+        /// </summary>
+        /// <param name="context">The <see cref="MessageProcessorFactoryContext"/> to use.</param>
+        public MessageProcessor(MessageProcessorFactoryContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            MessageOptions = context.MessageOptions;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="OnMessageOptions"/> that will be used by the message receiver.
+        /// </summary>
+        public OnMessageOptions MessageOptions { get; protected set; }
+
+        /// <summary>
+        /// This method is called when there is a new message to process, before the job function is invoked.
+        /// This allows any preprocessing to take place on the message before processing begins.
+        /// </summary>
+        /// <param name="message">The message to process.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
+        /// <returns>True if the message processing should continue, false otherwise.</returns>
+        public virtual async Task<bool> BeginProcessingMessageAsync(BrokeredMessage message, CancellationToken cancellationToken)
+        {
+            return await Task.FromResult<bool>(true);
+        }
+
+        /// <summary>
+        /// This method completes processing of the specified message, after the job function has been invoked.
+        /// </summary>
+        /// <param name="message">The message to complete processing for.</param>
+        /// <param name="result">The <see cref="FunctionResult"/> from the job invocation.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use</param>
+        /// <returns></returns>
+        public virtual async Task CompleteProcessingMessageAsync(BrokeredMessage message, FunctionResult result, CancellationToken cancellationToken)
+        {
+            if (!result.Succeeded)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await message.AbandonAsync();
+            }
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Listeners/MessageProcessorFactoryContext.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Listeners/MessageProcessorFactoryContext.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.ServiceBus.Messaging;
+
+namespace Microsoft.Azure.WebJobs.ServiceBus
+{
+    /// <summary>
+    /// Provides context input for <see cref="IMessageProcessorFactory"/>
+    /// </summary>
+    public class MessageProcessorFactoryContext
+    {
+        /// <summary>
+        /// Constructs a new instance.
+        /// </summary>
+        /// <param name="messageOptions">The default <see cref="OnMessageOptions"/> to use.</param>
+        /// <param name="entityPath">The path to the queue or topic.</param>
+        /// <param name="trace">The <see cref="TraceWriter"/> to use.</param>
+        public MessageProcessorFactoryContext(OnMessageOptions messageOptions, string entityPath, TraceWriter trace)
+        {
+            if (messageOptions == null)
+            {
+                throw new ArgumentNullException("messageOptions");
+            }
+            if (string.IsNullOrEmpty(entityPath))
+            {
+                throw new ArgumentNullException("entityPath");
+            }
+            if (trace == null)
+            {
+                throw new ArgumentNullException("trace");
+            }
+
+            MessageOptions = messageOptions;
+            EntityPath = entityPath;
+            Trace = trace;
+        }
+
+        /// <summary>
+        /// Gets or sets the default <see cref="OnMessageOptions"/> that will be used by
+        /// message receivers.
+        /// </summary>
+        public OnMessageOptions MessageOptions { get; set; }
+
+        /// <summary>
+        /// Gets the path to the ServiceBus queue or topic being processed.
+        /// </summary>
+        public string EntityPath { get; private set; }
+
+        /// <summary>
+        /// Gets the <see cref="TraceWriter"/>.
+        /// </summary>
+        public TraceWriter Trace { get; private set; }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Listeners/ServiceBusQueueListenerFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Listeners/ServiceBusQueueListenerFactory.cs
@@ -3,6 +3,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.ServiceBus;
@@ -17,14 +18,18 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
         private readonly string _queueName;
         private readonly ITriggeredFunctionExecutor _executor;
         private readonly AccessRights _accessRights;
+        private readonly TraceWriter _trace;
+        private readonly ServiceBusConfiguration _config;
 
-        public ServiceBusQueueListenerFactory(ServiceBusAccount account, string queueName, ITriggeredFunctionExecutor executor, AccessRights accessRights)
+        public ServiceBusQueueListenerFactory(ServiceBusAccount account, string queueName, ITriggeredFunctionExecutor executor, AccessRights accessRights, TraceWriter trace, ServiceBusConfiguration config)
         {
             _namespaceManager = account.NamespaceManager;
             _messagingFactory = account.MessagingFactory;
             _queueName = queueName;
             _executor = executor;
             _accessRights = accessRights;
+            _trace = trace;
+            _config = config;
         }
 
         public async Task<IListener> CreateAsync(CancellationToken cancellationToken)
@@ -38,7 +43,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
             }
 
             ServiceBusTriggerExecutor triggerExecutor = new ServiceBusTriggerExecutor(_executor);
-            return new ServiceBusListener(_messagingFactory, _queueName, triggerExecutor);
+            return new ServiceBusListener(_messagingFactory, _queueName, triggerExecutor, _trace, _config);
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Listeners/ServiceBusSubscriptionListenerFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Listeners/ServiceBusSubscriptionListenerFactory.cs
@@ -3,6 +3,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.ServiceBus;
@@ -18,8 +19,10 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
         private readonly string _subscriptionName;
         private readonly ITriggeredFunctionExecutor _executor;
         private readonly AccessRights _accessRights;
+        private readonly TraceWriter _trace;
+        private readonly ServiceBusConfiguration _config;
 
-        public ServiceBusSubscriptionListenerFactory(ServiceBusAccount account, string topicName, string subscriptionName, ITriggeredFunctionExecutor executor, AccessRights accessRights)
+        public ServiceBusSubscriptionListenerFactory(ServiceBusAccount account, string topicName, string subscriptionName, ITriggeredFunctionExecutor executor, AccessRights accessRights, TraceWriter trace, ServiceBusConfiguration config)
         {
             _namespaceManager = account.NamespaceManager;
             _messagingFactory = account.MessagingFactory;
@@ -27,6 +30,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
             _subscriptionName = subscriptionName;
             _executor = executor;
             _accessRights = accessRights;
+            _trace = trace;
+            _config = config;
         }
 
         public async Task<IListener> CreateAsync(CancellationToken cancellationToken)
@@ -43,7 +48,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
             string entityPath = SubscriptionClient.FormatSubscriptionPath(_topicName, _subscriptionName);
 
             ServiceBusTriggerExecutor triggerExecutor = new ServiceBusTriggerExecutor(_executor);
-            return new ServiceBusListener(_messagingFactory, entityPath, triggerExecutor);
+            return new ServiceBusListener(_messagingFactory, entityPath, triggerExecutor, _trace, _config);
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Triggers/ServiceBusTriggerAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Triggers/ServiceBusTriggerAttributeBindingProvider.cs
@@ -26,13 +26,18 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
                 new UserTypeArgumentBindingProvider()); // Must come last, because it will attempt to bind all types.
 
         private readonly INameResolver _nameResolver;
+        private readonly TraceWriter _trace;
         private readonly ServiceBusConfiguration _config;
 
-        public ServiceBusTriggerAttributeBindingProvider(INameResolver nameResolver, ServiceBusConfiguration config)
+        public ServiceBusTriggerAttributeBindingProvider(INameResolver nameResolver, TraceWriter trace, ServiceBusConfiguration config)
         {
             if (nameResolver == null)
             {
                 throw new ArgumentNullException("nameResolver");
+            }
+            if (trace == null)
+            {
+                throw new ArgumentNullException("trace");
             }
             if (config == null)
             {
@@ -40,6 +45,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
             }
 
             _nameResolver = nameResolver;
+            _trace = trace;
             _config = config;
         }
 
@@ -84,11 +90,11 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
 
             if (queueName != null)
             {
-                binding = new ServiceBusTriggerBinding(parameter.Name, parameter.ParameterType, argumentBinding, account, queueName, attribute.Access);
+                binding = new ServiceBusTriggerBinding(parameter.Name, parameter.ParameterType, argumentBinding, account, queueName, attribute.Access, _trace, _config);
             }
             else
             {
-                binding = new ServiceBusTriggerBinding(parameter.Name, argumentBinding, account, topicName, subscriptionName, attribute.Access);
+                binding = new ServiceBusTriggerBinding(parameter.Name, argumentBinding, account, topicName, subscriptionName, attribute.Access, _trace, _config);
             }
 
             return Task.FromResult(binding);

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/WebJobs.ServiceBus.csproj
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/WebJobs.ServiceBus.csproj
@@ -158,8 +158,12 @@
     <Compile Include="Config\ServiceBusExtensionConfig.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="ContentTypes.cs" />
+    <Compile Include="Listeners\DefaultMessageProcessorFactory.cs" />
+    <Compile Include="Listeners\IMessageProcessorFactory.cs" />
+    <Compile Include="Listeners\MessageProcessorFactoryContext.cs" />
     <Compile Include="Listeners\NamespaceManagerExtensions.cs" />
     <Compile Include="Listeners\ServiceBusListener.cs" />
+    <Compile Include="Listeners\MessageProcessor.cs" />
     <Compile Include="Listeners\ServiceBusSubscriptionListenerFactory.cs" />
     <Compile Include="Listeners\ServiceBusQueueListenerFactory.cs" />
     <Compile Include="ServiceBusAccount.cs" />

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Config/ServiceBusExtensionConfigTests.cs
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Config/ServiceBusExtensionConfigTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Diagnostics;
 using System.Linq;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Bindings;
@@ -33,7 +34,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Config
 
             ExtensionConfigContext context = new ExtensionConfigContext
             {
-                Config = config
+                Config = config,
+                Trace = new TestTraceWriter(TraceLevel.Verbose)
             };
             serviceBusExtensionConfig.Initialize(context);
 

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Listeners/ServiceBusListenerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Listeners/ServiceBusListenerTests.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Azure.WebJobs.ServiceBus.Listeners;
+using Microsoft.ServiceBus.Messaging;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Listeners
+{
+    public class ServiceBusListenerTests
+    {
+        private readonly ServiceBusListener _listener;
+        private readonly Mock<ITriggeredFunctionExecutor> _mockExecutor;
+        private readonly Mock<TraceWriter> _mockTraceWriter;
+        private readonly Mock<MessageProcessor> _mockMessageProcessor;
+        private readonly string _entityPath = "test-entity-path";
+
+        public ServiceBusListenerTests()
+        {
+            _mockExecutor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
+            _mockTraceWriter = new Mock<TraceWriter>(MockBehavior.Strict, TraceLevel.Verbose);
+
+            string testConnection = "Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abc123=";
+            MessagingFactory messagingFactory = MessagingFactory.CreateFromConnectionString(testConnection);
+            MessageProcessorFactoryContext context = new MessageProcessorFactoryContext(new OnMessageOptions(), _entityPath, _mockTraceWriter.Object);
+            _mockMessageProcessor = new Mock<MessageProcessor>(MockBehavior.Strict, context);
+            Mock<IMessageProcessorFactory> mockMessageProcessorFactory = new Mock<IMessageProcessorFactory>(MockBehavior.Strict);
+
+            ServiceBusConfiguration config = new ServiceBusConfiguration
+            {
+                MessageProcessorFactory = mockMessageProcessorFactory.Object
+            };
+
+            mockMessageProcessorFactory.Setup(p => p.Create(
+                It.Is<MessageProcessorFactoryContext>(q => 
+                    q.MessageOptions == config.MessageOptions && 
+                    q.Trace == _mockTraceWriter.Object && 
+                    q.EntityPath == _entityPath)))
+                .Returns(_mockMessageProcessor.Object);
+
+            ServiceBusTriggerExecutor triggerExecutor = new ServiceBusTriggerExecutor(_mockExecutor.Object);
+            _listener = new ServiceBusListener(messagingFactory, _entityPath, triggerExecutor, _mockTraceWriter.Object, config);
+        }
+
+        [Fact]
+        public async Task ProcessMessageAsync_Success()
+        {
+            BrokeredMessage message = new BrokeredMessage();
+            CancellationToken cancellationToken = new CancellationToken();
+            _mockMessageProcessor.Setup(p => p.BeginProcessingMessageAsync(message, cancellationToken)).ReturnsAsync(true);
+
+            FunctionResult result = new FunctionResult(true);
+            _mockExecutor.Setup(p => p.TryExecuteAsync(It.Is<TriggeredFunctionData>(q => q.TriggerValue == message), cancellationToken)).ReturnsAsync(result);
+
+            _mockMessageProcessor.Setup(p => p.CompleteProcessingMessageAsync(message, result, cancellationToken)).Returns(Task.FromResult(0));
+
+            await _listener.ProcessMessageAsync(message, CancellationToken.None);
+
+            _mockMessageProcessor.VerifyAll();
+            _mockExecutor.VerifyAll();
+            _mockMessageProcessor.VerifyAll();
+        }
+
+        [Fact]
+        public async Task ProcessMessageAsync_BeginProcessingReturnsFalse_MessageNotProcessed()
+        {
+            BrokeredMessage message = new BrokeredMessage();
+            CancellationToken cancellationToken = new CancellationToken();
+            _mockMessageProcessor.Setup(p => p.BeginProcessingMessageAsync(message, cancellationToken)).ReturnsAsync(false);
+
+            await _listener.ProcessMessageAsync(message, CancellationToken.None);
+
+            _mockMessageProcessor.VerifyAll();
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Listeners/ServiceBusQueueListenerFactoryTests.cs
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Listeners/ServiceBusQueueListenerFactoryTests.cs
@@ -1,10 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Listeners;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.Azure.WebJobs.ServiceBus.Listeners;
 using Microsoft.ServiceBus.Messaging;
 using Moq;
@@ -21,7 +24,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Listeners
         {
             ServiceBusAccount account = new ServiceBusAccount();
             Mock<ITriggeredFunctionExecutor> mockExecutor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
-            ServiceBusQueueListenerFactory factory = new ServiceBusQueueListenerFactory(account, "testqueue", mockExecutor.Object, accessRights);
+            ServiceBusQueueListenerFactory factory = new ServiceBusQueueListenerFactory(account, "testqueue", mockExecutor.Object, accessRights, new TestTraceWriter(TraceLevel.Verbose), new ServiceBusConfiguration());
 
             IListener listener = await factory.CreateAsync(CancellationToken.None);
             Assert.NotNull(listener);

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Triggers/ServiceBusSubscriptionListenerFactoryTests.cs
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Triggers/ServiceBusSubscriptionListenerFactoryTests.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Listeners;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.Azure.WebJobs.ServiceBus.Listeners;
 using Microsoft.ServiceBus.Messaging;
 using Moq;
@@ -21,7 +23,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Listeners
         {
             ServiceBusAccount account = new ServiceBusAccount();
             Mock<ITriggeredFunctionExecutor> mockExecutor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
-            ServiceBusSubscriptionListenerFactory factory = new ServiceBusSubscriptionListenerFactory(account, "testtopic", "testsubscription", mockExecutor.Object, accessRights);
+            ServiceBusSubscriptionListenerFactory factory = new ServiceBusSubscriptionListenerFactory(account, "testtopic", "testsubscription", mockExecutor.Object, accessRights, new TestTraceWriter(TraceLevel.Verbose), new ServiceBusConfiguration());
 
             IListener listener = await factory.CreateAsync(CancellationToken.None);
             Assert.NotNull(listener);

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Triggers/ServiceBusTriggerBindingIntegrationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Triggers/ServiceBusTriggerBindingIntegrationTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Text;
@@ -25,7 +26,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Triggers
             IQueueTriggerArgumentBindingProvider provider = new UserTypeArgumentBindingProvider();
             ParameterInfo pi = new StubParameterInfo("parameterName", typeof(UserDataType));
             var argumentBinding = provider.TryCreate(pi);
-            _binding = new ServiceBusTriggerBinding("parameterName", typeof(UserDataType), argumentBinding, null, "queueName", AccessRights.Manage);
+            _binding = new ServiceBusTriggerBinding("parameterName", typeof(UserDataType), argumentBinding, null, "queueName", AccessRights.Manage, new TestTraceWriter(TraceLevel.Verbose), new ServiceBusConfiguration());
         }
 
         [Theory]

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/WebJobs.ServiceBus.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/WebJobs.ServiceBus.UnitTests.csproj
@@ -100,6 +100,7 @@
     <Compile Include="Bindings\ParameterizedServiceBusPathTests.cs" />
     <Compile Include="Config\ServiceBusJobHostConfigurationExtensionsTests.cs" />
     <Compile Include="Config\ServiceBusExtensionConfigTests.cs" />
+    <Compile Include="Listeners\ServiceBusListenerTests.cs" />
     <Compile Include="Listeners\ServiceBusQueueListenerFactoryTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Listeners\NamespaceManagerExtensionsTests.cs" />


### PR DESCRIPTION
This PR addresses the issues discussed in #275. Specifically, it includes the following:

- new ServiceBusConfiguration.OnMessageOptions global default (for simplicity)
- Default OnMessageOptions now has concurrency set to 5 (was left at default 1 previously)
- added MessageProcessor which allows custom message processors to be used per queue/topic
- MessageProcessors are created by ServiceBusConfiguration.MessageProcessorFactory - the default   factory can be replaced to take control of creation, return custom processors, etc.