### PR TITLE
Adding built-in rand-guid binding parameter support

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/Path/BindingTemplate.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/Path/BindingTemplate.cs
@@ -103,8 +103,14 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings.Path
             {
                 if (token.IsParameter)
                 {
+                    // first try to resolve from the binding data parameters
+                    // next try to resolve "built-in" parameters (e.g. rand-guid)
                     string value;
                     if (parameters != null && parameters.TryGetValue(token.Value, out value))
+                    {
+                        builder.Append(value);
+                    }
+                    else if (TryResolveSystem(token.Value, out value))
                     {
                         builder.Append(value);
                     }
@@ -129,6 +135,23 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings.Path
         public override string ToString()
         {
             return _pattern;
+        }
+
+        /// <summary>
+        /// Try to resolve as a built-in "system" parameter. These are built in values
+        /// that don't come from the binding data bag.
+        /// </summary>
+        private static bool TryResolveSystem(string value, out string resolvedValue)
+        {
+            resolvedValue = null;
+
+            if (string.Compare(value, "rand-guid", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                resolvedValue = Guid.NewGuid().ToString();
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/Path/BindingTemplateParser.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/Path/BindingTemplateParser.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings.Path
                                     "Invalid template '{0}'. The parameter name at position {1} is empty.",
                                     input, m.Index + 1));
                             }
-                            if (!Regex.IsMatch(namedGroup.Value, IdentifierPattern))
+                            if (!IsValidIdentifier(namedGroup.Value))
                             {
                                 throw new FormatException(String.Format(
                                     "Invalid template '{0}'. The parameter name '{1}' is invalid.",
@@ -149,6 +149,20 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings.Path
                     }
                 }
             }
+        }
+
+        private static bool IsValidIdentifier(string identifier)
+        {
+            // built-in sysetem identifiers are valid
+            if (string.Compare(identifier, "rand-guid", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                return true;
+            }
+
+            // match against our identifier regex
+            // note that system identifiers include a '-' character so wouldn't
+            // pass this test
+            return Regex.IsMatch(identifier, IdentifierPattern);
         }
     }
 }


### PR DESCRIPTION
Moving the `rand-guid` support we added to Functions into the core SDK. This serves two goals:

1) Make it available to all users
2) Makes it a per-invocation resolution, so it works for early bound functions as well. In Functions currently, it only works for late bound functions (i.e. non-C#)