### PR TITLE
Fix 625, allow double dash in name 

### DIFF
--- a/src/Microsoft.Azure.WebJobs.ServiceBus.NuGet/WebJobs.ServiceBus.nuspec
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus.NuGet/WebJobs.ServiceBus.nuspec
@@ -16,8 +16,8 @@
     <dependencies>
       <dependency id="Microsoft.Azure.WebJobs" version="[$WebJobsPackageVersion$]" />
       <dependency id="Newtonsoft.Json" version="9.0.1"/>
-      <dependency id="WindowsAzure.ServiceBus" version="3.3.2"/>
-      <dependency id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.5" />
+      <dependency id="WindowsAzure.ServiceBus" version="3.4.0"/>
+      <dependency id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.6" />
     </dependencies>
   </metadata>
 </package>

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubConfiguration.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubConfiguration.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         /// Name of the blob container that the EventHostProcessor instances uses to coordinate load balancing listening on an event hub. 
         /// Each event hub gets its own blob prefix within the container. 
         /// </summary>
-        public const string LeaseContainerName = "AzureWebJobsEventHub";
+        public const string LeaseContainerName = "azure-webjobs-eventhub";
 
         /// <summary>
         /// default constructor. Callers can reference this without having any assembly references to service bus assemblies. 

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubConfiguration.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubConfiguration.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
 using System.Text;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Bindings;
@@ -31,6 +33,12 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         private readonly PartitionManagerOptions _partitionOptions; // optional, used to create EventProcessorHost
 
         private string _defaultStorageString; // set to JobHostConfig.StorageConnectionString
+
+        /// <summary>
+        /// Name of the blob container that the EventHostProcessor instances uses to coordinate load balancing listening on an event hub. 
+        /// Each event hub gets its own blob prefix within the container. 
+        /// </summary>
+        public const string LeaseContainerName = "AzureWebJobsEventHub";
 
         /// <summary>
         /// default constructor. Callers can reference this without having any assembly references to service bus assemblies. 
@@ -230,12 +238,18 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
                     sb.EntityPath = null; // need to remove to use with EventProcessorHost
                 }
 
+                var @namespace = GetServiceBusNamespace(sb);
+                var blobPrefix = GetBlobPrefix(actualPath, @namespace);
+
+                // Use blob prefix support available in EPH starting in 2.2.6 
                 EventProcessorHost host = new EventProcessorHost(
-                   eventProcessorHostName,
-                   actualPath,
-                   consumerGroup,
-                   sb.ToString(),
-                   storageConnectionString);
+                    hostName: eventProcessorHostName,
+                    eventHubPath: actualPath,
+                    consumerGroupName: consumerGroup, 
+                    eventHubConnectionString: sb.ToString(),
+                    storageConnectionString: storageConnectionString, 
+                    leaseContainerName: LeaseContainerName,
+                   leaseBlobPrefix: blobPrefix);
 
                 if (_partitionOptions != null)
                 {
@@ -254,6 +268,90 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
                 }
             }
             throw new InvalidOperationException("No event hub receiver named " + eventHubName);
+        }
+
+        private static string EscapeStorageCharacter(char character)
+        {
+            var ordinalValue = (ushort)character;
+            if (ordinalValue < 0x100)
+            {
+                return string.Format(CultureInfo.InvariantCulture, ":{0:X2}", ordinalValue);
+            }
+            else
+            {
+                return string.Format(CultureInfo.InvariantCulture, "::{0:X4}", ordinalValue);
+            }
+        }
+                
+        // Escape a blob path.  
+        // For diagnostics, we want human-readble strings that resemble the input. 
+        // Inputs are most commonly alphanumeric with a fex extra chars (dash, underscore, dot). 
+        // Escape character is a ':', which is also escaped. 
+        // Blob names are case sensitive; whereas input is case insensitive, so normalize to lower.  
+        private static string EscapeBlobPath(string path)
+        {
+            StringBuilder sb = new StringBuilder(path.Length);
+            foreach (char c in path)
+            {
+                if (c >= 'a' && c <= 'z')
+                {
+                    sb.Append(c);
+                }
+                else if (c == '-' || c == '_' || c == '.') 
+                {
+                    // Potentially common carahcters. 
+                    sb.Append(c);
+                }
+                else if (c >= 'A' && c <= 'Z')
+                {
+                    sb.Append((char)(c - 'A' + 'a')); // ToLower
+                }
+                else if (c >= '0' && c <= '9')
+                {
+                    sb.Append(c);
+                }
+                else
+                {
+                    sb.Append(EscapeStorageCharacter(c));
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        private static string GetServiceBusNamespace(ServiceBusConnectionStringBuilder connectionString)
+        {
+            // EventHubs only have 1 endpoint. 
+            var url = connectionString.Endpoints.First();
+            var @namespace = url.Host;
+            return @namespace;
+        }
+
+        /// <summary>
+        /// Get the blob prefix used with EventProcessorHost for a given event hub.  
+        /// </summary>
+        /// <param name="eventHubName">the event hub path</param>
+        /// <param name="serviceBusNamespace">the event hub's service bus namespace.</param>
+        /// <returns>a blob prefix path that can be passed to EventProcessorHost.</returns>
+        /// <remarks>
+        /// An event hub is defined by it's path and namespace. The namespace is extracted from the connection string. 
+        /// This must be an injective one-to-one function because:
+        /// 1. multiple machines listening on the same event hub must use the same blob prefix. This means it must be deterministic. 
+        /// 2. different event hubs must not resolve to the same path. 
+        /// </remarks>        
+        public static string GetBlobPrefix(string eventHubName, string serviceBusNamespace)
+        {
+            if (eventHubName == null)
+            {
+                throw new ArgumentNullException("eventHubName");
+            }
+            if (serviceBusNamespace == null)
+            {
+                throw new ArgumentNullException("serviceBusNamespace");
+            }
+
+            string key = EscapeBlobPath(serviceBusNamespace) + "/" + EscapeBlobPath(eventHubName) + "/";
+            return key;
         }
 
         EventProcessorOptions IEventHubProvider.GetOptions()

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/WebJobs.ServiceBus.csproj
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/WebJobs.ServiceBus.csproj
@@ -69,11 +69,11 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.ServiceBus, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\WindowsAzure.ServiceBus.3.3.2\lib\net45-full\Microsoft.ServiceBus.dll</HintPath>
+      <HintPath>..\..\packages\WindowsAzure.ServiceBus.3.4.0\lib\net45-full\Microsoft.ServiceBus.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.ServiceBus.Messaging.EventProcessorHost, Version=0.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.ServiceBus.EventProcessorHost.2.2.5\lib\net45-full\Microsoft.ServiceBus.Messaging.EventProcessorHost.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.ServiceBus.EventProcessorHost.2.2.6\lib\net45-full\Microsoft.ServiceBus.Messaging.EventProcessorHost.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/packages.config
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.5" targetFramework="net45" />
+  <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.6" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.7.0" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.7.0" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.7.0" targetFramework="net45" />
@@ -9,7 +9,7 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.53.0" targetFramework="net45" developmentDependency="true" />
   <package id="System.Spatial" version="5.7.0" targetFramework="net45" />
-  <package id="WindowsAzure.ServiceBus" version="3.3.2" targetFramework="net45" />
+  <package id="WindowsAzure.ServiceBus" version="3.4.0" targetFramework="net45" />
   <package id="WindowsAzure.Storage" version="7.2.0" targetFramework="net45" />
   <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net45" />
 </packages>

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/EventHubTests.cs
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/EventHubTests.cs
@@ -52,5 +52,18 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests
             var client = config.GetEventHubClient("k1");
             Assert.Equal(expectedPathName, client.Path);
         }
+
+
+        [Theory]
+        [InlineData("e", "n1", "n1/e/")]
+        [InlineData("e--1", "host_.path.foo", "host_.path.foo/e--1/")]
+        [InlineData("Ab", "Cd", "cd/ab/")]
+        [InlineData("A=", "Cd", "cd/a:3D/")]
+        [InlineData("A:", "Cd", "cd/a:3A/")]
+        public void EventHubBlobPrefix(string eventHubName, string serviceBusNamespace, string expected)
+        {
+            string actual = EventHubConfiguration.GetBlobPrefix(eventHubName, serviceBusNamespace);
+            Assert.Equal(expected, actual);
+        }
     }
 }


### PR DESCRIPTION
Use new EventProcessorHost sdk to pass a blob path. This lets us handle arbitrary event hub names.

Fix https://github.com/Azure/azure-webjobs-sdk-script/issues/625