### PR TITLE
fixing test cases and build warnings

### DIFF
--- a/WebJobs.sln
+++ b/WebJobs.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{639967B0-0544-4C52-94AC-9A3D25E33256}"
 EndProject
@@ -47,6 +47,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebJobs.ServiceBus.UnitTest
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebJobs.Host.FunctionalTests", "test\Microsoft.Azure.WebJobs.Host.FunctionalTests\WebJobs.Host.FunctionalTests.csproj", "{C6B834AB-7B6A-47AE-A7C3-C102B0C861FF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestApplication", "TestApplication\TestApplication.csproj", "{54BFA19E-30AF-4D31-8A99-B0ECA0D4093C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -110,6 +112,10 @@ Global
 		{C6B834AB-7B6A-47AE-A7C3-C102B0C861FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C6B834AB-7B6A-47AE-A7C3-C102B0C861FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C6B834AB-7B6A-47AE-A7C3-C102B0C861FF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{54BFA19E-30AF-4D31-8A99-B0ECA0D4093C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{54BFA19E-30AF-4D31-8A99-B0ECA0D4093C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{54BFA19E-30AF-4D31-8A99-B0ECA0D4093C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{54BFA19E-30AF-4D31-8A99-B0ECA0D4093C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Microsoft.Azure.WebJobs.Host/Blobs/Listeners/ContainerScanInfo.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Blobs/Listeners/ContainerScanInfo.cs
@@ -11,12 +11,12 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
 {
     internal class ContainerScanInfo
     {
-        public ICollection<ITriggerExecutor<IStorageBlob>> Registrations;
+        public ICollection<ITriggerExecutor<IStorageBlob>> Registrations { get; set; }
 
-        public DateTime LastSweepCycleStartTime;
+        public DateTime LastSweepCycleStartTime { get; set; }
 
-        public DateTime CurrentSweepCycleStartTime;
+        public DateTime CurrentSweepCycleStartTime { get; set; }
 
-        public BlobContinuationToken ContinuationToken;
+        public BlobContinuationToken ContinuationToken { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Blobs/Listeners/ScanBlobScanLogHybridPollingStrategy.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Blobs/Listeners/ScanBlobScanLogHybridPollingStrategy.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
         public ScanBlobScanLogHybridPollingStrategy() : base()
         {
             _scanInfo = new Dictionary<IStorageBlobContainer, ContainerScanInfo>(new StorageBlobContainerComparer());
-            _pollLogStrategy = new PollLogsStrategy();
+            _pollLogStrategy = new PollLogsStrategy(performInitialScan: false);
             _cancellationTokenSource = new CancellationTokenSource();
             _blobsFoundFromScanOrNotification = new ConcurrentQueue<IStorageBlob>();
         }
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
                 containerScanInfo = new ContainerScanInfo()
                 {
                     Registrations = new List<ITriggerExecutor<IStorageBlob>>(),
-                    LastSweepCycleStartTime = DateTime.MaxValue,
+                    LastSweepCycleStartTime = DateTime.MinValue,
                     CurrentSweepCycleStartTime = DateTime.MinValue,
                     ContinuationToken = null
                 };

--- a/src/Microsoft.Azure.WebJobs.Host/Blobs/Listeners/ScanBlobScanLogHybridPollingStrategy.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Blobs/Listeners/ScanBlobScanLogHybridPollingStrategy.cs
@@ -19,17 +19,15 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
 {
     internal sealed class ScanBlobScanLogHybridPollingStrategy : IBlobListenerStrategy
     {
-        private static readonly TimeSpan _pollintInterval = TimeSpan.FromSeconds(10);
-        private enum PollStrategy { ScanBlobs, ScanLogs, NotDetermined };
-
+        private static readonly TimeSpan PollingtInterval = TimeSpan.FromSeconds(10);
+        private readonly IDictionary<IStorageBlobContainer, ContainerScanInfo> _scanInfo;
+        private readonly ConcurrentQueue<IStorageBlob> _blobsFoundFromScanOrNotification;
+        private readonly CancellationTokenSource _cancellationTokenSource;
         // A budget is allocated representing the number of blobs to be listed in a polling 
         // interval, each container will get its share of _scanBlobLimitPerPoll/number of containers.
         // this share will be listed for each container each polling interval
         private int _scanBlobLimitPerPoll = 10000;
-        private readonly IDictionary<IStorageBlobContainer, ContainerScanInfo> _scanInfo;
-        private readonly ConcurrentQueue<IStorageBlob> _blobsFoundFromScanOrNotification;
         private PollLogsStrategy _pollLogStrategy;
-        private readonly CancellationTokenSource _cancellationTokenSource;
         private bool _disposed;
 
         public ScanBlobScanLogHybridPollingStrategy() : base()
@@ -68,7 +66,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
                 containerScanInfo = new ContainerScanInfo()
                 {
                     Registrations = new List<ITriggerExecutor<IStorageBlob>>(),
-                    LastSweepCycleStartTime = DateTime.MinValue,
+                    LastSweepCycleStartTime = DateTime.MaxValue,
                     CurrentSweepCycleStartTime = DateTime.MinValue,
                     ContinuationToken = null
                 };
@@ -82,7 +80,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
         {
             ThrowIfDisposed();
 
-            Task LogPollingTask = _pollLogStrategy.ExecuteAsync(cancellationToken);
+            Task logPollingTask = _pollLogStrategy.ExecuteAsync(cancellationToken);
             List<IStorageBlob> failedNotifications = new List<IStorageBlob>();
             List<Task> notifications = new List<Task>();
 
@@ -102,7 +100,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
             await Task.WhenAll(notifications);
 
             List<Task> pollingTasks = new List<Task>();
-            pollingTasks.Add(LogPollingTask);
+            pollingTasks.Add(logPollingTask);
 
             foreach (KeyValuePair<IStorageBlobContainer, ContainerScanInfo> containerScanInfoPair in _scanInfo)
             {
@@ -118,12 +116,11 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
             await Task.WhenAll(pollingTasks);
 
             // Run subsequent iterations at "_pollingInterval" second intervals.
-            return new TaskSeriesCommandResult(wait: Task.Delay(_pollintInterval));
+            return new TaskSeriesCommandResult(wait: Task.Delay(PollingtInterval));
         }
 
         private async Task PollAndNotify(IStorageBlobContainer container, ContainerScanInfo containerInfo, CancellationToken cancellationToken, List<IStorageBlob> failedNotifications)
         {
-
             cancellationToken.ThrowIfCancellationRequested();
             IEnumerable<IStorageBlob> newBlobs = await PollNewBlobsAsync(container, containerInfo, cancellationToken);
 
@@ -163,10 +160,10 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
         /// budget of allocated number of blobs to query, for each container we query a page of 
         /// that size and we keep the continuation token for the next time. AS a curser, we use
         /// the time stamp when the current cycle on the container started. blobs newer than that
-        /// time will be considered new and registerations will be notified
+        /// time will be considered new and registrations will be notified
         /// </summary>
         /// <param name="container"></param>
-        /// <param name="containerScanInfo"> Information that includes the lastcycle start
+        /// <param name="containerScanInfo"> Information that includes the last cycle start
         /// the continuation token and the current cycle start for a container</param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>

--- a/src/Microsoft.Azure.WebJobs.Host/Blobs/Listeners/SharedBlobListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Blobs/Listeners/SharedBlobListener.cs
@@ -99,7 +99,6 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
             {
                 return new ScanContainersStrategy();
             }
-
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/FunctionalTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/FunctionalTest.cs
@@ -338,7 +338,7 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
                 host.Start();
 
                 // Act
-                completed = task.WaitUntilCompleted(10 * 1000);
+                completed = task.WaitUntilCompleted(25 * 1000);
 
                 // Assert
                 Assert.True(completed);


### PR DESCRIPTION
3 fixes included
1- fixing warnings caused by coding style 
2- fixing the test case BlobTrigger_IfWritesToSecondBlobTrigger_TriggersOutputQuickly, the test case assumed that the polling interval was 2 seconds thus waited for 10 seconds only, now that the polling is 10 seconds I increased the wait time to 25, 20 is the worst case wait + extra 5 seconds for processing
3- in the hybrid stragegy, 2 initial scans were happening, disabled one and only the scan in logpolling takes place 
