### PR TITLE
Fix handling 'out object[]'  for Generic AsyncCollector. In this case…

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingFactory.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
             }
 
             return new GenericAsyncCollectorBindingProvider<TAttribute, TConstructorArgument>(
-                _nameResolver, _converterManager, asyncCollectorType, constructorParameterBuilder);
+                _nameResolver,  asyncCollectorType, constructorParameterBuilder);
         }
 
         /// <summary>

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/TestJobHost.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/TestJobHost.cs
@@ -35,5 +35,10 @@ namespace Microsoft.Azure.WebJobs.Host.TestCommon
         {
             return base.CallAsync(typeof(TProgram).GetMethod(methodName), arguments, cancellationToken);
         }
+
+        public Task CallAsync(string methodName, object arguments)
+        {
+            return base.CallAsync(typeof(TProgram).GetMethod(methodName), arguments);
+        }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Common/CollectorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Common/CollectorTests.cs
@@ -49,22 +49,15 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         [Fact]
         public void TestError()
         {
-            JobHostConfiguration config = new JobHostConfiguration()
-            {
-                TypeLocator = new FakeTypeLocator(typeof(ErrorProgram))
-            };
-
             FakeQueueClient client = new FakeQueueClient();
-            IExtensionRegistry extensions = config.GetService<IExtensionRegistry>();
-            extensions.RegisterExtension<IExtensionConfigProvider>(client);
 
             // Call 'ok' method which has no errors. Should still get the indexing errors from the other method. 
-            JobHost host = new JobHost(config);
+            var host = TestHelpers.NewJobHost<ErrorProgram>(client);
             var m = typeof(ErrorProgram).GetMethod("ValidMethod");
 
             try
             {
-                host.Call(m); // Will force indexing. 
+                host.Call("ValidMethod"); // Will force indexing. 
             }
             catch (FunctionIndexingException e)
             {
@@ -187,16 +180,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         [Fact]
         public void Test()
         {
-            JobHostConfiguration config = new JobHostConfiguration()
-            {
-                TypeLocator = new FakeTypeLocator(typeof(Functions))
-            };
-
             FakeQueueClient client = new FakeQueueClient();
-            IExtensionRegistry extensions = config.GetService<IExtensionRegistry>();
-            extensions.RegisterExtension<IExtensionConfigProvider>(client);
-
-            JobHost host = new JobHost(config);            
+            var host = TestHelpers.NewJobHost<Functions>(client);
             
             var p7 = Invoke(host, client, "SendDirectClient");
             Assert.Equal(1, p7.Length);

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Common/FakeItemTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Common/FakeItemTests.cs
@@ -47,28 +47,20 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         {
             var nr = new DictNameResolver();
             nr.Add("appsetting1", "val1");
-            JobHostConfiguration config = new JobHostConfiguration()
-            {
-                TypeLocator = new FakeTypeLocator(typeof(Functions)),
-                NameResolver = nr
-            };
 
             var client = new FakeItemClient();
             client._dict["ModifyInPlace"] = new Item
             {
                 value = 123
             };
-            IExtensionRegistry extensions = config.GetService<IExtensionRegistry>();
-            extensions.RegisterExtension<IExtensionConfigProvider>(client);
-
-            JobHost host = new JobHost(config);
+            
+            var host = TestHelpers.NewJobHost<Functions>(nr, client);
 
             // With out parameter 
             {
                 client._dict["SetToNull"] = new Item(); // should get ovewritten with null
 
-                var method = typeof(Functions).GetMethod("SetToNull");
-                host.Call(method);
+                host.Call("SetToNull");
 
                 var item = (Item)client._dict["SetToNull"];
                 Assert.Equal(null, item);
@@ -76,8 +68,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
 
             // Modifying in-place
             {
-                var method = typeof(Functions).GetMethod("ModifyInPlace");
-                host.Call(method);
+                host.Call("ModifyInPlace");
 
                 var item = (Item)client._dict["ModifyInPlace"];
                 Assert.Equal(124, item.value);

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Common/HostCallTestsWithBindingData.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Common/HostCallTestsWithBindingData.cs
@@ -148,27 +148,14 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         private async Task<string> Invoke<TFunction>(object arguments) where TFunction : FunctionBase, new()
         {
             var activator = new FakeActivator();
-            JobHostConfiguration config = new JobHostConfiguration()
-            {
-                TypeLocator = new FakeTypeLocator(typeof(TFunction)),
-                JobActivator = activator,
-
-                // Pure in-memory, no storage. 
-                HostId = Guid.NewGuid().ToString("n"),
-                DashboardConnectionString = null,
-                StorageConnectionString = null
-            };
             TFunction testInstance = new TFunction();
             activator.Add(testInstance);
 
-            IExtensionRegistry extensions = config.GetService<IExtensionRegistry>();
             FakeExtClient client = new FakeExtClient();
-            extensions.RegisterExtension<IExtensionConfigProvider>(client);
 
-            JobHost host = new JobHost(config);
+            var host = TestHelpers.NewJobHost<TFunction>(activator, client); 
 
-            var method = typeof(TFunction).GetMethod("Func");
-            await host.CallAsync(method, arguments);
+            await host.CallAsync("Func", arguments);
 
             var x = testInstance._sb.ToString();
 

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Common/TriggerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Common/TriggerTests.cs
@@ -221,17 +221,9 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Common
             var func1 = new TFunction();
             activator.Add(func1);
 
-            JobHostConfiguration config = new JobHostConfiguration()
-            {
-                TypeLocator = new FakeTypeLocator(typeof(TFunction)),
-                JobActivator = activator
-            };
-
             FakeQueueClient client = new FakeQueueClient();
-            IExtensionRegistry extensions = config.GetService<IExtensionRegistry>();
-            extensions.RegisterExtension<IExtensionConfigProvider>(client);
 
-            JobHost host = new JobHost(config);
+            var host = TestHelpers.NewJobHost<TFunction>(client, activator);
 
             foreach (var item in items)
             {


### PR DESCRIPTION
…, it shouldn't use a converter manager.

Add more tests and helper for easily creating a JobHost.