### PR TITLE
Allow EventData to bind to byte[].

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Triggers/TriggerArgumentBinding/CustomTriggerArgumentBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Triggers/TriggerArgumentBinding/CustomTriggerArgumentBinding.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.WebJobs.Host.Triggers
+{
+    // Bind TMessage --> TUserType. Use IConverterManager for the conversion. 
+    // TUserType = the parameter type. 
+    internal class CustomTriggerArgumentBinding<TMessage, TTriggerValue, TUserType> : 
+        SimpleTriggerArgumentBinding<TMessage, TTriggerValue>
+    {
+        private readonly Func<TMessage, Attribute, TUserType> _converter;
+
+        public CustomTriggerArgumentBinding(
+            ITriggerBindingStrategy<TMessage, TTriggerValue> bindingStrategy, 
+            IConverterManager converterManager,
+            Func<TMessage, Attribute, TUserType> converter) :
+            base(bindingStrategy, converterManager)
+        {
+            if (converter == null)
+            {
+                throw new ArgumentNullException("converter");
+            }
+            this._converter = converter;
+            this.ElementType = typeof(TUserType);
+        }
+
+        internal override object Convert(TMessage value, Dictionary<string, object> bindingData)
+        {
+            var obj = _converter(value, null);
+            return obj;
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
+++ b/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
@@ -412,6 +412,7 @@
     <Compile Include="Bindings\AsyncCollector\OutValueProvider.cs" />
     <Compile Include="Bindings\AsyncCollector\SyncAsyncCollectorAdapter.cs" />
     <Compile Include="Triggers\TriggerArgumentBinding\ArraryTriggerArgumentBinding.cs" />
+    <Compile Include="Triggers\TriggerArgumentBinding\CustomTriggerArgumentBinding.cs" />
     <Compile Include="Triggers\TriggerArgumentBinding\PocoTriggerArgumentBinding.cs" />
     <Compile Include="Triggers\TriggerArgumentBinding\SimpleTriggerArgumentBinding.cs" />
     <Compile Include="Triggers\TriggerArgumentBinding\StringTriggerArgumentBinding.cs" />

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubConfiguration.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubConfiguration.cs
@@ -278,6 +278,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
             cm.AddConverter<string, EventData>(ConvertString2EventData);
             cm.AddConverter<EventData, string>(ConvertEventData2String);
             cm.AddConverter<byte[], EventData>(ConvertBytes2EventData); // direct, handles non-string representations
+            cm.AddConverter<EventData, byte[]>(ConvertEventData2Bytes); // direct, handles non-string representations
 
             var bf = new BindingFactory(nameResolver, cm);
 
@@ -306,6 +307,12 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         {
             var eventData = new EventData(input);
             return eventData;
+        }
+
+        private static byte[] ConvertEventData2Bytes(EventData input)
+        {
+            var bytes = input.GetBytes();
+            return bytes;
         }
 
         private static EventData ConvertString2EventData(string input)

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/FakeQueue/FakeQueueClient.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/FakeQueue/FakeQueueClient.cs
@@ -31,11 +31,23 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             return Task.FromResult(0);
         }
 
+        // Test hook for customizing converters
+        public Action<IConverterManager> SetConverters
+        {
+            get; set;
+        }
+
         void IExtensionConfigProvider.Initialize(ExtensionConfigContext context)
         {
             INameResolver nameResolver = context.Config.GetService<INameResolver>();
             IConverterManager cm = context.Config.GetService<IConverterManager>();
             cm.AddConverter<string, FakeQueueData>(x => new FakeQueueData { Message = x });
+
+            if (this.SetConverters != null)
+            {
+                this.SetConverters(cm);
+            }
+            
             cm.AddConverter<FakeQueueData, string>(msg => msg.Message);
             cm.AddConverter<OtherFakeQueueData, FakeQueueData>(OtherFakeQueueData.ToEvent);
 

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/FakeQueue/FakeQueueData.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/FakeQueue/FakeQueueData.cs
@@ -7,10 +7,13 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
     // Fake queue message. Equivalent of CloudQueueMessage or EventData
     public class FakeQueueData
     {
-        // This correpsonds to string & poco conversion. 
+        // This corresonds to string & poco conversion. 
         public string Message { get; set; }
 
         // Advanced property not captured with JSON serialization. 
         public string ExtraPropertery { get; set; }
+
+        // For testing passing bytes. 
+        public byte Byte { get; set; }
     }
 }


### PR DESCRIPTION
The heavy lifting is in the common code; and the extension just provides the converter.

This really means:
1. EventHub's config can register a EventData-->Byte[] converter
2. The trigger support leverages the converter manager to find that converter.
If no such converter is found, then we have the same behavior as today.

Fixes https://github.com/Azure/azure-webjobs-sdk/issues/825