### PR TITLE
EventHub fixes

### DIFF
--- a/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubAsyncCollector.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubAsyncCollector.cs
@@ -50,6 +50,12 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
             if (batch.Length > 0)
             {
                 await _client.SendBatchAsync(batch);
+
+                // Dispose all messages to help with memory pressure. If this is missed, the finalizer thread will still get them. 
+                foreach (var msg in batch)
+                {
+                    msg.Dispose();
+                }
             }
         }
     }

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubConfiguration.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubConfiguration.cs
@@ -20,21 +20,37 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
     {
         // Event Hub Names are case-insensitive
         private readonly Dictionary<string, EventHubClient> _senders = new Dictionary<string, EventHubClient>(StringComparer.OrdinalIgnoreCase);
-        private readonly Dictionary<string, EventProcessorHost> _listeners  = new Dictionary<string, EventProcessorHost>(StringComparer.OrdinalIgnoreCase);
-        private readonly EventProcessorOptions _options;
-        private readonly List<Action<JobHostConfiguration>> _deferredWork = new List<Action<JobHostConfiguration>>();
+        
+        private readonly EventProcessorOptions _options; 
+        private readonly PartitionManagerOptions _partitionOptions; // optional, used to create EventProcessorHost
+        private readonly Dictionary<string, ReceiverCreds> _receiverCreds = new Dictionary<string, ReceiverCreds>();
+        private readonly Dictionary<string, EventProcessorHost> _explicitlyProvidedHosts = new Dictionary<string, EventProcessorHost>(StringComparer.OrdinalIgnoreCase);
+
+        private string _defaultStorageString; // set to JobHostConfig.StorageConnectionString
+
+        /// <summary>
+        /// default constructor. Callers can reference this without having any assembly references to service bus assemblies. 
+        /// </summary>
+        public EventHubConfiguration()
+            : this(null, null)
+        {
+        }
 
         /// <summary>
         /// Constructs a new instance.
         /// </summary>
         /// <param name="options">The optional <see cref="EventProcessorOptions"/> to use when receiving events.</param>
-        public EventHubConfiguration(EventProcessorOptions options = null)
+        /// <param name="partitionOptions">Optional <see cref="PartitionManagerOptions"/> to use to configure any EventProcessorHosts. </param>
+        public EventHubConfiguration(
+            EventProcessorOptions options, 
+            PartitionManagerOptions partitionOptions)
         {
             if (options == null)
             {
                 options = EventProcessorOptions.DefaultOptions;
                 options.MaxBatchSize = 1000;
             }
+            _partitionOptions = partitionOptions;
 
             _options = options;
         }
@@ -112,7 +128,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
                 throw new ArgumentNullException("listener");
             }
 
-            _listeners[eventHubName] = listener;
+            _explicitlyProvidedHosts[eventHubName] = listener;
         }
 
         /// <summary>
@@ -131,13 +147,10 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
                 throw new ArgumentNullException("receiverConnectionString");
             }
 
-            // We can't get the storage string until we get a JobHostConfig. 
-            // So verify the parameter upfront, but defer the creation. 
-            _deferredWork.Add((jobHostConfig) =>
-           {
-               string storageConnectionString = jobHostConfig.StorageConnectionString;
-               this.AddReceiver(eventHubName, receiverConnectionString, storageConnectionString);
-           });
+            this._receiverCreds[eventHubName] = new ReceiverCreds
+            {
+                 EventHubConnectionString = receiverConnectionString
+            };
         }
 
         /// <summary>
@@ -161,16 +174,11 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
                 throw new ArgumentNullException("storageConnectionString");
             }
 
-            string eventProcessorHostName = Guid.NewGuid().ToString();
-
-            EventProcessorHost eventProcessorHost = new EventProcessorHost(
-                eventProcessorHostName, 
-                eventHubName, 
-                EventHubConsumerGroup.DefaultGroupName,
-                receiverConnectionString, 
-                storageConnectionString);
-
-            this.AddEventProcessorHost(eventHubName, eventProcessorHost);
+            this._receiverCreds[eventHubName] = new ReceiverCreds
+            {
+                EventHubConnectionString = receiverConnectionString,
+                StorageConnectionString = storageConnectionString
+            };
         }
         
         private EventHubClient GetEventHubClient(string eventHubName)
@@ -183,12 +191,46 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
             throw new InvalidOperationException("No event hub sender named " + eventHubName);
         }
 
-        EventProcessorHost IEventHubProvider.GetEventProcessorHost(string eventHubName)
+        EventProcessorHost IEventHubProvider.GetEventProcessorHost(string eventHubName, string consumerGroup)
         {
-            EventProcessorHost host;
-            if (_listeners.TryGetValue(eventHubName, out host))
+            ReceiverCreds creds;
+            if (this._receiverCreds.TryGetValue(eventHubName, out creds))
             {
+                // Common case. Create a new EventProcessorHost instance to listen. 
+                string eventProcessorHostName = Guid.NewGuid().ToString();
+
+                if (consumerGroup == null)
+                {
+                    consumerGroup = EventHubConsumerGroup.DefaultGroupName;
+                }
+                var storageConnectionString = creds.StorageConnectionString;
+                if (storageConnectionString == null)
+                {
+                    storageConnectionString = _defaultStorageString;
+                }
+
+                EventProcessorHost host = new EventProcessorHost(
+                   eventProcessorHostName,
+                   eventHubName,
+                   consumerGroup,
+                   creds.EventHubConnectionString,
+                   storageConnectionString);
+
+                if (_partitionOptions != null)
+                {
+                    host.PartitionManagerOptions = _partitionOptions;
+                }
+
                 return host;
+            }
+            else
+            {
+                // Rare case: a power-user caller specifically provided an event processor host to use. 
+                EventProcessorHost host;
+                if (_explicitlyProvidedHosts.TryGetValue(eventHubName, out host))
+                {
+                    return host;
+                }
             }
             throw new InvalidOperationException("No event hub receiver named " + eventHubName);
         }
@@ -205,12 +247,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
                 throw new ArgumentNullException("context");
             }
 
-            // Deferred list 
-            foreach (var action in _deferredWork)
-            {
-                action(context.Config);
-            }
-            _deferredWork.Clear();
+            _defaultStorageString = context.Config.StorageConnectionString;
 
             // get the services we need to construct our binding providers
             INameResolver nameResolver = context.Config.NameResolver;
@@ -254,6 +291,17 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         {
             var eventData = new EventData(Encoding.UTF8.GetBytes(input));
             return eventData;
+        }
+
+        // Hold credentials for a given eventHub name. 
+        // Multiple consumer groups (and multiple listeners) on the same hub can share the same credentials. 
+        private class ReceiverCreds
+        {
+            // Required.  
+            public string EventHubConnectionString { get; set; }
+
+            // Optional. If not found, use the stroage from JobHostConfiguration
+            public string StorageConnectionString { get; set; }
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubConfiguration.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubConfiguration.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         /// <param name="partitionOptions">Optional <see cref="PartitionManagerOptions"/> to use to configure any EventProcessorHosts. </param>
         public EventHubConfiguration(
             EventProcessorOptions options, 
-            PartitionManagerOptions partitionOptions)
+            PartitionManagerOptions partitionOptions = null)
         {
             if (options == null)
             {

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubListener.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubListener.cs
@@ -13,7 +13,7 @@ using Microsoft.ServiceBus.Messaging;
 namespace Microsoft.Azure.WebJobs.ServiceBus
 {
     // Created from the EventHubTrigger attribute to listen on the EventHub. 
-    internal sealed class EventHubListener : IListener, IEventProcessor, IEventProcessorFactory
+    internal sealed class EventHubListener : IListener, IEventProcessorFactory
     {
         private readonly ITriggeredFunctionExecutor _executor;
         private readonly EventProcessorHost _eventListener;
@@ -38,8 +38,9 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
             // nothing to do. 
         }
 
+        // This will get called once when starting the JobHost. 
         public Task StartAsync(CancellationToken cancellationToken)
-        {            
+        {
             return _eventListener.RegisterEventProcessorFactoryAsync(this, _options);
         }
 
@@ -47,68 +48,105 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         {
             return _eventListener.UnregisterEventProcessorAsync();
         }
-
-        Task IEventProcessor.OpenAsync(PartitionContext context)
+        
+        // This will get called per-partition. 
+        IEventProcessor IEventProcessorFactory.CreateEventProcessor(PartitionContext context)
         {
-            // Begin listener 
-            return Task.FromResult(0);
+            return new Listenter(this);
         }
 
-        async Task IEventProcessor.ProcessEventsAsync(PartitionContext context, IEnumerable<EventData> messages)
+        // We get a new instance each time Start() is called. 
+        // We'll get a listener per partition - so they can potentialy run in parallel even on a single machine.
+        private class Listenter : IEventProcessor
         {
-            EventHubTriggerInput value = new EventHubTriggerInput
-            {
-                Events = messages.ToArray(),
-                Context = context
-            };
+            private readonly EventHubListener _parent;
+            private readonly CancellationTokenSource _cts = new CancellationTokenSource();
+            private static Task _done = Task.FromResult(0);
 
-            // Single dispatch 
-            if (_singleDispatch)
+            public Listenter(EventHubListener parent)
             {
-                int len = value.Events.Length;
+                this._parent = parent;
+            }
 
-                Task[] dispatches = new Task[len];
-                for (int i = 0; i < len; i++)
+            public async Task CloseAsync(PartitionContext context, CloseReason reason)
+            {
+                this._cts.Cancel(); // Signal interuption to ProcessEventsAsync()
+
+                // Finish listener
+                if (reason == CloseReason.Shutdown)
                 {
+                    await context.CheckpointAsync();
+                }
+            }
+
+            public Task OpenAsync(PartitionContext context)
+            {
+                return Task.FromResult(0);
+            }
+
+            public async Task ProcessEventsAsync(PartitionContext context, IEnumerable<EventData> messages)
+            {
+                EventHubTriggerInput value = new EventHubTriggerInput
+                {
+                    Events = messages.ToArray(),
+                    Context = context
+                };
+
+                // Single dispatch 
+                if (_parent._singleDispatch)
+                {
+                    int len = value.Events.Length;
+
+                    Task[] dispatches = new Task[len];
+                    for (int i = 0; i < len; i++)
+                    {
+                        Task task;
+                        if (_cts.IsCancellationRequested)
+                        {
+                            // If we stopped the listener, then we may lose the lease and be unable to checkpoint. 
+                            // So skip running the rest of the batch. The new listener will pick it up. 
+                            task = _done;
+                        }
+                        else
+                        {
+                            TriggeredFunctionData input = new TriggeredFunctionData
+                            {
+                                ParentId = null,
+                                TriggerValue = value.GetSingleEventTriggerInput(i)
+                            };
+                            task = this._parent._executor.TryExecuteAsync(input, _cts.Token);
+                        }
+                        dispatches[i] = task;
+                    }
+
+                    // Drain the whole batch before taking more work
+                    await Task.WhenAll(dispatches);
+                }
+                else
+                {
+                    // Batch dispatch
+
                     TriggeredFunctionData input = new TriggeredFunctionData
                     {
                         ParentId = null,
-                        TriggerValue = value.GetSingleEventTriggerInput(i)
+                        TriggerValue = value
                     };
-                    dispatches[i] = _executor.TryExecuteAsync(input, CancellationToken.None);
+
+                    FunctionResult result = await this._parent._executor.TryExecuteAsync(input, CancellationToken.None);
                 }
 
-                // Drain the whole batch before taking more work
-                await Task.WhenAll(dispatches);
-            }
-            else
-            {
-                // Batch dispatch
-
-                TriggeredFunctionData input = new TriggeredFunctionData
+                // Dispose all messages to help with memory pressure. If this is missed, the finalizer thread will still get them. 
+                foreach (var message in messages)
                 {
-                    ParentId = null,
-                    TriggerValue = value
-                };
+                    message.Dispose();
+                }
 
-                FunctionResult result = await _executor.TryExecuteAsync(input, CancellationToken.None);
-            }
-                        
-            await context.CheckpointAsync();        
-        }
-
-        async Task IEventProcessor.CloseAsync(PartitionContext context, CloseReason reason)
-        {
-            // Finish listener
-            if (reason == CloseReason.Shutdown)
-            {
+                // There are lots of reasons this could fail. That just means that events will get double-processed, which is inevitable
+                // with event hubs anyways. 
+                // For example, it could fail if we lost the lease. That could happen if we failed to renew it due to CPU starvation or an inability 
+                // to make the outbound network calls to renew. 
                 await context.CheckpointAsync();
             }
-        }
-
-        IEventProcessor IEventProcessorFactory.CreateEventProcessor(PartitionContext context)
-        {
-            return this;
-        }
+        } // end class Listener 
     }
 }

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubTriggerAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubTriggerAttribute.cs
@@ -18,11 +18,17 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         public EventHubTriggerAttribute(string eventHubName)
         {
             this.EventHubName = eventHubName;
+            this.ConsumerGroup = Microsoft.ServiceBus.Messaging.EventHubConsumerGroup.DefaultGroupName;
         }
 
         /// <summary>
         /// Name of the event hub. 
         /// </summary>
         public string EventHubName { get; private set; }
+
+        /// <summary>
+        /// Optional Name of the consumer group. If missing, then use the default name, "$Default"
+        /// </summary>
+        public string ConsumerGroup { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubTriggerAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubTriggerAttribute.cs
@@ -18,7 +18,6 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         public EventHubTriggerAttribute(string eventHubName)
         {
             this.EventHubName = eventHubName;
-            this.ConsumerGroup = Microsoft.ServiceBus.Messaging.EventHubConsumerGroup.DefaultGroupName;
         }
 
         /// <summary>

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubTriggerAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubTriggerAttributeBindingProvider.cs
@@ -48,6 +48,10 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
             string resolvedEventHubName = _nameResolver.ResolveWholeString(eventHubName);
 
             string consumerGroup = attribute.ConsumerGroup;
+            if (consumerGroup == null)
+            {
+                consumerGroup = Microsoft.ServiceBus.Messaging.EventHubConsumerGroup.DefaultGroupName;
+            }
             string resolvedConsumerGroup = _nameResolver.ResolveWholeString(consumerGroup);
 
             var eventHostListener = _eventHubConfig.GetEventProcessorHost(resolvedEventHubName, resolvedConsumerGroup);

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubTriggerAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubTriggerAttributeBindingProvider.cs
@@ -45,8 +45,12 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
             }
 
             string eventHubName = attribute.EventHubName;
-            string resolvedName = _nameResolver.ResolveWholeString(eventHubName);
-            var eventHostListener = _eventHubConfig.GetEventProcessorHost(resolvedName);
+            string resolvedEventHubName = _nameResolver.ResolveWholeString(eventHubName);
+
+            string consumerGroup = attribute.ConsumerGroup;
+            string resolvedConsumerGroup = _nameResolver.ResolveWholeString(consumerGroup);
+
+            var eventHostListener = _eventHubConfig.GetEventProcessorHost(resolvedEventHubName, resolvedConsumerGroup);
                         
             var options = _eventHubConfig.GetOptions();
             var hooks = new EventHubTriggerBindingStrategy();

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/IEventHubProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/IEventHubProvider.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
     internal interface IEventHubProvider
     {
         // Lookup a listener for receiving events given the name provided in the [EventHubTrigger] attribute. 
-        EventProcessorHost GetEventProcessorHost(string eventHubName);
+        EventProcessorHost GetEventProcessorHost(string eventHubName, string consumerGroup);
 
         // Get the eventhub options, used by the EventHub SDK for listening on event. 
         EventProcessorOptions GetOptions();

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/GlobalSuppressions.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/GlobalSuppressions.cs
@@ -3,3 +3,4 @@
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "AzureWebJobs", Scope = "member", Target = "Microsoft.Azure.WebJobs.ServiceBus.MessagingProvider.#GetConnectionString(System.String)")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Prefetch", Scope = "member", Target = "Microsoft.Azure.WebJobs.ServiceBus.ServiceBusConfiguration.#PrefetchCount")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1001:TypesThatOwnDisposableFieldsShouldBeDisposable", Scope = "type", Target = "Microsoft.Azure.WebJobs.ServiceBus.EventHubListener+Listenter")]


### PR DESCRIPTION
- add ConsumerGroup as 1st class property on EventHubTrigger. This is to allow users to read from a consumer group without having to create their own EventProcessorHost.
- avoid reusing  the same EventProcessorHost across multiple JobHosts. EventHubConfiguration will now create a new host instance per time.
- call EventData.Dispose() on both events dispatched and events sent.
- include support for PartitionManagerOptions
- better usage of EventProcessorHost. Stopping listening will eagerly abort ProcessEventsAsync.
- more commenting around PartitionContext.CheckpointAsync

There's another companion change to Scripts to take advantage of this to solve #800. 