### PR TITLE
Fixing SingletonListener lock release bug

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostContext.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostContext.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
 
         public void Dispose()
         {
-            if (_disposed)
+            if (!_disposed)
             {
                 _listener.Dispose();
 

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostContextTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostContextTests.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Azure.WebJobs.Host.Indexers;
+using Microsoft.Azure.WebJobs.Host.Listeners;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Moq;
+using Xunit;
+
+
+namespace Microsoft.Azure.WebJobs.Host.UnitTests
+{
+    public class JobHostContextTests
+    {
+        [Fact]
+        public void Dispose_Disposes()
+        {
+            var mockLookup = new Mock<IFunctionIndexLookup>(MockBehavior.Strict);
+            var mockExecutor = new Mock<IFunctionExecutor>(MockBehavior.Strict);
+            var mockListener = new Mock<IListener>(MockBehavior.Strict);
+            var traceWriter = new TestTraceWriter(TraceLevel.Verbose);
+
+            mockListener.Setup(p => p.Dispose());
+
+            var context = new JobHostContext(mockLookup.Object, mockExecutor.Object, mockListener.Object, traceWriter);
+
+            Assert.Same(traceWriter, context.Trace);
+
+            context.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                context.Trace.Info("Kaboom!");
+            });
+
+            // verify that calling Dispose again is a noop
+            context.Dispose();
+
+            mockListener.Verify(p => p.Dispose(), Times.Once);
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
@@ -176,6 +176,7 @@
     <Compile Include="FakeQueue\FakeQueueTriggerBindingProvider.cs" />
     <Compile Include="FakeQueue\FakeQueueTriggerBindingStrategy.cs" />
     <Compile Include="FunctionIndexerFactory.cs" />
+    <Compile Include="JobHostContextTests.cs" />
     <Compile Include="JobHostQueuesConfigurationTests.cs" />
     <Compile Include="Listeners\HostListenerFactoryTests.cs" />
     <Compile Include="Loggers\TraceWriterFunctionInstanceLoggerTests.cs" />


### PR DESCRIPTION
Fixing an issue reported by Hamid in his ApiHub trigger binding. The issue was that due to this bug, on error paths (e.g. listener fails to start due to invalid path), when the host is disposed, the singleton lock that was aquired as part of startup was not released.