### PR TITLE
MAke eventhub sending fit in 256k size limit

### DIFF
--- a/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubAsyncCollector.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubAsyncCollector.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         private const int BatchSize = 100;
 
         // Suggested to use 240k instead of 256k to leave padding room for headers.
-        private const int MaxByteSize = 240 * 1000; 
+        private const int MaxByteSize = 240 * 1024; 
 
         /// <summary>
         /// Create a sender around the given client. 
@@ -34,6 +34,10 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         /// <param name="client"></param>
         public EventHubAsyncCollector(EventHubClient client)
         {
+            if (client == null)
+            {
+                throw new ArgumentNullException("client");
+            }
             _client = client;
         }
 
@@ -45,6 +49,11 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         /// <returns></returns>
         public async Task AddAsync(EventData item, CancellationToken cancellationToken = default(CancellationToken))
         {
+            if (item == null)
+            {
+                throw new ArgumentNullException("item");
+            }
+
             while (true)
             {
                 lock (_list)
@@ -54,22 +63,20 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
                     if (size > MaxByteSize)
                     {
                         // Single event is too large to add.
-                        string msg = string.Format("Event is too large. Event is approximately {0}b and max size is {0}b", size, MaxByteSize);
+                        string msg = string.Format("Event is too large. Event is approximately {0}b and max size is {1}b", size, MaxByteSize);
                         throw new InvalidOperationException(msg);
                     }
 
-                    if ((_currentByteSize + size > MaxByteSize) || (_list.Count >= BatchSize))
-                    {
-                        // We should flush. 
-                        // Release the lock, flush, and then loop around and try again. 
-                    }
-                    else
+                    bool flush = (_currentByteSize + size > MaxByteSize) || (_list.Count >= BatchSize);
+                    if (!flush)
                     {
                         _list.Add(item);
                         _currentByteSize += size;
                         return;
                     }
-                }
+                    // We should flush. 
+                    // Release the lock, flush, and then loop around and try again. 
+                }                    
 
                 await this.FlushAsync(cancellationToken);                
             }
@@ -79,8 +86,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         /// synchronously flush events that have been queued up via AddAsync.
         /// </summary>
         /// <param name="cancellationToken">a cancellation token</param>
-        /// <returns></returns>
-        public async Task FlushAsync(CancellationToken cancellationToken)
+        public async Task FlushAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             EventData[] batch = null;
             lock (_list)
@@ -92,7 +98,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
 
             if (batch.Length > 0)
             {
-                await _client.SendBatchAsync(batch);
+                await this.SendBatchAsync(batch);
 
                 // Dispose all messages to help with memory pressure. If this is missed, the finalizer thread will still get them. 
                 foreach (var msg in batch)
@@ -100,6 +106,15 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
                     msg.Dispose();
                 }
             }
+        }
+
+        /// <summary>
+        /// Send the batch of events.
+        /// </summary>
+        /// <param name="batch">the set of events to send</param>
+        protected virtual async Task SendBatchAsync(EventData[] batch)
+        {
+            await _client.SendBatchAsync(batch);
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubAsyncCollector.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubAsyncCollector.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,36 +9,77 @@ using Microsoft.ServiceBus.Messaging;
 
 namespace Microsoft.Azure.WebJobs.ServiceBus
 {
-    // Core object to send events to EventHub. 
-    // Any user parameter that sends events will eventually get bound to this object. 
-    // This gets wrappers with various adapters and passed to the user function. 
-    internal class EventHubAsyncCollector : IAsyncCollector<EventData>
+    /// <summary>
+    /// Core object to send events to EventHub. 
+    /// Any user parameter that sends EventHub events will eventually get bound to this object. 
+    /// This will queue events and send in batches, also keeping under the 256kb event hub limit per batch. 
+    /// </summary>
+    public class EventHubAsyncCollector : IAsyncCollector<EventData>
     {
         private readonly EventHubClient _client;
 
         private List<EventData> _list = new List<EventData>();
+
+        // total size of bytes in _list that we'll be sending in this batch. 
+        private int _currentByteSize = 0;
+
         private const int BatchSize = 100;
 
+        // Suggested to use 240k instead of 256k to leave padding room for headers.
+        private const int MaxByteSize = 240 * 1000; 
+
+        /// <summary>
+        /// Create a sender around the given client. 
+        /// </summary>
+        /// <param name="client"></param>
         public EventHubAsyncCollector(EventHubClient client)
         {
             _client = client;
         }
 
-        public async Task AddAsync(EventData eventData, CancellationToken cancellationToken = default(CancellationToken))
+        /// <summary>
+        /// Add an event. 
+        /// </summary>
+        /// <param name="item">The event to add</param>
+        /// <param name="cancellationToken">a cancellation token. </param>
+        /// <returns></returns>
+        public async Task AddAsync(EventData item, CancellationToken cancellationToken = default(CancellationToken))
         {
-            bool flush;
-            lock (_list)
+            while (true)
             {
-                _list.Add(eventData);
-                flush = _list.Count > BatchSize;
-            }
+                lock (_list)
+                {
+                    var size = (int)item.SerializedSizeInBytes;
 
-            if (flush)
-            {
-                await this.FlushAsync(cancellationToken);
+                    if (size > MaxByteSize)
+                    {
+                        // Single event is too large to add.
+                        string msg = string.Format("Event is too large. Event is approximately {0}b and max size is {0}b", size, MaxByteSize);
+                        throw new InvalidOperationException(msg);
+                    }
+
+                    if ((_currentByteSize + size > MaxByteSize) || (_list.Count >= BatchSize))
+                    {
+                        // We should flush. 
+                        // Release the lock, flush, and then loop around and try again. 
+                    }
+                    else
+                    {
+                        _list.Add(item);
+                        _currentByteSize += size;
+                        return;
+                    }
+                }
+
+                await this.FlushAsync(cancellationToken);                
             }
         }
 
+        /// <summary>
+        /// synchronously flush events that have been queued up via AddAsync.
+        /// </summary>
+        /// <param name="cancellationToken">a cancellation token</param>
+        /// <returns></returns>
         public async Task FlushAsync(CancellationToken cancellationToken)
         {
             EventData[] batch = null;
@@ -45,6 +87,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
             {
                 batch = _list.ToArray();
                 _list.Clear();
+                _currentByteSize = 0;
             }
 
             if (batch.Length > 0)

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
@@ -87,6 +87,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 "EventHubConfiguration",
                 "EventHubJobHostConfigurationExtensions",
                 "EventHubTriggerAttribute",
+                "EventHubAsyncCollector",
                 "MessageProcessor",
                 "MessagingProvider",
                 "ServiceBusAccountAttribute",

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/EventHubAsyncCollectorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/EventHubAsyncCollectorTests.cs
@@ -1,0 +1,222 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.ServiceBus.Messaging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests
+{
+    public class EventHubAsyncCollectorTests
+    {
+        public class TestEventHubAsyncCollector : EventHubAsyncCollector
+        {
+            // A fake connection string for event hubs. This just needs to parse. It won't actually get invoked. 
+            const string FakeConnectionString = "Endpoint=sb://test89123-ns-x.servicebus.windows.net/;SharedAccessKeyName=ReceiveRule;SharedAccessKey=secretkey;EntityPath=path2";
+            public static EventHubClient _testClient = EventHubClient.CreateFromConnectionString(FakeConnectionString);
+
+            // EventData is disposed after sending. So track raw bytes; not the actual EventData. 
+            public List<byte[]> _sentEvents = new List<byte[]>();
+
+            public TestEventHubAsyncCollector() : base(_testClient)
+            {
+            }
+            protected override Task SendBatchAsync(EventData[] batch)
+            {
+                lock(_sentEvents)
+                {
+                    foreach (var e in batch)
+                    {
+                        var payloadBytes = e.GetBytes();
+                        Assert.NotNull(payloadBytes);
+                        _sentEvents.Add(payloadBytes);
+                    }
+                }
+                return Task.FromResult(0);
+            }
+        }
+
+        [Fact]
+        public void NullArgumentCheck()
+        {
+            Assert.Throws<ArgumentNullException>(() => new EventHubAsyncCollector(null));
+        }             
+
+        [Fact]
+        public async Task NotSentUntilFlushed()
+        {
+            var collector = new TestEventHubAsyncCollector();
+
+            await collector.FlushAsync(); // should be nop. 
+
+            var payload = new byte[] { 1, 2, 3 };
+            var e1 = new EventData(payload);
+            await collector.AddAsync(e1);
+
+            // Not physically sent yet since we haven't flushed 
+            Assert.Equal(0, collector._sentEvents.Count);
+
+            await collector.FlushAsync();
+            Assert.Equal(1, collector._sentEvents.Count);
+            Assert.Equal(payload, collector._sentEvents[0]);
+
+            // Verify the event was disposed.
+            Assert.Throws<ObjectDisposedException>(() => e1.GetBodyStream());
+        }
+
+        // If we send enough events, that will eventually tip over and flush. 
+        [Fact]
+        public async Task FlushAfterLotsOfSmallEvents()
+        {
+            var collector = new TestEventHubAsyncCollector();
+
+            // Sending a bunch of little events 
+            for (int i = 0; i < 150; i++)
+            {
+                var e1 = new EventData(new byte[] { 1, 2, 3 });
+                await collector.AddAsync(e1);
+            }
+
+            Assert.True(collector._sentEvents.Count > 0);
+        }
+
+        // If we send enough events, that will eventually tip over and flush. 
+        [Fact]
+        public async Task FlushAfterSizeThreshold()
+        {
+            var collector = new TestEventHubAsyncCollector();
+
+            // Trip the 256k EventHub limit. 
+            for (int i = 0; i < 10; i++)
+            {
+                var e1 = new EventData(new byte[10 * 1024]);
+                await collector.AddAsync(e1);
+            }
+            // Not yet 
+            Assert.Equal(0, collector._sentEvents.Count);
+
+            // This will push it over the theshold
+            for (int i = 0; i < 20; i++)
+            {
+                var e1 = new EventData(new byte[10 * 1024]);
+                await collector.AddAsync(e1);
+            }
+
+            Assert.True(collector._sentEvents.Count > 0);
+        }
+
+        [Fact]
+        public async Task CantSentGiantEvent()
+        {
+            var collector = new TestEventHubAsyncCollector();
+
+            // event hub max is 256k payload. 
+            var hugePayload = new byte[300 * 1024];
+            var e1 = new EventData(hugePayload);
+
+            try
+            {
+                await collector.AddAsync(e1);
+                Assert.False(true);
+            }
+            catch (InvalidOperationException e)
+            {
+                // Exact error message (and serialization byte size) is subject to change. 
+                Assert.Equal("Event is too large. Event is approximately 307208b and max size is 245760b", e.Message);
+            }
+
+            // Verify we didn't queue anything
+            await collector.FlushAsync();
+            Assert.Equal(0, collector._sentEvents.Count);
+        }
+
+        [Fact]
+        public async Task CantSendNullEvent()
+        {
+            var collector = new TestEventHubAsyncCollector();
+
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                async () => await collector.AddAsync(null)
+            );
+        }
+
+        // Send lots of events from multiple threads and ensure that all events are precisely accounted for. 
+        [Fact]
+        public async Task SendLotsOfEvents()
+        {
+            var collector = new TestEventHubAsyncCollector();
+
+            int numEvents = 1000;
+            int numThreads = 10;
+
+            HashSet<string> expected = new HashSet<string>();
+
+            // Send from different physical threads.             
+            Thread[] threads = new Thread[numThreads];
+            for (int iThread = 0; iThread < numThreads; iThread++)
+            {
+                var x = iThread;
+                threads[x] = new Thread(
+                    () =>
+                    {
+                        for (int i = 0; i < numEvents; i++)
+                        {
+                            var idx = x * numEvents + i;
+                            var payloadStr = idx.ToString();
+                            var payload = Encoding.UTF8.GetBytes(payloadStr);
+                            lock (expected)
+                            {
+                                expected.Add(payloadStr);
+                            }
+                            collector.AddAsync(new EventData(payload)).Wait();
+                        }
+                    });
+            };
+
+
+            foreach (var thread in threads)
+            {
+                thread.Start();
+            }
+
+            foreach (var thread in threads)
+            {
+                thread.Join();
+            }
+
+
+            // Add more events to trip flushing of the original batch without calling Flush()
+            const string ignore = "ignore";
+            byte[] ignoreBytes = Encoding.UTF8.GetBytes(ignore);
+            for (int i = 0; i < 100; i++)
+            {
+                await collector.AddAsync(new EventData(ignoreBytes));
+            }
+
+            // Verify that every event we sent is accounted for; and that there are no duplicates. 
+            int count = 0;
+            foreach (var payloadBytes in collector._sentEvents)
+            {
+                count++;   
+                var payloadStr = Encoding.UTF8.GetString(payloadBytes);
+                if (payloadStr == ignore)
+                {
+                    continue;
+                }
+                if (!expected.Remove(payloadStr))
+                {
+                    // Already removed!
+                    Assert.False(true, "event payload occured multiple times");
+                }
+            }
+
+            Assert.Equal(0, expected.Count); // Some events where missed. 
+
+        }            
+    } // end class         
+}

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/WebJobs.ServiceBus.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/WebJobs.ServiceBus.UnitTests.csproj
@@ -126,6 +126,7 @@
     <Compile Include="Config\ServiceBusConfigurationTests.cs" />
     <Compile Include="Config\ServiceBusJobHostConfigurationExtensionsTests.cs" />
     <Compile Include="Config\ServiceBusExtensionConfigTests.cs" />
+    <Compile Include="EventHubAsyncCollectorTests.cs" />
     <Compile Include="EventHubTests.cs" />
     <Compile Include="Listeners\ServiceBusListenerTests.cs" />
     <Compile Include="Listeners\ServiceBusQueueListenerFactoryTests.cs" />


### PR DESCRIPTION
EventHub can't send more than 256k of data at once. So the EventHub async collector needs to batch it. 
This is generally useful, so make the collector be public. 

Fix https://github.com/Azure/azure-webjobs-sdk/issues/834

Need to think of a good way to test this - none of the EventHub methods are virtual. 