### PR TITLE
Making FunctionIndexingException public

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostContextFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostContextFactory.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             ISharedContextProvider sharedContextProvider = new SharedContextProvider();
 
             // Create a wrapper TraceWriter that delegates to both the user 
-            // TraceWriter specified on Config (if present), as well as to Console
+            // TraceWriters specified via config (if present), as well as to Console
             TraceWriter trace = new ConsoleTraceWriter(config.Tracing, consoleProvider.Out);
 
             // Register system services with the service container
@@ -163,7 +163,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
 
                 if (functionIndexProvider == null)
                 {
-                    functionIndexProvider = new FunctionIndexProvider(typeLocator, triggerBindingProvider, bindingProvider, activator, functionExecutor, extensions, singletonManager);
+                    functionIndexProvider = new FunctionIndexProvider(typeLocator, triggerBindingProvider, bindingProvider, activator, functionExecutor, extensions, singletonManager, trace);
                 }
 
                 IFunctionIndex functions = await functionIndexProvider.GetAsync(combinedCancellationToken);

--- a/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexProvider.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
         private readonly IFunctionExecutor _executor;
         private readonly IExtensionRegistry _extensions;
         private readonly SingletonManager _singletonManager;
+        private readonly TraceWriter _trace;
 
         private IFunctionIndex _index;
 
@@ -30,7 +31,8 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
             IJobActivator activator,
             IFunctionExecutor executor,
             IExtensionRegistry extensions,
-            SingletonManager singletonManager)
+            SingletonManager singletonManager,
+            TraceWriter trace)
         {
             if (typeLocator == null)
             {
@@ -67,6 +69,11 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
                 throw new ArgumentNullException("singletonManager");
             }
 
+            if (trace == null)
+            {
+                throw new ArgumentNullException("trace");
+            }
+
             _typeLocator = typeLocator;
             _triggerBindingProvider = triggerBindingProvider;
             _bindingProvider = bindingProvider;
@@ -74,6 +81,7 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
             _executor = executor;
             _extensions = extensions;
             _singletonManager = singletonManager;
+            _trace = trace;
         }
 
         public async Task<IFunctionIndex> GetAsync(CancellationToken cancellationToken)
@@ -89,7 +97,7 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
         private async Task<IFunctionIndex> CreateAsync(CancellationToken cancellationToken)
         {
             FunctionIndex index = new FunctionIndex();
-            FunctionIndexer indexer = new FunctionIndexer(_triggerBindingProvider, _bindingProvider, _activator, _executor, _extensions, _singletonManager);
+            FunctionIndexer indexer = new FunctionIndexer(_triggerBindingProvider, _bindingProvider, _activator, _executor, _extensions, _singletonManager, _trace);
             IReadOnlyList<Type> types = _typeLocator.GetTypes();
 
             foreach (Type type in types)

--- a/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexer.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexer.cs
@@ -27,8 +27,9 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
         private readonly IFunctionExecutor _executor;
         private readonly HashSet<Assembly> _jobAttributeAssemblies;
         private readonly SingletonManager _singletonManager;
+        private readonly TraceWriter _trace;
 
-        public FunctionIndexer(ITriggerBindingProvider triggerBindingProvider, IBindingProvider bindingProvider, IJobActivator activator, IFunctionExecutor executor, IExtensionRegistry extensions, SingletonManager singletonManager)
+        public FunctionIndexer(ITriggerBindingProvider triggerBindingProvider, IBindingProvider bindingProvider, IJobActivator activator, IFunctionExecutor executor, IExtensionRegistry extensions, SingletonManager singletonManager, TraceWriter trace)
         {
             if (triggerBindingProvider == null)
             {
@@ -60,19 +61,45 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
                 throw new ArgumentNullException("singletonManager");
             }
 
+            if (trace == null)
+            {
+                throw new ArgumentNullException("trace");
+            }
+
             _triggerBindingProvider = triggerBindingProvider;
             _bindingProvider = bindingProvider;
             _activator = activator;
             _executor = executor;
             _singletonManager = singletonManager;
             _jobAttributeAssemblies = GetJobAttributeAssemblies(extensions);
+            _trace = trace;
         }
 
         public async Task IndexTypeAsync(Type type, IFunctionIndexCollector index, CancellationToken cancellationToken)
         {
             foreach (MethodInfo method in type.GetMethods(PublicMethodFlags).Where(IsJobMethod))
             {
-                await IndexMethodAsync(method, index, cancellationToken);
+                try
+                {
+                    await IndexMethodAsync(method, index, cancellationToken);
+                }
+                catch (FunctionIndexingException fex)
+                {
+                    // Route the indexing exception through the TraceWriter pipeline
+                    _trace.Error(fex.Message, fex);
+
+                    // If the error has been marked as handled, ignore the indexing exception
+                    // and continue on to the rest of the methods. In this case the method in
+                    // error simply won't be running in the JobHost.
+                    if (fex.Handled)
+                    {
+                        continue;
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
             }
         }
 
@@ -130,7 +157,7 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
             }
             catch (Exception exception)
             {
-                throw new FunctionIndexingException(method.Name, exception);
+                throw new FunctionIndexingException(method.GetShortName(), exception);
             }
         }
 

--- a/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexingException.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexingException.cs
@@ -3,17 +3,68 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.Serialization;
 
 namespace Microsoft.Azure.WebJobs.Host.Indexers
 {
-    [SuppressMessage("Microsoft.Design", "CA1064:ExceptionsShouldBePublic")]
+    /// <summary>
+    /// Exception that occurs when the <see cref="JobHost"/> encounters errors when trying
+    /// to index job methods on startup.
+    /// </summary>
     [SuppressMessage("Microsoft.Design", "CA1032:ImplementStandardExceptionConstructors")]
     [Serializable]
-    internal class FunctionIndexingException : Exception
+    public class FunctionIndexingException : Exception
     {
+        /// <summary>
+        /// Constructs a new instance.
+        /// </summary>
+        /// <param name="methodName">The name of the method in error.</param>
+        /// <param name="innerException">The inner exception.</param>
         public FunctionIndexingException(string methodName, Exception innerException)
             : base("Error indexing method '" + methodName + "'", innerException)
         {
+            MethodName = methodName;
+        }
+
+        /// <summary>
+        /// Constructs a new instance.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/>.</param>
+        /// <param name="context">The <see cref="StreamingContext"/>.</param>
+        protected FunctionIndexingException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+            if (info == null)
+            {
+                throw new ArgumentNullException("info");
+            }
+
+            MethodName = info.GetString("MethodName");
+            Handled = bool.Parse(info.GetString("Handled"));
+        }
+
+        /// <summary>
+        /// The name of the method in error.
+        /// </summary>
+        public string MethodName { get; private set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the exception should be treated
+        /// as handled.
+        /// </summary>
+        public bool Handled { get; set; }
+
+        /// <inheritdoc/>
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            if (info == null)
+            {
+                throw new ArgumentNullException("info");
+            }
+
+            info.AddValue("MethodName", this.MethodName);
+            info.AddValue("Handled", this.Handled);
+
+            base.GetObjectData(info, context);
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/FunctionalTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/FunctionalTest.cs
@@ -250,7 +250,7 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
             ITypeLocator typeLocator = new FakeTypeLocator(programType);
             FunctionIndexProvider functionIndexProvider = new FunctionIndexProvider(
                 typeLocator, triggerBindingProvider, bindingProvider,
-                activator, executor, extensions, singletonManager);
+                activator, executor, extensions, singletonManager, trace);
 
             IJobHostContextFactory contextFactory = new FakeJobHostContextFactory
             {

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/HostStartTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/HostStartTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
             {
                 // Act & Assert
                 FunctionIndexingException exception = Assert.Throws<FunctionIndexingException>(() => host.Start());
-                Assert.Equal("Error indexing method 'Invalid'", exception.Message);
+                Assert.Equal("Error indexing method 'InvalidQueueNameProgram.Invalid'", exception.Message);
                 Exception innerException = exception.InnerException;
                 Assert.IsType<ArgumentException>(innerException);
                 ArgumentException argumentException = (ArgumentException)innerException;

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/JobHostFactory.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/JobHostFactory.cs
@@ -60,9 +60,10 @@ namespace Microsoft.Azure.WebJobs.Host.TestCommon
 
             SingletonManager singletonManager = new SingletonManager();
 
+            TraceWriter trace = new TestTraceWriter(TraceLevel.Verbose);
             IFunctionOutputLoggerProvider outputLoggerProvider = new NullFunctionOutputLoggerProvider();
             IFunctionOutputLogger outputLogger = outputLoggerProvider.GetAsync(CancellationToken.None).Result;
-            IFunctionExecutor executor = new FunctionExecutor(new NullFunctionInstanceLogger(), outputLogger, BackgroundExceptionDispatcher.Instance, new TestTraceWriter(TraceLevel.Verbose), null);
+            IFunctionExecutor executor = new FunctionExecutor(new NullFunctionInstanceLogger(), outputLogger, BackgroundExceptionDispatcher.Instance, trace, null);
 
             var triggerBindingProvider = DefaultTriggerBindingProvider.Create(
                     nameResolver, storageAccountProvider, extensionTypeLocator, hostIdProvider, queueConfiguration,
@@ -72,7 +73,7 @@ namespace Microsoft.Azure.WebJobs.Host.TestCommon
             var bindingProvider = DefaultBindingProvider.Create(nameResolver, storageAccountProvider, extensionTypeLocator,
                         messageEnqueuedWatcherAccessor, blobWrittenWatcherAccessor, extensions);
 
-            var functionIndexProvider = new FunctionIndexProvider(new FakeTypeLocator(typeof(TProgram)), triggerBindingProvider, bindingProvider, DefaultJobActivator.Instance, executor, new DefaultExtensionRegistry(), singletonManager);
+            var functionIndexProvider = new FunctionIndexProvider(new FakeTypeLocator(typeof(TProgram)), triggerBindingProvider, bindingProvider, DefaultJobActivator.Instance, executor, new DefaultExtensionRegistry(), singletonManager, trace);
 
             IJobHostContextFactory contextFactory = new TestJobHostContextFactory
             {

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/FunctionIndexerFactory.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/FunctionIndexerFactory.cs
@@ -50,16 +50,17 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 extensionTypeLocator, messageEnqueuedWatcherAccessor,
                 blobWrittenWatcherAccessor, new DefaultExtensionRegistry());
 
+            TraceWriter trace = new TestTraceWriter(TraceLevel.Verbose);
             IFunctionOutputLoggerProvider outputLoggerProvider = new NullFunctionOutputLoggerProvider();
             IFunctionOutputLogger outputLogger = outputLoggerProvider.GetAsync(CancellationToken.None).Result;
-            IFunctionExecutor executor = new FunctionExecutor(new NullFunctionInstanceLogger(), outputLogger, BackgroundExceptionDispatcher.Instance, new TestTraceWriter(TraceLevel.Verbose), null);
+            IFunctionExecutor executor = new FunctionExecutor(new NullFunctionInstanceLogger(), outputLogger, BackgroundExceptionDispatcher.Instance, trace, null);
 
             if (extensionRegistry == null)
             {
                 extensionRegistry = new DefaultExtensionRegistry();
             }
 
-            return new FunctionIndexer(triggerBindingProvider, bindingProvider, DefaultJobActivator.Instance, executor, extensionRegistry, new SingletonManager());
+            return new FunctionIndexer(triggerBindingProvider, bindingProvider, DefaultJobActivator.Instance, executor, extensionRegistry, new SingletonManager(), trace);
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Indexers/FunctionIndexerIntegrationErrorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Indexers/FunctionIndexerIntegrationErrorTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -11,6 +12,7 @@ using Microsoft.Azure.WebJobs.Host.Config;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Indexers;
 using Microsoft.Azure.WebJobs.Host.Storage.Blob;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.Azure.WebJobs.Host.Triggers;
 using Moq;
 using Xunit;
@@ -39,7 +41,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Indexers
                     new Mock<IJobActivator>(MockBehavior.Strict).Object,
                     executorMock.Object,
                     extensionsMock.Object,
-                    new SingletonManager());
+                    new SingletonManager(),
+                    new TestTraceWriter(TraceLevel.Verbose));
 
                 Assert.Throws<FunctionIndexingException>(() => indexer.IndexMethodAsync(method, stubIndex, CancellationToken.None).GetAwaiter().GetResult());
             }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
@@ -137,7 +137,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 "IBindingDataProvider",
                 "FunctionInvocationException",
                 "TraceEvent",
-                "BindingTemplateExtensions"
+                "BindingTemplateExtensions",
+                "FunctionIndexingException"
             };
 
             AssertPublicTypes(expected, assembly);


### PR DESCRIPTION
And flowing it through TraceWriter pipeline. This supports scenarios where a user might want to register a TraceWriter that inspects/acts upon indexing exceptions.