### PR TITLE
JobHost.CallAsync can now handle Task.WhenAll.

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Executors/TaskMethodInvoker.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/TaskMethodInvoker.cs
@@ -52,6 +52,13 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
                 return null;
             }
 
+            // Secondary check: static Task methods sometimes return nested Task types which
+            // fail the first check, but aren't generic types and throw an exception below.
+            if (!taskType.IsGenericType)
+            {
+                return null;
+            }
+
             Debug.Assert(taskType.IsGenericType);
             Debug.Assert(!taskType.IsGenericTypeDefinition);
             Type genericTypeDefinition = taskType.GetGenericTypeDefinition();


### PR DESCRIPTION
The Task.WhenAll (and Task.WhenAny) methods return an internal or
private class representing the wrapped tasks at hand. This causes the
CallAsync method to fail, because it attempts to retrieve the generic
parameters when there are none.

Support for WhenAny is not included as this returns a nested task, and
is explicitly tested for and forbidden.

Fixes #660.