### PR TITLE
Extending ServiceBus string/byte[] conversion capabilities

### DIFF
--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Triggers/BrokeredMessageToByteArrayConverter.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Triggers/BrokeredMessageToByteArrayConverter.cs
@@ -13,7 +13,9 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
     {
         public async Task<byte[]> ConvertAsync(BrokeredMessage input, CancellationToken cancellationToken)
         {
-            if (input.ContentType == ContentTypes.ApplicationOctetStream)
+            if (input.ContentType == ContentTypes.ApplicationOctetStream ||
+                input.ContentType == ContentTypes.TextPlain ||
+                input.ContentType == ContentTypes.ApplicationJson)
             {
                 using (MemoryStream outputStream = new MemoryStream())
                 using (Stream inputStream = input.GetBody<Stream>())

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Triggers/BrokeredMessageToStringConverter.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Triggers/BrokeredMessageToStringConverter.cs
@@ -19,7 +19,9 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
                 throw new ArgumentNullException("input");
             }
 
-            if (input.ContentType == ContentTypes.TextPlain)
+            if (input.ContentType == ContentTypes.TextPlain ||
+                input.ContentType == ContentTypes.ApplicationOctetStream ||
+                input.ContentType == ContentTypes.ApplicationJson)
             {
                 Stream stream = input.GetBody<Stream>();
                 if (stream == null)

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/BrokeredMessageToByteArrayConverterTests.cs
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/BrokeredMessageToByteArrayConverterTests.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.ServiceBus.Triggers;
+using Microsoft.ServiceBus.Messaging;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests
+{
+    public class BrokeredMessageToByteArrayConverterTests
+    {
+        private const string TestString = "This is a test!";
+
+        [Theory]
+        [InlineData(ContentTypes.ApplicationOctetStream)]
+        [InlineData(ContentTypes.TextPlain)]
+        [InlineData(ContentTypes.ApplicationJson)]
+        public async Task ConvertAsync_ReturnsExpectedResult(string contentType)
+        {
+            MemoryStream ms = new MemoryStream();
+            StreamWriter sw = new StreamWriter(ms);
+            sw.Write(TestString);
+            sw.Flush();
+            ms.Seek(0, SeekOrigin.Begin);
+
+            BrokeredMessage message = new BrokeredMessage(ms);
+            message.ContentType = contentType;
+            BrokeredMessageToByteArrayConverter converter = new BrokeredMessageToByteArrayConverter();
+
+            byte[] result = await converter.ConvertAsync(message, CancellationToken.None);
+            string decoded = Encoding.UTF8.GetString(result);
+            Assert.Equal(TestString, decoded);
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/BrokeredMessageToStringConverterTests.cs
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/BrokeredMessageToStringConverterTests.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.ServiceBus.Triggers;
+using Microsoft.ServiceBus.Messaging;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests
+{
+    public class BrokeredMessageToStringConverterTests
+    {
+        private const string TestString = "This is a test!";
+        private const string TestJson = "{ value: 'This is a test!' }";
+
+        [Theory]
+        [InlineData(ContentTypes.TextPlain, TestString)]
+        [InlineData(ContentTypes.ApplicationJson, TestJson)]
+        [InlineData(ContentTypes.ApplicationOctetStream, TestString)]
+        public async Task ConvertAsync_ReturnsExpectedResult(string contentType, string value)
+        {
+            MemoryStream ms = new MemoryStream();
+            StreamWriter sw = new StreamWriter(ms);
+            sw.Write(value);
+            sw.Flush();
+            ms.Seek(0, SeekOrigin.Begin);
+
+            BrokeredMessage message = new BrokeredMessage(ms);
+            message.ContentType = contentType;
+
+            BrokeredMessageToStringConverter converter = new BrokeredMessageToStringConverter();
+            string result = await converter.ConvertAsync(message, CancellationToken.None);
+
+            Assert.Equal(value, result);
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/WebJobs.ServiceBus.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/WebJobs.ServiceBus.UnitTests.csproj
@@ -119,6 +119,8 @@
     <Compile Include="Bindings\ParameterizedServiceBusPathTests.cs" />
     <Compile Include="Bindings\ServiceBusAttributeBindingProviderTests.cs" />
     <Compile Include="Bindings\ServiceBusTriggerAttributeBindingProviderTests.cs" />
+    <Compile Include="BrokeredMessageToByteArrayConverterTests.cs" />
+    <Compile Include="BrokeredMessageToStringConverterTests.cs" />
     <Compile Include="Config\ServiceBusConfigurationTests.cs" />
     <Compile Include="Config\ServiceBusJobHostConfigurationExtensionsTests.cs" />
     <Compile Include="Config\ServiceBusExtensionConfigTests.cs" />


### PR DESCRIPTION
See dependent PR in Script repo linked below. The issue was that the message to string converter was only handling messages with a `text/plain` content type. However, we want to allow for a message to be read a string even if the content type is `application/octet-stream`. That supports scenarios where a `byte[]`/`IAsyncCollector<byte[]>` binding is used to write string messages.