### PR TITLE
Truncate log entries with silly  long string values.

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/FunctionInstanceLogEntry.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/FunctionInstanceLogEntry.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.WebJobs.Host.Loggers
         public IDictionary<string, string> Arguments { get; set; }
 
         /// <summary>Direct inline capture for output written to the per-function instance TextWriter log. 
-        /// For large log outputs, this is faulted over to a blob. </summary>
+        /// For large log outputs, this is truncated</summary>
         public string LogOutput { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Logging/Entities/InstanceTableEntity.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging/Entities/InstanceTableEntity.cs
@@ -19,6 +19,8 @@ namespace Microsoft.Azure.WebJobs.Logging
 
         internal static InstanceTableEntity New(FunctionInstanceLogItem item)
         {
+            item.Truncate();
+
             string argumentJson = null;
             if (item.Arguments != null)
             {


### PR DESCRIPTION
Fix https://github.com/Azure/azure-webjobs-sdk/issues/847