### PR TITLE
refactoring FunctionExecutor so we can pass the invokeTask to FunctionTimeoutException

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/FunctionTimeoutException.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/FunctionTimeoutException.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.Serialization;
+using System.Threading.Tasks;
 
 namespace Microsoft.Azure.WebJobs.Host
 {
@@ -33,16 +34,22 @@ namespace Microsoft.Azure.WebJobs.Host
         }
 
         /// <inheritdoc/>
-        public FunctionTimeoutException(string message, Guid instanceId, string methodName, TimeSpan timeout, Exception innerException)
+        public FunctionTimeoutException(string message, Guid instanceId, string methodName, TimeSpan timeout, Task functionTask, Exception innerException)
             : base(message, instanceId, methodName, innerException)
         {
             Timeout = timeout;
+            FunctionTask = functionTask;
         }
 
         /// <summary>
         /// The function timeout value that expired.
         /// </summary>
         public TimeSpan Timeout { get; set; }
+
+        /// <summary>
+        /// The task that did not complete due to a timeout.
+        /// </summary>
+        public Task FunctionTask { get; set; }
 
         /// <inheritdoc/>
         public override void GetObjectData(SerializationInfo info, StreamingContext context)

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/FunctionExecutorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/FunctionExecutorTests.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
 
             var timeoutSource = new CancellationTokenSource();
             var shutdownSource = new CancellationTokenSource();
-            bool throwOnTimeout = false;
+            bool throwOnTimeout = true;
 
             await FunctionExecutor.InvokeAsync(mockInvoker.Object, new object[0], timeoutSource, shutdownSource,
                 throwOnTimeout, TimeSpan.MinValue, null);


### PR DESCRIPTION
Required to fix https://github.com/Azure/azure-webjobs-sdk-script/issues/655. With the Task included in the exception, an ExceptionHandler can wait and see if the task exits on its own after the token is canceled. This means we won't have to restart. 

The PR for script is also ready -- https://github.com/Azure/azure-webjobs-sdk-script/pull/708