### PR TITLE
Add validate hook for index-type validate.

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/AttributeCloner.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/AttributeCloner.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
                             // Resolve %% once upfront. This ensures errors will occur during indexing time. 
                             str = nameResolver.ResolveWholeString(str);
                             BindingTemplate template = BindingTemplate.FromString(str);
-                            getArgFuncs[i] = (bindingData) => template.Bind(bindingData);
+                            getArgFuncs[i] = (bindingData) => TemplateBind(template, bindingData);
                         }
                     }
                 }
@@ -117,7 +117,7 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
                                     str = nameResolver.ResolveWholeString(str);
                                     BindingTemplate template = BindingTemplate.FromString(str);
 
-                                    setFunc = (newAttr, bindingData) => prop.SetValue(newAttr, template.Bind(bindingData));
+                                    setFunc = (newAttr, bindingData) => prop.SetValue(newAttr, TemplateBind(template, bindingData));
                                 }
                             }
 
@@ -137,6 +137,22 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
                 // error!!!
                 throw new InvalidOperationException("Can't figure out which ctor to call.");
             }
+        }
+
+        private static string TemplateBind(BindingTemplate template, IReadOnlyDictionary<string, object> bindingData)
+        {
+            if (bindingData == null)
+            {
+                return template.Pattern;
+            }
+            return template.Bind(bindingData);
+        }
+
+        // Get a attribute with %% resolved, but not runtime {} resolved. 
+        public TAttribute GetNameResolvedAttribute()
+        {
+            TAttribute attr = ResolveFromBindings(null);
+            return attr;
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic")]

--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingFactory.cs
@@ -57,7 +57,21 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
         {
             return new FilteringBindingProvider(predicate, innerRule);
         }
-        
+
+        /// <summary>
+        /// Creating a validation predicate around another rule. 
+        /// The predicate is only run if the inner rule is applied. 
+        /// </summary>
+        /// <param name="validator">a validator function to invoke on the attribute before runtime. </param>
+        /// <param name="innerRule">Inner rule. </param>
+        /// <returns></returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic")]
+        public IBindingProvider AddValidator<TAttribute>(Func<TAttribute, Type, Task> validator, IBindingProvider innerRule)
+            where TAttribute : Attribute
+        {
+            return new ValidatingWrapperBindingProvider<TAttribute>(validator, this._nameResolver, innerRule);
+        }
+
         /// <summary>
         /// Create a rule that returns an IValueBinder from a resolved attribute. IValueBinder will let you have an OnCompleted hook that 
         /// is invoked after the user function completes. 

--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingFactory.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
         /// <param name="innerRule">Inner rule. </param>
         /// <returns></returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic")]
-        public IBindingProvider AddValidator<TAttribute>(Func<TAttribute, Type, Task> validator, IBindingProvider innerRule)
+        public IBindingProvider AddValidator<TAttribute>(Action<TAttribute, Type> validator, IBindingProvider innerRule)
             where TAttribute : Attribute
         {
             return new ValidatingWrapperBindingProvider<TAttribute>(validator, this._nameResolver, innerRule);

--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingProviders/ValidatingWrapperBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingProviders/ValidatingWrapperBindingProvider.cs
@@ -12,11 +12,11 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
     internal class ValidatingWrapperBindingProvider<TAttribute> : IBindingProvider
         where TAttribute : Attribute
     {
-        private readonly Func<TAttribute, Type, Task> _validator;
+        private readonly Action<TAttribute, Type> _validator;
         private readonly IBindingProvider _inner;
         private readonly INameResolver _nameResolver;
 
-        public ValidatingWrapperBindingProvider(Func<TAttribute, Type, Task> validator, INameResolver nameResolver, IBindingProvider inner)
+        public ValidatingWrapperBindingProvider(Action<TAttribute, Type> validator, INameResolver nameResolver, IBindingProvider inner)
         {
             _validator = validator;
             _inner = inner;
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
 
                 var cloner = new AttributeCloner<TAttribute>(attr, _nameResolver);
                 var attrNameResolved = cloner.GetNameResolvedAttribute();
-                await _validator(attrNameResolved, parameterType);
+                _validator(attrNameResolved, parameterType);
             }
 
             return binding;

--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingProviders/ValidatingWrapperBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingProviders/ValidatingWrapperBindingProvider.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.WebJobs.Host.Bindings
+{
+    // Applies a local validator function for just a specific rule. 
+    // Validator only runs if the inner rule claims it. 
+    internal class ValidatingWrapperBindingProvider<TAttribute> : IBindingProvider
+        where TAttribute : Attribute
+    {
+        private readonly Func<TAttribute, Type, Task> _validator;
+        private readonly IBindingProvider _inner;
+        private readonly INameResolver _nameResolver;
+
+        public ValidatingWrapperBindingProvider(Func<TAttribute, Type, Task> validator, INameResolver nameResolver, IBindingProvider inner)
+        {
+            _validator = validator;
+            _inner = inner;
+            _nameResolver = nameResolver;
+        }
+
+        public async Task<IBinding> TryCreateAsync(BindingProviderContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var binding = await _inner.TryCreateAsync(context);
+
+            if (binding != null)
+            {
+                // Only run the validator if the inner binding claims it. 
+                // Expected this will throw on errors. 
+                Type parameterType = context.Parameter.ParameterType;
+                var attr = context.Parameter.GetCustomAttribute<TAttribute>();
+
+                var cloner = new AttributeCloner<TAttribute>(attr, _nameResolver);
+                var attrNameResolved = cloner.GetNameResolvedAttribute();
+                await _validator(attrNameResolved, parameterType);
+            }
+
+            return binding;
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Config/ExtensionConfigContext.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Config/ExtensionConfigContext.cs
@@ -23,5 +23,5 @@ namespace Microsoft.Azure.WebJobs.Host.Config
         /// The <see cref="JobHost"/> being configured.
         /// </summary>
         public JobHost Host { get; set; }
-    }
+    }    
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Config/ExtensionConfigContextExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Config/ExtensionConfigContextExtensions.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+
+namespace Microsoft.Azure.WebJobs.Host.Config
+{
+    /// <summary>
+    /// Helper Extension methods for extension configuration. 
+    /// </summary>
+    public static class ExtensionConfigContextExtensions
+    {
+        /// <summary>
+        /// Register a set of rules to handle binding to a given attribute. 
+        /// </summary>
+        /// <typeparam name="TAttribute">The attribute to bind to</typeparam>
+        /// <param name="context"></param>
+        /// <param name="validator">a validator function to invoke on the attribute before runtime. </param>
+        /// <param name="bindingProviders">list of binding providers to handle this attribute. 
+        /// If none of these handle the attribute, an error is thrown at indexing. </param>
+        public static void RegisterBindingRules<TAttribute>(
+            this ExtensionConfigContext context,
+            Action<TAttribute, Type> validator,
+            params IBindingProvider[] bindingProviders)
+            where TAttribute : Attribute
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+            if (validator == null)
+            {
+                throw new ArgumentNullException("validator");
+            }
+            if (bindingProviders == null)
+            {
+                throw new ArgumentNullException("bindingProviders");
+            }
+            
+            IExtensionRegistry extensions = context.Config.GetService<IExtensionRegistry>();
+            INameResolver nameResolver = context.Config.NameResolver;
+            extensions.RegisterBindingRules<TAttribute>(validator, nameResolver, bindingProviders);
+        }
+
+        /// <summary>
+        /// Register a set of rules to handle binding to a given attribute. 
+        /// </summary>
+        /// <typeparam name="TAttribute">The attribute to bind to</typeparam>
+        /// <param name="context"></param>
+        /// <param name="bindingProviders">list of binding providers to handle this attribute. 
+        /// If none of these handle the attribute, an error is thrown at indexing. </param>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter")]
+        public static void RegisterBindingRules<TAttribute>(
+            this ExtensionConfigContext context,
+            params IBindingProvider[] bindingProviders)
+            where TAttribute : Attribute
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }        
+            if (bindingProviders == null)
+            {
+                throw new ArgumentNullException("bindingProviders");
+            }
+
+            IExtensionRegistry extensions = context.Config.GetService<IExtensionRegistry>();
+            extensions.RegisterBindingRules<TAttribute>(bindingProviders);
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Extensions/IExtensionRegistryExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Extensions/IExtensionRegistryExtensions.cs
@@ -44,6 +44,31 @@ namespace Microsoft.Azure.WebJobs.Host
         }
 
         /// <summary>
+        /// Register a set of binding rules for a given type. The rules are applied in order, first one wins.  
+        /// An catch-all error binding is automatically placed at the end that will raise a binding error if no binder claims it. 
+        /// </summary>
+        /// <param name="registry">The registry instance.</param>
+        /// <param name="validator">Validator function to be called at indexing time for catching upfront errors. </param>
+        /// <param name="nameResolver">NameResolver to pass to validator.</param>
+        /// <param name="bindingProviders">binding rules for a parameter.</param>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter")]
+        public static void RegisterBindingRules<TAttribute>(
+            this IExtensionRegistry registry, 
+            Action<TAttribute, Type> validator, 
+            INameResolver nameResolver, 
+            params IBindingProvider[] bindingProviders)
+            where TAttribute : Attribute
+        {
+            if (registry == null)
+            {
+                throw new ArgumentNullException("registry");
+            }
+
+            var all = new GenericCompositeBindingProvider<TAttribute>(validator, nameResolver, bindingProviders);
+            registry.RegisterExtension<IBindingProvider>(all);
+        }
+
+        /// <summary>
         /// Registers the specified instance. 
         /// </summary>
         /// <typeparam name="TExtension">The service type to register the instance for.</typeparam>

--- a/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
+++ b/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
@@ -367,6 +367,7 @@
     <Compile Include="Bindings\BindingBase.cs" />
     <Compile Include="Bindings\BindingFactory.cs" />
     <Compile Include="Bindings\BindingProviders\AsyncCollectorWithConverterManagerBindingProvider.cs" />
+    <Compile Include="Bindings\BindingProviders\CodeFile1.cs" />
     <Compile Include="Bindings\BindingProviders\FilteringBindingProvider.cs" />
     <Compile Include="Bindings\BindingProviders\GenericCompositeBindingProvider.cs" />
     <Compile Include="Bindings\BindingProviders\GenericAsyncCollectorBindingProvider.cs" />
@@ -393,7 +394,7 @@
     <Compile Include="Blobs\Listeners\ContainerScanInfo.cs" />
     <Compile Include="Blobs\Listeners\ScanBlobScanLogHybridPollingStrategy.cs" />
     <Compile Include="Bindings\AsyncCollector\AsyncCollectorBinding.cs" />
-    <Compile Include="Config\Class1.cs" />
+    <Compile Include="Config\ExtensionConfigContextExtensions.cs" />
     <Compile Include="Triggers\StrategyTriggerBinding.cs" />
     <Compile Include="Bindings\ConstantValueProvider.cs" />
     <Compile Include="Bindings\ConverterManager.cs" />

--- a/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
+++ b/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
@@ -367,7 +367,7 @@
     <Compile Include="Bindings\BindingBase.cs" />
     <Compile Include="Bindings\BindingFactory.cs" />
     <Compile Include="Bindings\BindingProviders\AsyncCollectorWithConverterManagerBindingProvider.cs" />
-    <Compile Include="Bindings\BindingProviders\CodeFile1.cs" />
+    <Compile Include="Bindings\BindingProviders\ValidatingWrapperBindingProvider.cs" />
     <Compile Include="Bindings\BindingProviders\FilteringBindingProvider.cs" />
     <Compile Include="Bindings\BindingProviders\GenericCompositeBindingProvider.cs" />
     <Compile Include="Bindings\BindingProviders\GenericAsyncCollectorBindingProvider.cs" />

--- a/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
+++ b/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
@@ -393,6 +393,7 @@
     <Compile Include="Blobs\Listeners\ContainerScanInfo.cs" />
     <Compile Include="Blobs\Listeners\ScanBlobScanLogHybridPollingStrategy.cs" />
     <Compile Include="Bindings\AsyncCollector\AsyncCollectorBinding.cs" />
+    <Compile Include="Config\Class1.cs" />
     <Compile Include="Triggers\StrategyTriggerBinding.cs" />
     <Compile Include="Bindings\ConstantValueProvider.cs" />
     <Compile Include="Bindings\ConverterManager.cs" />

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/FakeNameResolver.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/FakeNameResolver.cs
@@ -13,6 +13,13 @@ namespace Microsoft.Azure.WebJobs.Host.TestCommon
         {
             return _dict[name];
         }
+
+        // Fluid method for adding entries. 
+        public FakeNameResolver Add(string key, string value)
+        {
+            _dict[key] = value;
+            return this;
+        }
     }
 
 }

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/TestHelpers.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/TestHelpers.cs
@@ -1,8 +1,10 @@
 ﻿using Microsoft.Azure.WebJobs.Host.Config;
+using Microsoft.Azure.WebJobs.Host.Indexers;
 using System;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Host.TestCommon
 {
@@ -36,6 +38,25 @@ namespace Microsoft.Azure.WebJobs.Host.TestCommon
         {
             FieldInfo field = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
             field.SetValue(target, value);
+        }
+
+        // Test that we get an indexing error (FunctionIndexingException)  
+        // functionName - the function name that has the indexing error. 
+        // expectedErrorMessage - inner exception's message with details.
+        // Invoking func() should cause an indexing error. 
+        public static void AssertIndexingError(Action func, string functionName, string expectedErrorMessage)
+        {
+            try
+            {
+                func(); // expected indexing error
+            }
+            catch (FunctionIndexingException e)
+            {
+                Assert.Equal("Error indexing method '" + functionName + "'", e.Message);
+                Assert.Equal(expectedErrorMessage, e.InnerException.Message);
+                return;
+            }
+            Assert.True(false, "Invoker should have failed");
         }
 
         // Helper to quickly create a new JobHost object from a set of services. 

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Common/HostCallTestsWithBindingData.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Common/HostCallTestsWithBindingData.cs
@@ -141,7 +141,9 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
 
                 var msg2 = "No value for named parameter 'k2'.";
                 Assert.Equal(msg2, e.InnerException.InnerException.Message);
-            }            
+                return;
+            }
+            Assert.True(false, "Invoker should have failed");
         }
 
         // Helper to invoke the method with the given parameters

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Common/ValidationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Common/ValidationTests.cs
@@ -117,10 +117,9 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Common
                 context.RegisterBindingRules<TestAttribute>(rule2Validator, rule1);
             }
 
-            private Task LocalValidator(TestAttribute attribute, Type parameterType)
+            private void LocalValidator(TestAttribute attribute, Type parameterType)
             {
                 attribute.ValidateAtIndexTime(parameterType);
-                return Task.FromResult(0);
             }
         }
 

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Common/ValidationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Common/ValidationTests.cs
@@ -15,7 +15,6 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Common
 {
     public class ValidationTests
     {
-
         public class TestAttribute : Attribute
         {
             public bool Bad { get; set; }
@@ -24,10 +23,28 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Common
 
             [AutoResolve]
             public string Path { get; set; }
+
+
+            public void ValidateAtIndexTime(Type parameterType)
+            {
+                // Verify that FX is passing the expected paramteer type.
+                Assert.True(parameterType == typeof(Widget) || parameterType == typeof(Widget2));
+
+                // Test that validation is valled after INameResolver has handled %%, but before {} are resolved. 
+                Assert.Equal("v1-{k2}", this.Path);
+
+                if (this.Bad)
+                {
+                    throw new InvalidOperationException(TestAttribute.ErrorMessage);
+                }
+            }
         }
 
+        // Some arbitrary types to use in parameters.  
+        public class Widget { }
+
         // Some arbitrary type. 
-        public class Widget { } 
+        public class Widget2 { }
 
         public class FunctionBase
         {
@@ -60,18 +77,9 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Common
                 context.RegisterBindingRules<TestAttribute>(ValidateAtIndexTime, rule);
             }
 
-            public void ValidateAtIndexTime(TestAttribute attribute, Type parameterType)
+            private static void ValidateAtIndexTime(TestAttribute attribute, Type parameterType)
             {
-                // Verify that FX is passing the expected paramteer type.
-                Assert.Equal(typeof(Widget), parameterType);
-
-                // Test that validation is valled after INameResolver has handled %%, but before {} are resolved. 
-                Assert.Equal("v1-{k2}", attribute.Path);
-
-                if (attribute.Bad)
-                {
-                    throw new InvalidOperationException(TestAttribute.ErrorMessage);
-                }
+                attribute.ValidateAtIndexTime(parameterType);
             }
         }
 
@@ -81,17 +89,9 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Common
             var nr = new FakeNameResolver().Add("k1", "v1");
             var host = TestHelpers.NewJobHost<BadFunction>(new FakeExtClient(), nr);
 
-            try
-            {
-                host.Call("Valid"); // Should get indexing error from 'Bad' function 
-            }
-            catch (FunctionIndexingException e)
-            {
-                Assert.Equal("Error indexing method 'BadFunction.Bad'", e.Message);
-                Assert.Equal(TestAttribute.ErrorMessage, e.InnerException.Message);
-                return;
-            }
-            Assert.True(false, "Invoker should have failed");
+            TestHelpers.AssertIndexingError(
+                () => host.Call("Valid"),
+                "BadFunction.Bad", TestAttribute.ErrorMessage);
         }
 
         [Fact]
@@ -100,6 +100,68 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Common
             var nr = new FakeNameResolver().Add("k1", "v1");
             var host = TestHelpers.NewJobHost<GoodFunction>(new FakeExtClient(), nr);
             host.Call("Good", new { k2 = "xxxx" } ); 
+        }
+
+        // Register [Test]  with 2 rules and a local validator. 
+        public class FakeExtClient2 : IExtensionConfigProvider
+        {
+            public void Initialize(ExtensionConfigContext context)
+            {
+                var bf = context.Config.BindingFactory;
+
+                // Add [Test] support
+                var rule1 = bf.BindToExactType<TestAttribute, Widget>(attr => new Widget());
+                var rule2 = bf.BindToExactType<TestAttribute, Widget2>(attr => new Widget2());
+                var rule2Validator = bf.AddValidator<TestAttribute>(LocalValidator, rule2);
+
+                context.RegisterBindingRules<TestAttribute>(rule2Validator, rule1);
+            }
+
+            private Task LocalValidator(TestAttribute attribute, Type parameterType)
+            {
+                attribute.ValidateAtIndexTime(parameterType);
+                return Task.FromResult(0);
+            }
+        }
+
+        public class LocalFunction1 : FunctionBase
+        {
+            // No validation on Widget-rule to cathc that ths is bad. 
+            // So this passes. Validator is never run. 
+            public void NoValidation([Test(Bad = true, Path = "%k1%-{k2}")] Widget x)
+            {
+            }
+        }
+
+        public class LocalFunction2 : FunctionBase
+        {
+            // Validation rule does run on this parameter, catches the failure. 
+            public void WithValidation([Test(Bad = true, Path = "%k1%-{k2}")] Widget2 x)
+            {
+            }
+        }
+
+        [Fact]
+        public void TestLocalValidatorSkipped()
+        {
+            // Local validator only run if we use the given rule. 
+            var nr = new FakeNameResolver().Add("k1", "v1");
+            var host = TestHelpers.NewJobHost<LocalFunction1>(new FakeExtClient2(), nr);
+
+            host.Call("NoValidation", new { k2 = "xxxx" }); // Succeeds since validate doesn't run on this rule             
+        }
+
+        [Fact]
+        public void TestLocalValidatorApplied()
+        {
+            // Local validator only run if we use the given rule. 
+            var nr = new FakeNameResolver().Add("k1", "v1");
+            var host = TestHelpers.NewJobHost<LocalFunction2>(new FakeExtClient2(), nr);
+
+            TestHelpers.AssertIndexingError(
+                () => host.Call("WithValidation"),
+                "LocalFunction2.WithValidation", TestAttribute.ErrorMessage);
+            
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Common/ValidationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Common/ValidationTests.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.WebJobs.Host.Config;
+using Microsoft.Azure.WebJobs.Host.Indexers;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Host.UnitTests.Common
+{
+    public class ValidationTests
+    {
+
+        public class TestAttribute : Attribute
+        {
+            public bool Bad { get; set; }
+
+            internal const string ErrorMessage = "Test attribute is not valid!";
+
+            [AutoResolve]
+            public string Path { get; set; }
+        }
+
+        // Some arbitrary type. 
+        public class Widget { } 
+
+        public class FunctionBase
+        {
+            [NoAutomaticTrigger]
+            public void Valid() { }
+        }
+
+        public class BadFunction : FunctionBase
+        {
+            public void Bad([Test(Bad = true, Path = "%k1%-{k2}")] Widget x)
+            {
+            }        
+        }
+
+        public class GoodFunction : FunctionBase
+        {
+            public void Good([Test(Bad= false, Path = "%k1%-{k2}")] Widget x)
+            {
+            }
+        }
+
+        public class FakeExtClient : IExtensionConfigProvider
+        {
+            public void Initialize(ExtensionConfigContext context)
+            {
+                var bf = context.Config.BindingFactory;
+
+                // Add [Test] support
+                var rule = bf.BindToExactType<TestAttribute, Widget>(attr => new Widget());
+                context.RegisterBindingRules<TestAttribute>(ValidateAtIndexTime, rule);
+            }
+
+            public void ValidateAtIndexTime(TestAttribute attribute, Type parameterType)
+            {
+                // Verify that FX is passing the expected paramteer type.
+                Assert.Equal(typeof(Widget), parameterType);
+
+                // Test that validation is valled after INameResolver has handled %%, but before {} are resolved. 
+                Assert.Equal("v1-{k2}", attribute.Path);
+
+                if (attribute.Bad)
+                {
+                    throw new InvalidOperationException(TestAttribute.ErrorMessage);
+                }
+            }
+        }
+
+        [Fact]
+        public void TestValidatorFails()
+        {
+            var nr = new FakeNameResolver().Add("k1", "v1");
+            var host = TestHelpers.NewJobHost<BadFunction>(new FakeExtClient(), nr);
+
+            try
+            {
+                host.Call("Valid"); // Should get indexing error from 'Bad' function 
+            }
+            catch (FunctionIndexingException e)
+            {
+                Assert.Equal("Error indexing method 'BadFunction.Bad'", e.Message);
+                Assert.Equal(TestAttribute.ErrorMessage, e.InnerException.Message);
+                return;
+            }
+            Assert.True(false, "Invoker should have failed");
+        }
+
+        [Fact]
+        public void TestValidatorSucceeds()
+        {
+            var nr = new FakeNameResolver().Add("k1", "v1");
+            var host = TestHelpers.NewJobHost<GoodFunction>(new FakeExtClient(), nr);
+            host.Call("Good", new { k2 = "xxxx" } ); 
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
@@ -124,6 +124,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 "BindingTemplateSource",
                 "TriggeredFunctionData",
                 "ExtensionConfigContext",
+                "ExtensionConfigContextExtensions",
                 "IQueueProcessorFactory",
                 "QueueProcessorFactoryContext",
                 "QueueProcessor",

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
@@ -148,6 +148,7 @@
     <Compile Include="Common\FakeItemTests.cs" />
     <Compile Include="Common\CollectorTests.cs" />
     <Compile Include="Common\TriggerTests.cs" />
+    <Compile Include="Common\ValidationTests.cs" />
     <Compile Include="CompositeTraceWriterTests.cs" />
     <Compile Include="ConfigurationUtilityTests.cs" />
     <Compile Include="ConsoleTraceWriterTests.cs" />


### PR DESCRIPTION
Validator hook is dispatched after the %% are resolved, but before any runtime invocation (so no { } resolved yet).