### PR TITLE
fixing threading bug in logging

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/UpdateOutputLogCommand.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/UpdateOutputLogCommand.cs
@@ -139,7 +139,10 @@ namespace Microsoft.Azure.WebJobs.Host.Loggers
                     _synchronizedWriter.Flush();
                 }
 
-                snapshot = _innerWriter.ToString();
+                // Explicitly specify the length. Without this, any writes occurring 
+                // during the call to ToString() could throw.
+                StringBuilder innerBuilder = _innerWriter.GetStringBuilder();
+                snapshot = innerBuilder.ToString(0, innerBuilder.Length);
 
                 if (flushAndClose)
                 {


### PR DESCRIPTION
Fixes #675. 

`StringBuilder.ToString()` first allocates the string, then starts copying the buffered data to it until it reaches the end of its data. If you `Append()` more strings after the output string has been allocated, it will pass the end of the allocated string and you'll end up with the Exception we were seeing. 

By snapshotting the Length, we don't have that problem. Now the copying stops at the appropriate place, even if the `Append()` is called during `ToString()`. Thanks for brainstorming the solution @fabiocav!