### PR TITLE
addressing blob scan clock skew

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Blobs/Listeners/ContainerScanInfo.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Blobs/Listeners/ContainerScanInfo.cs
@@ -13,9 +13,9 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
     {
         public ICollection<ITriggerExecutor<IStorageBlob>> Registrations { get; set; }
 
-        public DateTime LastSweepCycleStartTime { get; set; }
+        public DateTime LastSweepCycleLatestModified { get; set; }
 
-        public DateTime CurrentSweepCycleStartTime { get; set; }
+        public DateTime CurrentSweepCycleLatestModified { get; set; }
 
         public BlobContinuationToken ContinuationToken { get; set; }
     }

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/TestDoubles/FakeStorageBlobContainer.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/TestDoubles/FakeStorageBlobContainer.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests.TestDoubles
             return new FakeStoragePageBlob(_store, blobName, this);
         }
 
-        public Task<IStorageBlobResultSegment> ListBlobsSegmentedAsync(string prefix, bool useFlatBlobListing,
+        public virtual Task<IStorageBlobResultSegment> ListBlobsSegmentedAsync(string prefix, bool useFlatBlobListing,
             BlobListingDetails blobListingDetails, int? maxResults, BlobContinuationToken currentToken,
             BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {


### PR DESCRIPTION
Addresses #785.

It is possible for blob LastModified timestamps to be off by a few seconds when compared to the local machine. This would result in us missing new blobs after our initial scans. They'd later be picked up by the log-reading strategy, but that could be a delay of several minutes. This change reduces the chances of missing due to clock skew by basing our last scan-time on the latest-read blob, rather than on the local machine's time.

An example of where we could miss a blob before this change -- assume our local machine's clock is ahead of Azure by 2 seconds:

1. BlobA is added at 12:00:00. 
2. This is our first scan, so we pull it and see that it is new immediately after it has been added. We mark the 'last scan time' as 12:00:02 (because we're skewed ahead of Azure).
3. BlobB is added at 12:00:01.
4. We pull it and compare it to our 'last scan time' of 12:00:02. Because we think this is old, we never process it.

With this change, in step 2, we'd put our 'last scan time' as 12:00:00 (the timestamp of BlobA), and thus pick up BlobB with the next scan.

Note that this does not completely eliminate the chances of missing a blob with this scan. I've noticed that LastModified timestamps are all rounded to the nearest second. So it's possible that we pull a blob at exactly 12:00:00 and mark 12:00:00 as our 'last timestamp seen'. Then a new blob can come in at 12:00:00.5, but also get a timestamp of 12:00:00 when stored in Azure. On our next scan, we'd miss that because the timestamp is equal to our last scan. There may be ways to account for this but it also may not be worth the effort. I gave it some thought but all of my solutions had drawbacks. I'd rather not move to use `>=` as that would mean we'd always have at least one 'new blob' that we'd later reject when we found its receipt. Any suggestions welcome :-)