### PR TITLE
Remove storage emulator checks

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Executors/StorageAccountParseResult.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/StorageAccountParseResult.cs
@@ -4,14 +4,13 @@
 namespace Microsoft.Azure.WebJobs.Host.Executors
 {
     /// <summary>
-    /// Enumerates list of possible errors detected by the <see cref="StorageAccountParser"/> while trying to 
+    /// Enumerates list of possible errors detected by the <see cref="StorageAccountParser"/> while trying to
     /// parse Microsoft Azure Cloud Storage account.
     /// </summary>
     internal enum StorageAccountParseResult
     {
         Success,
         MissingOrEmptyConnectionStringError,
-        MalformedConnectionStringError,
-        EmulatorIsNotSupportedError
+        MalformedConnectionStringError
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/StorageAccountParser.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/StorageAccountParser.cs
@@ -10,7 +10,7 @@ using Microsoft.WindowsAzure.Storage;
 namespace Microsoft.Azure.WebJobs.Host.Executors
 {
     /// <summary>
-    /// Utility class designed to parse given connection string and create instance of the 
+    /// Utility class designed to parse given connection string and create instance of the
     /// <see cref="CloudStorageAccount"/>.
     /// </summary>
     internal sealed class StorageAccountParser : IStorageAccountParser
@@ -58,12 +58,6 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
                 return StorageAccountParseResult.MalformedConnectionStringError;
             }
 
-            if (StorageClient.IsDevelopmentStorageAccount(possibleAccount))
-            {
-                account = null;
-                return StorageAccountParseResult.EmulatorIsNotSupportedError;
-            }
-
             account = possibleAccount;
             return StorageAccountParseResult.Success;
         }
@@ -95,13 +89,6 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
                         "The Microsoft Azure Storage account connection string is not formatted " +
                         "correctly. Please visit http://msdn.microsoft.com/en-us/library/windowsazure/ee758697.aspx for " +
                         "details about configuring Microsoft Azure Storage connection strings.",
-                        connectionStringName);
-
-                case StorageAccountParseResult.EmulatorIsNotSupportedError:
-                    return String.Format(CultureInfo.CurrentCulture,
-                        "Failed to validate Microsoft Azure WebJobs SDK {0} account. " + 
-                        "The Microsoft Azure Storage Emulator is not supported, please use a " +
-                        "Microsoft Azure Storage account hosted in Microsoft Azure.",
                         connectionStringName);
             }
 

--- a/src/Microsoft.Azure.WebJobs.Host/StorageClient.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/StorageClient.cs
@@ -40,18 +40,9 @@ namespace Microsoft.Azure.WebJobs.Host
             return credentials.AccountName;
         }
 
-        public static bool IsDevelopmentStorageAccount(CloudStorageAccount account)
-        {
-            // see the section "Addressing local storage resources" in http://msdn.microsoft.com/en-us/library/windowsazure/hh403989.aspx 
-            return String.Equals(
-                account.BlobEndpoint.PathAndQuery.TrimStart('/'),
-                account.Credentials.AccountName,
-                StringComparison.OrdinalIgnoreCase);
-        }
-
         public static bool IsDevelopmentStorageAccount(IStorageAccount account)
         {
-            // see the section "Addressing local storage resources" in http://msdn.microsoft.com/en-us/library/windowsazure/hh403989.aspx 
+            // see the section "Addressing local storage resources" in http://msdn.microsoft.com/en-us/library/windowsazure/hh403989.aspx
             return String.Equals(
                 account.BlobEndpoint.PathAndQuery.TrimStart('/'),
                 account.Credentials.AccountName,

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/StorageAccountParserTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/StorageAccountParserTests.cs
@@ -10,28 +10,6 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
     public class StorageAccountParserTests
     {
         [Fact]
-        public void TryParseAccount_WithEmulator_Fails()
-        {
-            string connectionString = "UseDevelopmentStorage=true";
-            CloudStorageAccount ignore;
-            
-            StorageAccountParseResult result = StorageAccountParser.TryParseAccount(connectionString, out ignore);
-
-            Assert.Equal(StorageAccountParseResult.EmulatorIsNotSupportedError, result);
-        }
-
-        [Fact]
-        public void TryParseAccount_WithProxiedEmulator_Fails()
-        {
-            string connectionString = "UseDevelopmentStorage=true;DevelopmentStorageProxyUri=http://myProxyUri";
-            CloudStorageAccount ignore;
-
-            StorageAccountParseResult result = StorageAccountParser.TryParseAccount(connectionString, out ignore);
-
-            Assert.Equal(StorageAccountParseResult.EmulatorIsNotSupportedError, result);
-        }
-
-        [Fact]
         public void TryParseAccount_WithEmpty_Fails()
         {
             string connectionString = string.Empty;


### PR DESCRIPTION
This isn't really meant to be merged, more to open the discussion brought up in #53.

Based on the comment by @davidebbo I removed the checks and was able to use blob and queue triggers with the storage emulator.

This is my full test app https://github.com/Azure/azure-webjobs-sdk/issues/53#issuecomment-215989639

I then used the [Azure Storage Explorer](http://storageexplorer.com/) to add text documents to the blob container, and messages to the queue. Both actions triggered their respective job to run and output the correct contents in the console.