### PR TITLE
Make logger use new casing rules

### DIFF
--- a/src/Dashboard/FastTable/FastTableReader.cs
+++ b/src/Dashboard/FastTable/FastTableReader.cs
@@ -125,7 +125,7 @@ namespace Dashboard.Data
         private async Task<FunctionSnapshot> ReadAsync(string functionId)
         {
             var snapshots = await GetSnapshotsAsync();
-            var snapshot = snapshots.FirstOrDefault(x => x.Id == functionId);
+            var snapshot = snapshots.FirstOrDefault(x => string.Equals(x.Id, functionId, StringComparison.OrdinalIgnoreCase));
             return snapshot;
         }
 

--- a/src/Microsoft.Azure.WebJobs.Logging/Entities/FunctionDefinitionEntity.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging/Entities/FunctionDefinitionEntity.cs
@@ -26,17 +26,22 @@ namespace Microsoft.Azure.WebJobs.Logging
         string IFunctionDefinition.Name
         {
             get
-            {
-                return this.RowKey;
+            {                
+                return OriginalName ?? this.RowKey;
             }
         }
+
+        // Store the orginal name since functions are case-insensitive, but rowkey must be normalized (table is case-sensitive) 
+        // and functions must be case-preserving. 
+        public string OriginalName { get; set; }
 
         public static FunctionDefinitionEntity New(string functionName)
         {
             return new FunctionDefinitionEntity
             {
                 PartitionKey = PartitionKeyFormat,
-                RowKey = string.Format(CultureInfo.InvariantCulture, RowKeyFormat, TableScheme.NormalizeFunctionName(functionName))
+                RowKey = string.Format(CultureInfo.InvariantCulture, RowKeyFormat, TableScheme.NormalizeFunctionName(functionName)),
+                OriginalName = functionName
             };
         }
     }


### PR DESCRIPTION
Make Logging  comply with Function naming rules. Notably, case insensitive and case preserving.

Fixes https://github.com/Azure/azure-webjobs-sdk/issues/811