### PR TITLE
New logging API to track the "volume" of function throughput.  

### DIFF
--- a/src/Dashboard/ApiControllers/FunctionsController.cs
+++ b/src/Dashboard/ApiControllers/FunctionsController.cs
@@ -213,8 +213,9 @@ namespace Dashboard.ApiControllers
             // Return as parallel arrays since that's more efficient than an array of structs.
             var result = new
             {
-                Times = Array.ConvertAll(data, x => x.Item1),
-                Counts = Array.ConvertAll(data, x => x.Item2)
+                Times = Array.ConvertAll(data, x => x.Time),
+                Counts = Array.ConvertAll(data, x => x.Volume),
+                InstanceCounts = Array.ConvertAll(data, x => x.InstanceCounts)
             };
 
             return Ok(result);

--- a/src/Dashboard/ApiControllers/FunctionsController.cs
+++ b/src/Dashboard/ApiControllers/FunctionsController.cs
@@ -202,6 +202,24 @@ namespace Dashboard.ApiControllers
             return Invocations(indexSegment);
         }
 
+        [Route("api/functions/volume")]
+        public async Task<IHttpActionResult> GetVolume(
+            DateTime startTime,
+            DateTime endTime,
+            int numberBuckets)
+        {
+            var data = await _reader.GetVolumeAsync(startTime, endTime, numberBuckets);
+
+            // Return as parallel arrays since that's more efficient than an array of structs.
+            var result = new
+            {
+                Times = Array.ConvertAll(data, x => x.Item1),
+                Counts = Array.ConvertAll(data, x => x.Item2)
+            };
+
+            return Ok(result);
+        }
+
         // Returns a sparse array of (StartBucket, Start, TotalPass, TotalFail, TotalRun)                
         [Route("api/functions/invocations/{functionId}/timeline")]
         public async Task<IHttpActionResult> GetRecentInvocationsTimeline(

--- a/src/Dashboard/FastTable/NullFastReader.cs
+++ b/src/Dashboard/FastTable/NullFastReader.cs
@@ -34,5 +34,10 @@ namespace Dashboard
         {
             throw new NotImplementedException();
         }
+
+        public Task<Tuple<DateTime, int>[]> GetVolumeAsync(DateTime startTime, DateTime endTime, int numBuckets)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/Dashboard/FastTable/NullFastReader.cs
+++ b/src/Dashboard/FastTable/NullFastReader.cs
@@ -35,7 +35,7 @@ namespace Dashboard
             throw new NotImplementedException();
         }
 
-        public Task<Tuple<DateTime, int>[]> GetVolumeAsync(DateTime startTime, DateTime endTime, int numBuckets)
+        public Task<FunctionVolumeTimelineEntry[]> GetVolumeAsync(DateTime startTime, DateTime endTime, int numBuckets)
         {
             throw new NotImplementedException();
         }

--- a/src/Microsoft.Azure.WebJobs.Logging/Entities/InstanceCountEntity.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging/Entities/InstanceCountEntity.cs
@@ -36,6 +36,21 @@ namespace Microsoft.Azure.WebJobs.Logging.Internal
         }
 
         ///
+        public long GetEndTicks()
+        {
+            var startTicks = GetTicks();
+            var endTime = new DateTime(startTicks).AddMilliseconds(this.DurationMilliseconds);
+            var endTicks = endTime.Ticks;
+            return endTicks;
+        }
+
+        /// 
+        public long GetDurationInTicks()
+        {
+            return TimeSpan.FromMilliseconds(DurationMilliseconds).Ticks;
+        }
+
+        ///
         public InstanceCountEntity(long ticks, string containerName)
         {
             int salt = Interlocked.Increment(ref _salt);
@@ -59,18 +74,23 @@ namespace Microsoft.Azure.WebJobs.Logging.Internal
         }
 
         /// <summary>
-        /// Number of inidividual instances run in this period
+        /// Number of individual instances active in this period
         /// </summary>
-        public int Count { get; set; }
+        public int CurrentActive { get; set; }
+
+        /// <summary>
+        /// Number of total instances started during this period
+        /// </summary>
+        public int TotalThisPeriod { get; set; }
 
         /// <summary>
         /// Size of the machine that these instances ran on.  
         /// </summary>
-        public int Size { get; set; }
+        public int MachineSize { get; set; }
 
         /// <summary>
         /// Polling duration in MS. 
         /// </summary>
-        public int Duration { get; set; }
+        public int DurationMilliseconds { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Logging/Entities/InstanceCountEntity.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging/Entities/InstanceCountEntity.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Threading;
+using Microsoft.WindowsAzure.Storage.Table;
+
+namespace Microsoft.Azure.WebJobs.Logging.Internal
+{
+    /// <summary>
+    /// Entity for logging function instance counts
+    /// </summary>
+    public class InstanceCountEntity : TableEntity
+    {
+        const string PartitionKeyFormat = TableScheme.InstanceCountPK;
+        const string RowKeyPrefix = "{0:D20}-";
+        const string RowKeyFormat = "{0:D20}-{1}-{2}"; // timestamp ticks, container name, salt
+
+        // Have a salt value for writing to avoid collisions since timeBucket is not gauranteed to be unique
+        // when many functions are quickly run within a single time tick. 
+        static int _salt;
+
+        ///
+        public InstanceCountEntity()
+        {
+        }
+
+        // from rowKey
+        ///
+        public long GetTicks()
+        {
+            var time = TableScheme.Get1stTerm(this.RowKey);
+            long ticks = long.Parse(time, CultureInfo.InvariantCulture);
+            return ticks;
+        }
+
+        ///
+        public InstanceCountEntity(long ticks, string containerName)
+        {
+            int salt = Interlocked.Increment(ref _salt);
+
+            this.PartitionKey = PartitionKeyFormat;
+            this.RowKey = string.Format(CultureInfo.InvariantCulture, RowKeyFormat, ticks, containerName, salt);
+        }
+
+        ///
+        public static TableQuery<InstanceCountEntity> GetQuery(DateTime startTime, DateTime endTime)
+        {
+            if (startTime > endTime)
+            {
+                throw new InvalidOperationException("Start time must be less than or equal to end time");
+            }
+            string rowKeyStart = string.Format(CultureInfo.InvariantCulture, RowKeyPrefix, startTime.Ticks);
+            string rowKeyEnd = string.Format(CultureInfo.InvariantCulture, RowKeyPrefix, endTime.Ticks);
+
+            var query = TableScheme.GetRowsInRange<InstanceCountEntity>(PartitionKeyFormat, rowKeyStart, rowKeyEnd);
+            return query;
+        }
+
+        /// <summary>
+        /// Number of inidividual instances run in this period
+        /// </summary>
+        public int Count { get; set; }
+
+        /// <summary>
+        /// Size of the machine that these instances ran on.  
+        /// </summary>
+        public int Size { get; set; }
+
+        /// <summary>
+        /// Polling duration in MS. 
+        /// </summary>
+        public int Duration { get; set; }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Logging/FunctionVolumeTimelineEntry.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging/FunctionVolumeTimelineEntry.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.WebJobs.Logging
+{
+    /// <summary>
+    /// Timeline entry from logging to track "volume" of functions executed. 
+    /// </summary>
+    public class FunctionVolumeTimelineEntry
+    {
+        /// <summary>
+        /// time this entry refers to
+        /// </summary>
+        public DateTime Time { get; set; }
+
+        /// <summary>
+        /// # of function instances active during slice * size. 
+        /// </summary>
+        public double Volume { get; set; }
+
+        /// <summary>
+        /// total # of function instances.
+        /// </summary>
+        public int InstanceCounts { get; set; }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Logging/ILogReader.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging/ILogReader.cs
@@ -12,6 +12,17 @@ namespace Microsoft.Azure.WebJobs.Logging
     public interface ILogReader
     {
         /// <summary>
+        /// Get the "# of function instance * size" for a given time window.
+        /// Size is determined by the machine size. 
+        /// </summary>
+        /// <param name="startTime">start of time window</param>
+        /// <param name="endTime">end of time window</param>
+        /// <param name="numberBuckets">Size of the returned array</param>
+        /// <returns>An array of (time, value) where value is the "# of function instance * size". 
+        /// This can be readily graphed. </returns>
+        Task<Tuple<DateTime, int>[]> GetVolumeAsync(DateTime startTime, DateTime endTime, int numberBuckets);
+
+        /// <summary>
         /// A "container" refers to a single VM that's running functions. A container can be identified by the machine name.
         /// Get per-container timeline to tell how many active containers per minute. 
         /// A container is "active" if it is running at least 1 function. 

--- a/src/Microsoft.Azure.WebJobs.Logging/ILogReader.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging/ILogReader.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.WebJobs.Logging
         /// <param name="numberBuckets">Size of the returned array</param>
         /// <returns>An array of (time, value) where value is the "# of function instance * size". 
         /// This can be readily graphed. </returns>
-        Task<Tuple<DateTime, int>[]> GetVolumeAsync(DateTime startTime, DateTime endTime, int numberBuckets);
+        Task<FunctionVolumeTimelineEntry[]> GetVolumeAsync(DateTime startTime, DateTime endTime, int numberBuckets);
 
         /// <summary>
         /// A "container" refers to a single VM that's running functions. A container can be identified by the machine name.

--- a/src/Microsoft.Azure.WebJobs.Logging/Internal/CloudTableInstanceCountLogger.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging/Internal/CloudTableInstanceCountLogger.cs
@@ -37,17 +37,18 @@ namespace Microsoft.Azure.WebJobs.Logging.Internal
         }
 
         /// 
-        protected override async Task WriteEntry(long ticks, int value)
+        protected override async Task WriteEntry(long ticks, int currentActive, int totalThisPeriod)
         {
-            if (value == 0)
+            if (currentActive == 0 && totalThisPeriod == 0)
             {
-                return;
+                return; // skip logging if no activity 
             }
             var entity = new InstanceCountEntity(ticks, _containerName)
             {
-                Count = value,
-                Size = _containerSize,
-                Duration = (int) this.PollingInterval.TotalMilliseconds
+                CurrentActive = currentActive,
+                TotalThisPeriod = totalThisPeriod,
+                MachineSize = _containerSize,
+                DurationMilliseconds = (int) this.PollingInterval.TotalMilliseconds
             };
 
             TableOperation opInsert = TableOperation.Insert(entity);

--- a/src/Microsoft.Azure.WebJobs.Logging/Internal/CloudTableInstanceCountLogger.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging/Internal/CloudTableInstanceCountLogger.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.WindowsAzure.Storage.Table;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.WebJobs.Logging.Internal
+{
+    /// <summary>
+    /// Log function instance counts to a Azure Table
+    /// </summary>
+    public class CloudTableInstanceCountLogger : InstanceCountLoggerBase
+    {
+        private readonly CloudTable _instanceTable;
+        private readonly string _containerName;
+
+        private readonly int _containerSize;
+
+        /// <summary>
+        /// Rate at which to poll and call WriteEntry(). 
+        /// </summary>
+        public TimeSpan PollingInterval
+        {
+            get; set;
+        }
+
+        ///
+        public CloudTableInstanceCountLogger(string containerName, CloudTable instanceTable, int containerSize)
+        {
+            this.PollingInterval = TimeSpan.FromSeconds(5);
+
+            this._instanceTable = instanceTable;
+            this._containerName = containerName;
+            this._containerSize = containerSize;
+        }
+
+        /// 
+        protected override async Task WriteEntry(long ticks, int value)
+        {
+            if (value == 0)
+            {
+                return;
+            }
+            var entity = new InstanceCountEntity(ticks, _containerName)
+            {
+                Count = value,
+                Size = _containerSize,
+                Duration = (int) this.PollingInterval.TotalMilliseconds
+            };
+
+            TableOperation opInsert = TableOperation.Insert(entity);
+            await _instanceTable.ExecuteAsync(opInsert);
+        }
+
+        /// <summary>
+        /// Poll, return the ticks. 
+        /// </summary>
+        /// <param name="token">cancellation token to interupt the poll. Don't throw when cancelled, just return early.</param>
+        /// <returns>Tick counter after the poll.</returns>
+        protected override async Task<long> WaitOnPoll(CancellationToken token)
+        {
+            try
+            {
+                await Task.Delay(PollingInterval, token);
+            }
+            catch (OperationCanceledException)
+            {
+                // Don't return yet. One last chance to flush 
+            }
+
+            return DateTime.UtcNow.Ticks;
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Logging/Internal/InstanceCountLoggerBase.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging/Internal/InstanceCountLoggerBase.cs
@@ -1,0 +1,143 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.WebJobs.Logging.Internal
+{
+    /// <summary>
+    /// Base class for aggregating Increment/Decrement counters. 
+    /// Maintains a background poller thread that periodically logs a count. 
+    /// </summary>
+    public abstract class InstanceCountLoggerBase
+    {
+        // Track functionInstanceGuids (instead of just a single integer counter) in case we missed an event or double reported an event. 
+        private readonly HashSet<Guid> _outstandingCount = new HashSet<Guid>();
+                
+        // Capture the maximum value of _outstandingCount.Count per each interval. 
+        // If we get 1000 functions that each take 1 ms,  a random sample may catch _outstandingCount.Count at 0 and miss the activity. 
+        private int _maxCount;
+
+        private Worker _worker;
+        
+        object _lock = new object();
+
+        /// <summary>
+        /// Stop logging. Flush outstanding entries.
+        /// </summary>
+        /// <returns></returns>
+        public Task StopAsync()
+        {
+            lock(_lock)
+            {
+                if (_worker != null)
+                {
+                    var task = _worker.StopAsync();
+                    _worker = null;
+                    return task;
+                }
+                else {
+                    // already stopped
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Begin logging a function instance guid. 
+        /// </summary>
+        /// <param name="instanceId">instance guid for function that started</param>
+        public void Increment(Guid instanceId)
+        {
+            lock (_lock)
+            {
+                if (_worker == null)
+                {
+                    _worker = Worker.Start(this);                    
+                }
+
+                _outstandingCount.Add(instanceId);
+                _maxCount = Math.Max(_maxCount, _outstandingCount.Count);
+            }
+        }
+
+        /// <summary>
+        /// Stop logging a function instance guid. Guid should have been previously passed to Increment().
+        /// </summary>
+        /// <param name="instanceId">instance guid for function that completed.</param>
+        public void Decrement(Guid instanceId)
+        {
+            lock (_lock)
+            {
+                _outstandingCount.Remove(instanceId);
+            }
+        }
+
+        /// <summary>
+        /// Poll, return the ticks. 
+        /// </summary>
+        /// <param name="token">cancellation token to interupt the poll. 
+        /// Don't throw when cancelled, just return early because we still need a tick counter returned.</param>
+        /// <returns>Tick counter after the poll. </returns>
+        protected abstract Task<long> WaitOnPoll(CancellationToken token);        
+
+        /// <summary>
+        /// Called to write 
+        /// </summary>
+        /// <param name="ticks">time ticks returned via WaitOnPoll</param>
+        /// <param name="value">number of outstanding Increment calls. </param>
+        /// <returns></returns>
+        protected abstract Task WriteEntry(long ticks, int value);
+
+        // Wrap cancellation token and task in a separate class so that StopAsync()  doesn't reccyle them. 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1001:TypesThatOwnDisposableFieldsShouldBeDisposable")]
+        class Worker
+        {
+            private readonly CancellationTokenSource _cancel = new CancellationTokenSource();
+            private Task _pollTask; 
+            private InstanceCountLoggerBase _parent;
+
+            public static Worker Start(InstanceCountLoggerBase parent)
+            {
+                var worker = new Worker();
+                worker._parent = parent;
+                worker._pollTask = worker.PollerAsync();
+                return worker;
+            }
+
+            public Task StopAsync()
+            {
+                _cancel.Cancel();
+                return _pollTask;
+            }
+
+            async Task PollerAsync()
+            {
+                do
+                {
+                    long ticks = await _parent.WaitOnPoll(_cancel.Token);
+
+                    int totalActiveFuncs;
+                    lock (_parent._lock)
+                    {
+                        totalActiveFuncs = _parent._maxCount;
+                        _parent._maxCount = _parent._outstandingCount.Count; // reset. 
+                    }
+
+                    try
+                    {
+                        await _parent.WriteEntry(ticks, totalActiveFuncs);
+                    }
+                    catch
+                    {
+                        // Failures from writing (such as IO), may mean missing data, but shouldn't bring down the whole polling. 
+                    }
+                }
+                while (!_cancel.IsCancellationRequested);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Logging/Internal/ProjectionHelper.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging/Internal/ProjectionHelper.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Azure.WebJobs.Logging.Internal
+{
+    /// <summary>
+    /// Create projection from table rows to chartable data
+    /// </summary>
+    public static class ProjectionHelper
+    {
+        /// 
+        public static Tuple<long, double>[] Work(InstanceCountEntity[] rows, long startTicks, long endTicks, int numberBuckets)
+        {
+            if (rows == null)
+            {
+                throw new ArgumentNullException("rows");
+            }
+
+            int N = numberBuckets;
+            double bucketWidthTicks = ((double)(endTicks - startTicks)) / N;
+
+            double[] values = new double[N];
+
+            Action<int, double> add = (index, amount) =>
+            {
+                if (index >= 0 && index < values.Length)
+                {
+                    values[index] += amount;
+                }
+            };
+
+            // need a projection from Rows to buckets. 
+            // rows are are sparse array 
+            // buckets are a dense linear array. 
+            foreach (var entity in rows)
+            {
+                long ticks1 = entity.GetTicks();
+                double idx1 = ((ticks1 - startTicks) / bucketWidthTicks);
+
+                // Spread the area across all buckets. 
+                long ticks2 = entity.GetEndTicks();
+                double idx2 = ((ticks2 - startTicks) / bucketWidthTicks);
+
+                double area = (entity.CurrentActive * entity.MachineSize) * entity.GetDurationInTicks();
+                double area2 = area / bucketWidthTicks;
+
+                // 3 sections 
+                double pfull = idx2 - idx1;
+
+                if (pfull < 1)
+                {
+                    // entire projection is smaller than a single bucket
+                    double val = area2;
+                    add((int)idx1, val);
+                }
+                else
+                {
+                    // projection spans multiple puckets. 
+                    int idx1Whole = RoundUp(idx1);
+                    int idx2Whole = RoundDown(idx2);
+
+                    double pleft = idx1Whole - idx1;
+                    double pright = idx2 - idx2Whole;
+
+                    double val_mid = area2 / pfull;
+                    double val_left = val_mid * pleft;
+                    double val_right = val_mid * pright;
+
+                    add((int)idx1, val_left);
+                    for (int i = idx1Whole; i < idx2Whole; i++)
+                    {
+                        add(i, val_mid);
+                    }
+                    add((int)idx2, val_right);
+                }
+            }
+
+            // Convert to output format. 
+            Tuple<long, double>[] chart = new Tuple<long, double>[N];
+            for (int i = 0; i < N; i++)
+            {
+                long ticks = (long)(startTicks + (i * bucketWidthTicks));
+                chart[i] = new Tuple<long, double>(ticks, values[i]);
+            }
+
+            return chart;
+        }
+
+        static int RoundUp(double d)
+        {
+            int i = (int)d; // truncate
+            if (i == d)
+            {
+                return i;
+            }
+            return i + 1;
+        }
+        static int RoundDown(double d)
+        {
+            return (int)d;
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Logging/Internal/TableScheme.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging/Internal/TableScheme.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Azure.WebJobs.Logging
         internal const string RecentFuncIndexPK = "R"; // RecentPerFuncEntity
         internal const string ContainerActivePK = "C"; // ContainerActiveEntity
         internal const string FuncDefIndexPK = "FD"; // FunctionDefinitionEntity
+        internal const string InstanceCountPK = "IA"; // InstanceCountEntity
 
         // Read entire partition
         internal static TableQuery<TElement> GetRowsInPartition<TElement>(string partitionKey)
@@ -52,7 +53,17 @@ namespace Microsoft.Azure.WebJobs.Logging
             TableQuery<TElement> rangeQuery = new TableQuery<TElement>().Where(query);
             return rangeQuery;            
         }
-            
+
+        public static string Get1stTerm(string rowKey)
+        {
+            int i = rowKey.IndexOf('-');
+            if (i >= 0)
+            {
+                return rowKey.Substring(0, i);
+            }
+            throw new InvalidOperationException("Row key is in illegal format: " + rowKey);
+        }
+
         public static string Get2ndTerm(string rowKey)
         {
             int i = rowKey.IndexOf('-');

--- a/src/Microsoft.Azure.WebJobs.Logging/WebJobs.Logging.csproj
+++ b/src/Microsoft.Azure.WebJobs.Logging/WebJobs.Logging.csproj
@@ -93,6 +93,7 @@
     <Compile Include="FunctionInstanceStatus.cs" />
     <Compile Include="IFunctionDefinition.cs" />
     <Compile Include="IFunctionInstanceBaseEntry.cs" />
+    <Compile Include="Internal\ProjectionHelper.cs" />
     <Compile Include="Internal\CloudTableInstanceCountLogger.cs" />
     <Compile Include="Internal\InstanceCountLoggerBase.cs" />
     <Compile Include="Internal\ContainerActiveLogger.cs" />

--- a/src/Microsoft.Azure.WebJobs.Logging/WebJobs.Logging.csproj
+++ b/src/Microsoft.Azure.WebJobs.Logging/WebJobs.Logging.csproj
@@ -89,9 +89,12 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ActivationEvent.cs" />
+    <Compile Include="Entities\InstanceCountEntity.cs" />
     <Compile Include="FunctionInstanceStatus.cs" />
     <Compile Include="IFunctionDefinition.cs" />
     <Compile Include="IFunctionInstanceBaseEntry.cs" />
+    <Compile Include="Internal\CloudTableInstanceCountLogger.cs" />
+    <Compile Include="Internal\InstanceCountLoggerBase.cs" />
     <Compile Include="Internal\ContainerActiveLogger.cs" />
     <Compile Include="Entities\ContainerActiveEntity.cs" />
     <Compile Include="Entities\FunctionDefinitionEntity.cs" />

--- a/src/Microsoft.Azure.WebJobs.Logging/WebJobs.Logging.csproj
+++ b/src/Microsoft.Azure.WebJobs.Logging/WebJobs.Logging.csproj
@@ -89,6 +89,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ActivationEvent.cs" />
+    <Compile Include="FunctionVolumeTimelineEntry.cs" />
     <Compile Include="Entities\InstanceCountEntity.cs" />
     <Compile Include="FunctionInstanceStatus.cs" />
     <Compile Include="IFunctionDefinition.cs" />

--- a/test/Microsoft.Azure.WebJobs.Logging.FunctionalTests/InstanceCountLoggerBaseTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Logging.FunctionalTests/InstanceCountLoggerBaseTests.cs
@@ -1,0 +1,245 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Threading;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Logging.Internal.FunctionalTests
+{
+    // Test function-instance count logger. 
+    // Pure in-memory tests (mock out azure storage and timer). 
+    public class InstanceCountLoggerBaseTests
+    {
+        // Activity within a single polling interval. 
+        [Fact]
+        public async Task BasicAndStop()
+        {
+            TestLogger l = new TestLogger();
+
+            Guid g1 = Guid.NewGuid();
+
+            // Activity within single poll interval. 
+            l.Increment(g1); // will start the timer. 
+            l.Increment(g1); // ignored, already staretd g1.                         
+            l.Decrement(g1); // count is back to 0 before poll happens. 
+            
+            Assert.Equal(0, l._dict.Count); // Large poll, haven't written yet. 
+
+            l._newTicks = 100;
+            await l.StopAsync();
+
+            // StopAsync will flush and cause a write. 
+            // We still picked up g1
+            Assert.Equal(1, l._dict.Count);
+            Assert.Equal(1, l._dict[100]);
+        }
+
+        // Activity within a single polling interval. 
+        [Fact]
+        public async Task BasicAndPoll()
+        {
+            TestLogger l = new TestLogger();
+
+            Guid g1 = Guid.NewGuid();
+
+            // Activity within single poll interval. 
+            l.Increment(g1); // will start the timer. 
+            l.Decrement(g1); // ignored, already staretd g1.                         
+            
+            Assert.Equal(0, l._dict.Count); // Large poll, haven't written yet. 
+
+            l.Poll(100);
+            l._newTicks = 200;
+            await l.StopAsync(); // no extra counts, 
+
+            // StopAsync will flush and cause a write. 
+            // We still picked up g1
+            Assert.Equal(1, l._dict.Count);
+            Assert.Equal(1, l._dict[100]);
+        }
+
+        [Fact]
+        public async Task StopWithNoActivity()
+        {
+            TestLogger l = new TestLogger();
+            Guid g1 = Guid.NewGuid();
+
+            await l.StopAsync();
+            Assert.Equal(0, l._dict.Count);
+        }
+
+        // It's ok to call Stop() many times. 
+        [Fact]
+        public async Task MultiStop()
+        {
+            TestLogger l = new TestLogger();
+            Guid g1 = Guid.NewGuid();
+
+            l.Increment(g1);
+
+            l._newTicks = 101;
+
+            Task[] tasks = Array.ConvertAll(Enumerable.Range(1, 10).ToArray(), _ => l.StopAsync());
+            await Task.WhenAll(tasks);
+
+            Assert.Equal(1, l._dict.Count);
+            Assert.Equal(1, l._dict[101]);
+        }
+
+        [Fact]
+        public async Task Consistency()
+        {
+            // Simulate a steady stream over a long time.
+            TestLogger l = new TestLogger();
+
+            for (int i = 0; i < 1000; i += 100)
+            {
+                var g = Guid.NewGuid();
+                l.Increment(g);
+                l.Decrement(g);
+                l.Poll(i);
+            }
+            l._newTicks = 1000;
+            await l.StopAsync();
+
+            // Verify 
+            int c = 0;
+            for (int i = 0; i < 1000; i += 100)
+            {
+                Assert.Equal(1, l._dict[i]);
+                c++;
+            }
+            Assert.Equal(c, l._dict.Count);
+        }
+
+        [Fact]
+        public async Task StopAndRestart()
+        {
+            TestLogger l = new TestLogger();
+            Guid g1 = Guid.NewGuid();
+            Guid g2 = Guid.NewGuid();
+            Guid g3 = Guid.NewGuid();
+
+            l.Increment(g1);
+            l.Increment(g2);
+            l.Decrement(g1);
+
+            l._newTicks = 100;
+            await l.StopAsync();
+
+            Assert.Equal(2, l._dict[100]); // max was g1,g2
+
+            l.Increment(g3); // start up again 
+            l.Poll(200);
+            l.Decrement(g2);
+            l.Decrement(g3);
+
+            l.Poll(300);
+
+            l._newTicks = 301;
+            await l.StopAsync();
+
+            
+            Assert.Equal(2, l._dict[200]); // max was g2, g3
+            
+            Assert.Equal(2, l._dict[300]); // spill over from time-200
+            Assert.Equal(3, l._dict.Count); 
+        }
+
+        // 1 long instance,  across multiple polls;. 
+        [Fact]
+        public async Task LongInstance()
+        {
+            TestLogger l = new TestLogger();
+            Guid g1 = Guid.NewGuid();
+
+            l.Increment(g1);
+            l.Poll(10);
+            l.Poll(20);
+            l.Poll(30);
+            l.Decrement(g1);
+            l.Poll(40); // this will catch partial activity after 30
+            l.Poll(41); // should be 0, so no entry 
+
+            Assert.Equal(4, l._dict.Count);
+            Assert.Equal(1, l._dict[10]);
+            Assert.Equal(1, l._dict[20]);
+            Assert.Equal(1, l._dict[30]);
+
+            // This is 1, not 0, because it's catching the partial activity between 30 and 40. 
+            // But no entry after Time40. 
+            Assert.Equal(1, l._dict[40]);
+        }
+
+        // Pure in-memory logger. 
+        public class TestLogger : InstanceCountLoggerBase
+        {
+            // Record WriteEntry results. Map Ticks --> value at that time. 
+            public Dictionary<long, int> _dict = new Dictionary<long, int>();
+
+            // Events to handshake between Poll() from test thread and WriteEntry() on background thread.
+            private readonly AutoResetEvent _eventPollReady = new AutoResetEvent(false);
+            private readonly AutoResetEvent _eventFinishedWrite = new AutoResetEvent(false);
+            public long _newTicks;
+
+            public TestLogger()
+            {                
+            }
+
+            // Callback from background Poller thread. 
+            protected override Task WriteEntry(long ticks, int value)
+            {
+                if (value > 0)
+                {
+                    _dict.Add(ticks, value); // shouldn't exist yet. 
+                }
+
+                _eventFinishedWrite.Set(); // unblocks call to Poll() on main thread. 
+
+                return Task.FromResult(0);
+            }
+                       
+
+            // Callback from poller thread. 
+            protected override async Task<long> WaitOnPoll(CancellationToken token)
+            {
+                await WaitOne(_eventPollReady, token);
+
+                return _newTicks;
+                // Thread returns and calls WriteEntry()             
+            }
+
+            // Test method called by test main thread. 
+            // Signals WaitOnPoll to continue. Will block until WriteEntry() has been called. 
+            public void Poll(long newTicks)
+            {
+                _eventFinishedWrite.Reset();
+
+                _newTicks = newTicks;
+                _eventPollReady.Set();
+
+                // Block until Write has finished 
+                WaitOne(_eventFinishedWrite, CancellationToken.None).Wait();
+            }
+
+            // Helper for waiting on an event. 
+            static async Task WaitOne(AutoResetEvent e, CancellationToken token)
+            {
+                await Task.Yield();
+
+                while (!token.IsCancellationRequested)
+                {
+                    if (e.WaitOne(0))
+                    {
+                        return;
+                    }
+                    await Task.Delay(10);
+                }
+            }
+        }        
+    }    
+}

--- a/test/Microsoft.Azure.WebJobs.Logging.FunctionalTests/LoggerTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Logging.FunctionalTests/LoggerTest.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Logging.Internal;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Table;
-using System;
-using System.Reflection;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Logging.FunctionalTests
@@ -14,6 +15,43 @@ namespace Microsoft.Azure.WebJobs.Logging.FunctionalTests
     public class LoggerTest
     {
         static string CommonFuncName1 = "gamma";
+       
+        // End-2-end test that function instance counter can write to tables 
+        [Fact]
+        public async Task FunctionInstance()
+        {
+            var table = GetNewLoggingTable();
+            try
+            {
+                ILogReader reader = LogFactory.NewReader(table);
+                TimeSpan poll = TimeSpan.FromMilliseconds(50);
+                TimeSpan poll5 = TimeSpan.FromMilliseconds(poll.TotalMilliseconds * 5);
+                
+                var logger1 = new CloudTableInstanceCountLogger("c1", table, 100) { PollingInterval = poll };
+                
+                Guid g1 = Guid.NewGuid();
+                
+                DateTime startTime = DateTime.UtcNow;
+                logger1.Increment(g1);
+                await Task.Delay(poll5); // should get at least 1 poll entry in           
+                logger1.Decrement(g1);
+                await Task.WhenAll(logger1.StopAsync());
+
+                DateTime endTime = DateTime.UtcNow;
+
+                // Now read. 
+                // We may get an arbitrary number of raw poll entries since the
+                // low poll latency combined with network delay can be unpredictable.
+                var values = await reader.GetVolumeAsync(startTime, endTime, 1);
+
+                int total = (from value in values select value.Item2).Sum();
+                Assert.True(total > 0);
+            }
+            finally
+            {
+                table.DeleteIfExists();
+            }        
+}
 
         [Fact]
         public async Task TimeRange()

--- a/test/Microsoft.Azure.WebJobs.Logging.FunctionalTests/LoggerTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Logging.FunctionalTests/LoggerTest.cs
@@ -44,8 +44,11 @@ namespace Microsoft.Azure.WebJobs.Logging.FunctionalTests
                 // low poll latency combined with network delay can be unpredictable.
                 var values = await reader.GetVolumeAsync(startTime, endTime, 1);
 
-                int total = (from value in values select value.Item2).Sum();
-                Assert.True(total > 0);
+                double totalVolume = (from value in values select value.Volume).Sum();
+                Assert.True(totalVolume > 0);
+
+                double totalInstance = (from value in values select value.InstanceCounts).Sum();
+                Assert.Equal(1, totalInstance);
             }
             finally
             {

--- a/test/Microsoft.Azure.WebJobs.Logging.FunctionalTests/ProjectionTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Logging.FunctionalTests/ProjectionTests.cs
@@ -1,0 +1,200 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Logging.Internal.FunctionalTests
+{
+    // Test projection from raw logging rows to linear buckets that can be graphed. 
+    public class ProjectionTests
+    {
+        private static readonly int durationMs = 10;
+        private static readonly long durationTicks = TimeSpan.FromMilliseconds(durationMs).Ticks;
+
+        private static readonly long t0 = 100 * 1000;
+        private static readonly long t1 = t0 + durationTicks;
+        private static readonly long t2 = t1 + durationTicks;
+        private static readonly long t3 = t2 + durationTicks;
+        private static readonly long t4 = t3 + durationTicks;
+        private static readonly long t5 = t4 + durationTicks;
+
+        private static Tuple<long, double>[] Work(InstanceCountEntity[] rows, long startTicks, long endTicks, int numberBuckets)
+        {
+            return ProjectionHelper.Work(rows, startTicks, endTicks, numberBuckets);
+        }
+
+        private static InstanceCountEntity[] GetData()
+        {
+            var rows = new InstanceCountEntity[] {
+                new InstanceCountEntity(t1, "c1") { DurationMilliseconds = durationMs, CurrentActive = 6, MachineSize = 20 },
+                new InstanceCountEntity(t2, "c1") { DurationMilliseconds = durationMs, CurrentActive = 6, MachineSize = 20 },
+            };
+            return rows;
+        }
+
+        private static readonly int StdArea = 6 * 20; // CurrentActive & MachineSize
+
+        [Fact]
+        public void TestScale()
+        {
+            var rows = GetData();
+
+            double totalArea = 0;
+            foreach (var row in rows)
+            {
+                totalArea += row.GetDurationInTicks() * row.CurrentActive * row.MachineSize;
+            }
+
+            // Scale # of buckets shouldn't matter. Always has the same area
+            for (int i = 1; i < 20; i++)
+            {
+                var fx = Work(rows, t0, t5, i);
+                var sx = Sum(fx, t0, t5);
+                var round = Math.Round(sx, MidpointRounding.AwayFromZero);
+                Assert.Equal(round, totalArea);
+            }
+        }
+
+        // Test 1:1 relationship between source data and projection
+        [Fact]
+        public void Basic()
+        {
+            var rows = GetData();
+
+            var f1 = Work(rows, t1, t3, 2); // 1:1
+            Assert.Equal(2, f1.Length);
+            Assert.Equal(StdArea, f1[0].Item2);
+            Assert.Equal(StdArea, f1[1].Item2);
+        }
+
+        // Test multiple rows projecting into a single bucket at hte same Scale
+        [Fact]
+        public void SingleBucket_Same()
+        {
+            var rows = GetData();
+
+            var f2 = Work(rows, t1, t3, 1); // single bucket , same
+            Assert.Equal(1, f2.Length);
+            Assert.Equal(StdArea, f2[0].Item2);
+        }
+
+        // Project into a longer bucket. Value is half since bucket is twice as wide. 
+        [Fact]
+        public void SingleBucket_Long()
+        {
+            var rows = GetData();
+
+            var f2b = Work(rows, t1, t5, 1); // long bucket , half
+            Assert.Equal(1, f2b.Length);
+            Assert.Equal(StdArea/2, f2b[0].Item2);
+        }
+
+        // Project into more granular buckets. Proportionately distribute
+        [Fact]
+        public void MoreGranularBuckets()
+        {
+            var rows = GetData();
+
+            var f3 = Work(rows, t1, t3, 4); 
+            Assert.Equal(4, f3.Length);
+            Assert.Equal(StdArea, f3[0].Item2);
+            Assert.Equal(StdArea, f3[1].Item2);
+            Assert.Equal(StdArea, f3[2].Item2);
+            Assert.Equal(StdArea, f3[3].Item2);
+        }
+
+        // Project into more granular buckets. Proportionately distribute
+        [Fact]
+        public void SubsectionLeft()
+        {
+            var rows = GetData();
+
+            var f4 = Work(rows, t1, t2, 1); // subsection 
+            Assert.Equal(1, f4.Length);
+            Assert.Equal(t1, f4[0].Item1);
+            Assert.Equal(StdArea, f4[0].Item2);
+        }
+
+        // Project into more granular buckets. Proportionately distribute
+        [Fact]
+        public void SubsectionRight()
+        {
+            var rows = GetData();
+
+            var f5 = Work(rows, t2, t3, 1); // subsection 
+            Assert.Equal(1, f5.Length);
+            Assert.Equal(t2, f5[0].Item1);
+            Assert.Equal(StdArea, f5[0].Item2);
+        }
+
+        // Projection does not fall into bucket range; so buckets are 0.
+        [Fact]
+        public void OutsideLeft()
+        {
+            var rows = GetData();
+
+            // Totally outside should be 0. 
+            var f6 = Work(rows, t0, t1, 2); // empty 
+            Assert.Equal(2, f6.Length);
+            Assert.Equal(t0, f6[0].Item1);
+            Assert.Equal(0, f6[0].Item2);
+            Assert.Equal((t0 + t1) / 2, f6[1].Item1);
+            Assert.Equal(0, f6[1].Item2);
+        }
+
+        // Projection does not fall into bucket range; so buckets are 0.
+        [Fact]
+        public void OutsideRight()
+        {
+            var rows = GetData();
+
+            var f6b = Work(rows, t3, t4, 2); // empty 
+            Assert.Equal(2, f6b.Length);
+            Assert.Equal(t3, f6b[0].Item1);
+            Assert.Equal(0, f6b[0].Item2);
+            Assert.Equal((t3 + t4) / 2, f6b[1].Item1);
+            Assert.Equal(0, f6b[1].Item2);
+        }
+
+        // Projection does not fall into bucket range; so buckets are 0.
+        [Fact]
+        public void Single_odd_bucket()
+        {
+            var rows = GetData();
+
+            // Projection in single bucket            
+            var f7 = Work(rows, t0, t5, 1); // larger bucket.  smaller. 
+            Assert.Equal(1, f7.Length);
+            Assert.Equal(48, f7[0].Item2);
+        }
+
+        // projection across multiple odd buckets
+        [Fact]
+        public void multiple_odd_buckets()
+        {
+            var rows = GetData();
+
+            var f8 = Work(rows, t0, t5, 2); // split buckets. 
+            Assert.Equal(2, f8.Length);
+            Assert.Equal(96, f8[0].Item2);
+            Assert.Equal((t2+t3)/2, f8[1].Item1);
+            Assert.Equal(0, f8[1].Item2);
+        }
+
+        // Area should be preserved.
+        static double Sum(Tuple<long, double>[] results, long startTicks, long endTicks)
+        {
+            int buckets = results.Length;
+            double bucketWidth = ((double) endTicks - startTicks) / buckets;
+
+            double total = 0;
+            foreach (var tuple in results)
+            {
+                var value = tuple.Item2;
+                total += (value * bucketWidth);
+            }
+            return total;
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Logging.FunctionalTests/WebJobs.Logging.FunctionalTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Logging.FunctionalTests/WebJobs.Logging.FunctionalTests.csproj
@@ -92,6 +92,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ProjectionTests.cs" />
     <Compile Include="InstanceCountLoggerBaseTests.cs" />
     <Compile Include="LoggerTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/test/Microsoft.Azure.WebJobs.Logging.FunctionalTests/WebJobs.Logging.FunctionalTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Logging.FunctionalTests/WebJobs.Logging.FunctionalTests.csproj
@@ -92,6 +92,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="InstanceCountLoggerBaseTests.cs" />
     <Compile Include="LoggerTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
PR is ready - Math is tweaked and I added a bunch of unit tests for it.
Volume is the for getting "# of functions" x "size"
API is in WebJobs.Logging  and exposed through Dashboard APIs.
Since there can be millions of function instances, requires a background poller to aggregate.
"Size" comes from an env var.