### PR TITLE
Perf work for Dashboard logging and ServiceBus (PrefetchCount)

### DIFF
--- a/CustomDictionary.xml
+++ b/CustomDictionary.xml
@@ -69,7 +69,8 @@
       <Word>MessagingProvider</Word>
       <Word>CloudBlobContainer</Word>
       <Word>SingletonAttribute</Word>
-	  </Recognized>
+      <Word>Prefetch</Word>
+	</Recognized>
     <Deprecated/>
     <Compound>
       <Term CompoundAlternate="CancellationToken">cancellationToken</Term>

--- a/Settings.StyleCop
+++ b/Settings.StyleCop
@@ -22,6 +22,7 @@
       <Value>eTag</Value>
       <Value>bindable</Value>
 	  <Value>dequeue</Value>
+	  <Value>Prefetch</Value>
     </CollectionProperty>
   </GlobalSettings>
   <Parsers>

--- a/src/Dashboard/Properties/AssemblyInfo.cs
+++ b/src/Dashboard/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyVersion("1.2.0.0")]
-[assembly: AssemblyFileVersion("1.2.0.0")]
+[assembly: AssemblyVersion("1.1.1.0")]
+[assembly: AssemblyFileVersion("1.1.1.0")]
 
 [assembly: InternalsVisibleTo("Dashboard.UnitTests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostContextFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostContextFactory.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
                 }
                 else
                 {
-                    functionInstanceLogger = (IFunctionInstanceLogger)(await((IFunctionInstanceLoggerProvider)loggerProvider).GetAsync(combinedCancellationToken));
+                    functionInstanceLogger = await((IFunctionInstanceLoggerProvider)loggerProvider).GetAsync(combinedCancellationToken);
                 }
 
                 IFunctionOutputLogger functionOutputLogger = null;
@@ -153,7 +153,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
                 }
                 else
                 {
-                    functionOutputLogger = (IFunctionOutputLogger)(await((IFunctionOutputLoggerProvider)loggerProvider).GetAsync(combinedCancellationToken));
+                    functionOutputLogger = await((IFunctionOutputLoggerProvider)loggerProvider).GetAsync(combinedCancellationToken);
                 }
 
                 if (functionExecutor == null)

--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/BlobFunctionOutputLogger.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/BlobFunctionOutputLogger.cs
@@ -15,8 +15,7 @@ namespace Microsoft.Azure.WebJobs.Host.Loggers
         private readonly IStorageBlobDirectory _outputLogDirectory;
 
         public BlobFunctionOutputLogger(IStorageBlobClient client)
-            : this(client.GetContainerReference(
-                HostContainerNames.Hosts).GetDirectoryReference(HostDirectoryNames.OutputLogs))
+            : this(client.GetContainerReference(HostContainerNames.Hosts).GetDirectoryReference(HostDirectoryNames.OutputLogs))
         {
         }
 
@@ -25,13 +24,11 @@ namespace Microsoft.Azure.WebJobs.Host.Loggers
             _outputLogDirectory = outputLogDirectory;
         }
 
-        public async Task<IFunctionOutputDefinition> CreateAsync(IFunctionInstance instance,
-            CancellationToken cancellationToken)
+        public async Task<IFunctionOutputDefinition> CreateAsync(IFunctionInstance instance, CancellationToken cancellationToken)
         {
             await _outputLogDirectory.Container.CreateIfNotExistsAsync(cancellationToken);
 
             string namePrefix = instance.Id.ToString("N");
-
             LocalBlobDescriptor outputBlob = CreateDescriptor(_outputLogDirectory, namePrefix + ".txt");
             LocalBlobDescriptor parameterLogBlob = CreateDescriptor(_outputLogDirectory, namePrefix + ".params.txt");
 

--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/ConsoleFunctionOutputDefinition.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/ConsoleFunctionOutputDefinition.cs
@@ -26,10 +26,9 @@ namespace Microsoft.Azure.WebJobs.Host.Loggers
         }
 
         [SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]
-        public Task<IFunctionOutput> CreateOutputAsync(CancellationToken cancellationToken)
+        public IFunctionOutput CreateOutput()
         {
-            IFunctionOutput output = new ConsoleFunctionOutputLog();
-            return Task.FromResult(output);
+            return new ConsoleFunctionOutputLog();
         }
 
         public IRecurrentCommand CreateParameterLogUpdateCommand(IReadOnlyDictionary<string, IWatcher> watches, TraceWriter trace)

--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/DefaultLoggerProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/DefaultLoggerProvider.cs
@@ -69,8 +69,7 @@ namespace Microsoft.Azure.WebJobs.Host.Loggers
             {
                 // Create logging against a live Azure account.
                 IStorageBlobClient dashboardBlobClient = dashboardAccount.CreateBlobClient();
-                IPersistentQueueWriter<PersistentQueueMessage> queueWriter =
-                    new PersistentQueueWriter<PersistentQueueMessage>(dashboardBlobClient);
+                IPersistentQueueWriter<PersistentQueueMessage> queueWriter = new PersistentQueueWriter<PersistentQueueMessage>(dashboardBlobClient);
                 PersistentQueueLogger queueLogger = new PersistentQueueLogger(queueWriter);
                 _hostInstanceLogger = queueLogger;
                 _functionInstanceLogger = new CompositeFunctionInstanceLogger(queueLogger, traceWriterFunctionLogger);

--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/IFunctionOutputDefinition.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/IFunctionOutputDefinition.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Protocols;
 using Microsoft.Azure.WebJobs.Host.Timers;
@@ -16,7 +15,7 @@ namespace Microsoft.Azure.WebJobs.Host.Loggers
 
         LocalBlobDescriptor ParameterLogBlob { get; }
 
-        Task<IFunctionOutput> CreateOutputAsync(CancellationToken cancellationToken);
+        IFunctionOutput CreateOutput();
 
         IRecurrentCommand CreateParameterLogUpdateCommand(IReadOnlyDictionary<string, IWatcher> watches, TraceWriter trace);
     }

--- a/src/Microsoft.Azure.WebJobs.Host/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Properties/AssemblyInfo.cs
@@ -5,8 +5,8 @@ using System.Reflection;
 using System.Resources;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyVersion("1.2.0.0")]
-[assembly: AssemblyFileVersion("1.2.0.0")]
+[assembly: AssemblyVersion("1.1.1.0")]
+[assembly: AssemblyFileVersion("1.1.1.0")]
 
 [assembly: InternalsVisibleTo("Dashboard.UnitTests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]

--- a/src/Microsoft.Azure.WebJobs.Protocols/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Azure.WebJobs.Protocols/Properties/AssemblyInfo.cs
@@ -3,5 +3,5 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("1.2.0.0")]
-[assembly: AssemblyFileVersion("1.2.0.0")]
+[assembly: AssemblyVersion("1.1.1.0")]
+[assembly: AssemblyFileVersion("1.1.1.0")]

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Config/ServiceBusConfiguration.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Config/ServiceBusConfiguration.cs
@@ -51,9 +51,14 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
 
         /// <summary>
         /// Gets or sets the default <see cref="OnMessageOptions"/> that will be used by
-        /// message receivers.
+        /// <see cref="MessageReceiver"/>s.
         /// </summary>
         public OnMessageOptions MessageOptions { get; set; }
+
+        /// <summary>
+        /// Gets or sets the default PrefetchCount that will be used by <see cref="MessageReceiver"/>s.
+        /// </summary>
+        public int PrefetchCount { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="MessagingProvider"/> that will be used to create

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/GlobalSuppressions.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/GlobalSuppressions.cs
@@ -2,3 +2,4 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "AzureWebJobs", Scope = "member", Target = "Microsoft.Azure.WebJobs.ServiceBus.MessagingProvider.#GetConnectionString(System.String)")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Prefetch", Scope = "member", Target = "Microsoft.Azure.WebJobs.ServiceBus.ServiceBusConfiguration.#PrefetchCount")]

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/MessageProcessor.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/MessageProcessor.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         }
 
         /// <summary>
-        /// Gets the <see cref="OnMessageOptions"/> that will be used by the message receiver.
+        /// Gets the <see cref="OnMessageOptions"/> that will be used by the <see cref="MessageReceiver"/>.
         /// </summary>
         public OnMessageOptions MessageOptions { get; protected set; }
 

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/MessagingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/MessagingProvider.cs
@@ -78,6 +78,31 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         }
 
         /// <summary>
+        /// Creates a <see cref="MessageReceiver"/> for the specified ServiceBus entity.
+        /// </summary>
+        /// <remarks>
+        /// You can override this method to customize the <see cref="MessageReceiver"/>.
+        /// </remarks>
+        /// <param name="factory">The <see cref="MessagingFactory"/> to use.</param>
+        /// <param name="entityPath">The ServiceBus entity to create a <see cref="MessageReceiver"/> for.</param>
+        /// <returns></returns>
+        public virtual MessageReceiver CreateMessageReceiver(MessagingFactory factory, string entityPath)
+        {
+            if (factory == null)
+            {
+                throw new ArgumentNullException("factory");
+            }
+            if (string.IsNullOrEmpty(entityPath))
+            {
+                throw new ArgumentNullException("entityPath");
+            }
+
+            MessageReceiver receiver = factory.CreateMessageReceiver(entityPath);
+            receiver.PrefetchCount = _config.PrefetchCount;
+            return receiver;
+        }
+
+        /// <summary>
         /// Gets the connection string for the specified connection string name.
         /// If no value is specified, the default connection string will be returned.
         /// </summary>

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyVersion("1.2.0.0")]
-[assembly: AssemblyFileVersion("1.2.0.0")]
+[assembly: AssemblyVersion("1.1.1.0")]
+[assembly: AssemblyFileVersion("1.1.1.0")]
 
 [assembly: InternalsVisibleTo("Microsoft.Azure.WebJobs.ServiceBus.UnitTests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]

--- a/src/Microsoft.Azure.WebJobs.Storage/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Azure.WebJobs.Storage/Properties/AssemblyInfo.cs
@@ -3,5 +3,5 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("1.2.0.0")]
-[assembly: AssemblyFileVersion("1.2.0.0")]
+[assembly: AssemblyVersion("1.1.1.0")]
+[assembly: AssemblyFileVersion("1.1.1.0")]

--- a/src/Microsoft.Azure.WebJobs/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Azure.WebJobs/Properties/AssemblyInfo.cs
@@ -3,5 +3,5 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("1.2.0.0")]
-[assembly: AssemblyFileVersion("1.2.0.0")]
+[assembly: AssemblyVersion("1.1.1.0")]
+[assembly: AssemblyFileVersion("1.1.1.0")]

--- a/src/Microsoft.Azure.WebJobs/TraceLevelAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs/TraceLevelAttribute.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+
+namespace Microsoft.Azure.WebJobs
+{
+    /// <summary>
+    /// Attribute used to specify <see cref="TraceLevel"/> for job functions.
+    /// This setting will affect both Console logging as well as Dashboard logging.
+    /// </summary>
+    /// <remarks>
+    /// For very high throughput functions where performance is key you can set the
+    /// level to <see cref="TraceLevel.Off"/> if you don't want any logs (Console or
+    /// Dashboard) to be produced. Dashboard logging is somewhat expensive, so this
+    /// can improve your throughput. You can also choose to set the level to
+    /// <see cref="TraceLevel.Error"/> and logs will only be written for function
+    /// invocations that fail.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
+    public sealed class TraceLevelAttribute : Attribute
+    {
+        /// <summary>
+        /// Constructs a new instance.
+        /// </summary>
+        /// <param name="level">The <see cref="TraceLevel"/> to use for the function.</param>
+        public TraceLevelAttribute(TraceLevel level)
+        {
+            Level = level;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="TraceLevel"/> to use for the function.
+        /// </summary>
+        public TraceLevel Level { get; private set; }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs/WebJobs.csproj
+++ b/src/Microsoft.Azure.WebJobs/WebJobs.csproj
@@ -73,6 +73,7 @@
     <Compile Include="NoAutomaticTriggerAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TimeoutAttribute.cs" />
+    <Compile Include="TraceLevelAttribute.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\Common\PublicKey.snk">

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/NullFunctionOutputLoggerProvider.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/NullFunctionOutputLoggerProvider.cs
@@ -23,8 +23,7 @@ namespace Microsoft.Azure.WebJobs.Host.TestCommon
 
         private class NullFunctionOutputLogger : IFunctionOutputLogger
         {
-            public Task<IFunctionOutputDefinition> CreateAsync(IFunctionInstance instance,
-                CancellationToken cancellationToken)
+            public Task<IFunctionOutputDefinition> CreateAsync(IFunctionInstance instance, CancellationToken cancellationToken)
             {
                 IFunctionOutputDefinition outputDefinition = new NullFunctionOutputDefinition();
                 return Task.FromResult(outputDefinition);
@@ -43,10 +42,9 @@ namespace Microsoft.Azure.WebJobs.Host.TestCommon
                 get { return null; }
             }
 
-            public Task<IFunctionOutput> CreateOutputAsync(CancellationToken cancellationToken)
+            public IFunctionOutput CreateOutput()
             {
-                IFunctionOutput output = new NullFunctionOutput();
-                return Task.FromResult(output);
+                return new NullFunctionOutput();
             }
 
             public IRecurrentCommand CreateParameterLogUpdateCommand(IReadOnlyDictionary<string, IWatcher> watches, TraceWriter trace)

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/FunctionExecutorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/FunctionExecutorTests.cs
@@ -125,6 +125,32 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             Assert.Equal("Timeout value of 00:01:00 exceeded by function 'Functions.MethodLevel' (Id: 'b2d1dd72-80e2-412b-a22e-3b4558f378b4'). Initiating cancellation.", trace.Message);
         }
 
+        [Fact]
+        public void GetFunctionTraceLevel_ReturnsExpectedLevel()
+        {
+            _mockFunctionInstance.SetupGet(p => p.Reason).Returns(ExecutionReason.AutomaticTrigger);
+
+            _descriptor.Method = typeof(Functions).GetMethod("MethodLevel", BindingFlags.Static | BindingFlags.Public);
+            TraceLevel result = FunctionExecutor.GetFunctionTraceLevel(_mockFunctionInstance.Object);
+            Assert.Equal(TraceLevel.Verbose, result);
+
+            _descriptor.Method = typeof(Functions).GetMethod("TraceLevelOverride_Off", BindingFlags.Static | BindingFlags.Public);
+            result = FunctionExecutor.GetFunctionTraceLevel(_mockFunctionInstance.Object);
+            Assert.Equal(TraceLevel.Off, result);
+
+            _descriptor.Method = typeof(Functions).GetMethod("TraceLevelOverride_Error", BindingFlags.Static | BindingFlags.Public);
+            result = FunctionExecutor.GetFunctionTraceLevel(_mockFunctionInstance.Object);
+            Assert.Equal(TraceLevel.Error, result);
+
+            _mockFunctionInstance.SetupGet(p => p.Reason).Returns(ExecutionReason.Dashboard);
+            result = FunctionExecutor.GetFunctionTraceLevel(_mockFunctionInstance.Object);
+            Assert.Equal(TraceLevel.Verbose, result);
+
+            _mockFunctionInstance.SetupGet(p => p.Reason).Returns(ExecutionReason.HostCall);
+            result = FunctionExecutor.GetFunctionTraceLevel(_mockFunctionInstance.Object);
+            Assert.Equal(TraceLevel.Verbose, result);
+        }
+
         public static void GlobalLevel(CancellationToken cancellationToken)
         {
         }
@@ -142,6 +168,16 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             }
 
             public static void NoCancellationTokenParameter()
+            {
+            }
+
+            [TraceLevel(TraceLevel.Off)]
+            public static void TraceLevelOverride_Off()
+            {
+            }
+
+            [TraceLevel(TraceLevel.Error)]
+            public static void TraceLevelOverride_Error()
             {
             }
         }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/UpdateOutputLogCommandTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/UpdateOutputLogCommandTests.cs
@@ -18,8 +18,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
         {
             string content = null;
             Func<string, CancellationToken, Task> fp = (x, _) => { content = x; return Task.FromResult(0); };
-            UpdateOutputLogCommand writer = UpdateOutputLogCommand.CreateAsync(new Mock<IStorageBlockBlob>().Object,
-                null, fp, CancellationToken.None).GetAwaiter().GetResult();
+            UpdateOutputLogCommand writer = UpdateOutputLogCommand.Create(new Mock<IStorageBlockBlob>().Object, fp);
 
             var tw = writer.Output;
             tw.Write("1");

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
@@ -22,8 +22,9 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             // The DLL containing the binding attributes should be truly minimal and have no extra dependencies. 
             var names = GetAssemblyReferences(typeof(QueueTriggerAttribute).Assembly);
 
-            Assert.Equal(1, names.Count);
+            Assert.Equal(2, names.Count);
             Assert.Equal("mscorlib", names[0]);
+            Assert.Equal("System", names[1]);
         }
 
         [Fact]
@@ -63,7 +64,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 "SingletonMode",
                 "StorageAccountAttribute",
                 "DisableAttribute",
-                "TimeoutAttribute"
+                "TimeoutAttribute",
+                "TraceLevelAttribute"
             };
 
             AssertPublicTypes(expected, assembly);

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Config/ServiceBusConfigurationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Config/ServiceBusConfigurationTests.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Config
         {
             ServiceBusConfiguration config = new ServiceBusConfiguration();
             Assert.Equal(16, config.MessageOptions.MaxConcurrentCalls);
+            Assert.Equal(0, config.PrefetchCount);
         }
 
         [Fact]
@@ -26,6 +27,15 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Config
             string testConnection = "testconnection";
             config.ConnectionString = testConnection;
             Assert.Equal(testConnection, config.ConnectionString);
+        }
+
+        [Fact]
+        public void PrefetchCount_GetSet()
+        {
+            ServiceBusConfiguration config = new ServiceBusConfiguration();
+            Assert.Equal(0, config.PrefetchCount);
+            config.PrefetchCount = 100;
+            Assert.Equal(100, config.PrefetchCount);
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/MessagingProviderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/MessagingProviderTests.cs
@@ -52,6 +52,18 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests
         }
 
         [Fact]
+        public void CreateMessageReceiver_ReturnsExpectedReceiver()
+        {
+            MessagingFactory factory = _provider.CreateMessagingFactory("test");
+            MessageReceiver receiver = _provider.CreateMessageReceiver(factory, "test");
+            Assert.Equal("test", receiver.Path);
+
+            _config.PrefetchCount = 100;
+            receiver = _provider.CreateMessageReceiver(factory, "test");
+            Assert.Equal(100, receiver.PrefetchCount);
+        }
+
+        [Fact]
         public void GetConnectionString_ThrowsIfConnectionStringNullOrEmpty()
         {
             var ex = Assert.Throws<InvalidOperationException>(() =>

--- a/tools/NuGetProj.settings.targets
+++ b/tools/NuGetProj.settings.targets
@@ -4,8 +4,8 @@
     <WebJobsRootPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\'))</WebJobsRootPath>
     <WebJobsToolsPath>$(MSBuildThisFileDirectory)</WebJobsToolsPath>
     <WebJobsPackageEULA>http://www.microsoft.com/web/webpi/eula/aspnetcomponent_rtw_enu.htm</WebJobsPackageEULA>
-    <Version>1.2.0</Version>
-    <PrereleaseTag>alpha</PrereleaseTag>
+    <Version>1.1.1</Version>
+    <PrereleaseTag>-alpha</PrereleaseTag>
   </PropertyGroup>
   <Choose>
     <When Condition=" '$(IncludeBuildNumberInVersion)' == '1'">


### PR DESCRIPTION
Adding a new **TraceLevelAttribute** that can be applied at the class/method level to control Console/Dashboard logging for a particular function. The idea is to allow very high scale functions to opt out of Dashboard logging (since this logging introduces a bit of overhead) to increase throughput. Notes on this feature:

* If the TraceLevel is set to Off for a function, no Console or Dashboard logs will be written for function invocations
* If the TraceLevel is set to Error for a function, normal invocations will not produce logs, but if a function errors it will produce logs (both Console and Dashboard)
* When functions are invoked manually via Dashboard Run/Replay, or via JobHost.Call, any TraceLevelAttribute annotation will be ignored, and normal full logs will be produced. This facilitates development/debugging, while retaining the benefits of actual steady state production behavior.

Adding a **ServiceBusConfiguration.PrefetchCount** setting to allow users to easily configure this for performance. The value will be applied to all MessageReceivers the runtime creates (`MessageReceiver.PrefetchCount`). Also adding a new virtual method **MessagingProvider.CreateMessageReceiver** to allow users to further customize MessageReceivers as needed. Users can override this to to return a receiver they have configured.

Using these two new features (setting PrefetchCount to 100), we are able to achieve throughput parity for a high scale ServiceBus job function (below). In my testing, this function could process the same number of messages per second as a non-WebJobs ServiceBus MessageReceiver configured with the same settings. In my testing, I was pushing this to ~800 messages per second on a single instance.

```csharp
[TraceLevel(TraceLevel.Error)]
public static async Task ProcessMessageAsync(
    [ServiceBusTrigger("perftest")] BrokeredMessage message)
{
    Program.MessageProcessed();
    await Task.Delay(10);
}
```