### PR TITLE
Correct connection string name in exception if none is given

### DIFF
--- a/src/Microsoft.Azure.WebJobs.ServiceBus/MessagingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/MessagingProvider.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
             {
                 throw new InvalidOperationException(
                     string.Format(CultureInfo.InvariantCulture, "Microsoft Azure WebJobs SDK ServiceBus connection string '{0}{1}' is missing or empty.",
-                    "AzureWebJobs", connectionStringName));
+                    "AzureWebJobs", connectionStringName ?? ConnectionStringNames.ServiceBus));
             }
 
             return connectionString;


### PR DESCRIPTION
If no connection string in the config is set, an exception is thrown. The message of this exception says, that there is no connection string with the name "AzureWebJobs". This is misleading, because the expected connection string name is "AzureWebJobsServiceBus".