### PR TITLE
Adding back TraceWriter function instance logging to FastLogger

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostContextFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostContextFactory.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             FunctionExecutor functionExecutor = null,
             IFunctionIndexProvider functionIndexProvider = null,
             IBindingProvider bindingProvider = null,
-            IHostInstanceLoggerProvider hostInstanceLogerProvider = null,
+            IHostInstanceLoggerProvider hostInstanceLoggerProvider = null,
             IFunctionInstanceLoggerProvider functionInstanceLoggerProvider = null,
             IFunctionOutputLoggerProvider functionOutputLoggerProvider = null,
             IBackgroundExceptionDispatcher backgroundExceptionDispatcher = null,
@@ -119,15 +119,15 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             bool noDashboardStorage = config.DashboardConnectionString == null;
             if (hasFastTableHook && noDashboardStorage)
             {
-                var loggerProvider = new FastTableLoggerProvider();
-                hostInstanceLogerProvider = loggerProvider;
+                var loggerProvider = new FastTableLoggerProvider(trace);
+                hostInstanceLoggerProvider = loggerProvider;
                 functionInstanceLoggerProvider = loggerProvider;
                 functionOutputLoggerProvider = loggerProvider;
             }
             else
             {
                 var loggerProvider = new DefaultLoggerProvider(storageAccountProvider, trace);
-                hostInstanceLogerProvider = loggerProvider;
+                hostInstanceLoggerProvider = loggerProvider;
                 functionInstanceLoggerProvider = loggerProvider;
                 functionOutputLoggerProvider = loggerProvider;
             }
@@ -145,7 +145,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
 
                 IStorageAccount dashboardAccount = await storageAccountProvider.GetDashboardAccountAsync(combinedCancellationToken);
 
-                IHostInstanceLogger hostInstanceLogger = await hostInstanceLogerProvider.GetAsync(combinedCancellationToken);                
+                IHostInstanceLogger hostInstanceLogger = await hostInstanceLoggerProvider.GetAsync(combinedCancellationToken);                
                 IFunctionInstanceLogger functionInstanceLogger = await functionInstanceLoggerProvider.GetAsync(combinedCancellationToken);                
                 IFunctionOutputLogger functionOutputLogger = await functionOutputLoggerProvider.GetAsync(combinedCancellationToken);
                 

--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/FastTableLoggerProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/FastTableLoggerProvider.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -23,11 +22,12 @@ namespace Microsoft.Azure.WebJobs.Host.Loggers
         IFunctionOutputLogger
     {
         private IHostInstanceLogger _hostInstanceLogger;
-        private IFunctionInstanceLogger _nullInstanceLogger = new NullInstanceLogger();
+        private IFunctionInstanceLogger _traceWriterFunctionLogger;
 
-        public FastTableLoggerProvider()
+        public FastTableLoggerProvider(TraceWriter trace)
         {
             _hostInstanceLogger = new NullHostInstanceLogger();
+            _traceWriterFunctionLogger = new TraceWriterFunctionInstanceLogger(trace);
         }
 
         Task<IFunctionOutputLogger> IFunctionOutputLoggerProvider.GetAsync(CancellationToken cancellationToken)
@@ -43,32 +43,13 @@ namespace Microsoft.Azure.WebJobs.Host.Loggers
 
         Task<IFunctionInstanceLogger> IFunctionInstanceLoggerProvider.GetAsync(CancellationToken cancellationToken)
         {
-            // No instance loggin
-            return Task.FromResult<IFunctionInstanceLogger>(_nullInstanceLogger);
+            return Task.FromResult<IFunctionInstanceLogger>(_traceWriterFunctionLogger);
         }
 
         Task<IFunctionOutputDefinition> IFunctionOutputLogger.CreateAsync(IFunctionInstance instance, CancellationToken cancellationToken)
         {
             IFunctionOutputDefinition x = new PerFunc();
             return Task.FromResult(x);
-        }
-        
-        private class NullInstanceLogger : IFunctionInstanceLogger
-        {
-            public Task DeleteLogFunctionStartedAsync(string startedMessageId, CancellationToken cancellationToken)
-            {
-                return Task.FromResult(0);
-            }
-
-            public Task LogFunctionCompletedAsync(FunctionCompletedMessage message, CancellationToken cancellationToken)
-            {
-                return Task.FromResult(0);
-            }
-
-            public Task<string> LogFunctionStartedAsync(FunctionStartedMessage message, CancellationToken cancellationToken)
-            {
-                return Task.FromResult(string.Empty);
-            }
         }
 
         private class PerFunc : IFunctionOutputDefinition, IFunctionOutput


### PR DESCRIPTION
We still need to route function instance events through the TraceWriterFunctionInstanceLogger to allow registered TraceWriters to receive the events. This is also the mechanism that invocations are written to Console when running locally.

Discovered this in Functions - previously we would get function started/completed events and log them, but that was broken with the FastLogger changes. Console logging was broken as well.

@MikeStall Can you take a look? I've verified these changes locally - they fix the issue in Functions.