### PR TITLE
Extending struct data binding to support nullable types

### DIFF
--- a/Settings.StyleCop
+++ b/Settings.StyleCop
@@ -10,6 +10,7 @@
       <Value>Guid</Value>
       <Value>linq</Value>
       <Value>mockable</Value>
+      <Value>Nullable</Value>
       <Value>Nullables</Value>
       <Value>odata</Value>
       <Value>Queryable</Value>

--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/Data/StructDataBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/Data/StructDataBindingProvider.cs
@@ -8,8 +8,10 @@ using Microsoft.Azure.WebJobs.Host.Converters;
 
 namespace Microsoft.Azure.WebJobs.Host.Bindings.Data
 {
+    /// <summary>
+    /// Handles value types (structs) as well as nullable types.
+    /// </summary>
     internal class StructDataBindingProvider<TBindingData> : IBindingProvider
-        where TBindingData : struct
     {
         private static readonly IDataArgumentBindingProvider<TBindingData> InnerProvider =
             new CompositeArgumentBindingProvider<TBindingData>(

--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/ObjectToTypeConverterFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/ObjectToTypeConverterFactory.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
             return Create(identityConverter);
         }
 
-        public static IObjectToTypeConverter<TOutput> CreateForStruct<TOutput>() where TOutput : struct
+        public static IObjectToTypeConverter<TOutput> CreateForStruct<TOutput>()
         {
             IObjectToTypeConverter<TOutput> identityConverter =
                 new StructOutputConverter<TOutput, TOutput>(new IdentityConverter<TOutput>());

--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/StructOutputConverter.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/StructOutputConverter.cs
@@ -6,18 +6,19 @@ using Microsoft.Azure.WebJobs.Host.Converters;
 namespace Microsoft.Azure.WebJobs.Host.Bindings
 {
     internal class StructOutputConverter<TInput, TOutput> : IObjectToTypeConverter<TOutput>
-        where TInput : struct
     {
+        private readonly bool _isNullable;
         private readonly IConverter<TInput, TOutput> _innerConverter;
 
         public StructOutputConverter(IConverter<TInput, TOutput> innerConverter)
         {
+            _isNullable = TypeUtility.IsNullable(typeof(TInput));
             _innerConverter = innerConverter;
         }
 
         public bool TryConvert(object input, out TOutput output)
         {
-            if (!(input is TInput))
+            if (!(input is TInput) && !(input == null && _isNullable))
             {
                 output = default(TOutput);
                 return false;

--- a/src/Microsoft.Azure.WebJobs.Host/TypeUtility.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/TypeUtility.cs
@@ -2,12 +2,30 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Globalization;
 using System.Reflection;
 
 namespace Microsoft.Azure.WebJobs.Host
 {
     internal static class TypeUtility
-    {    
+    {
+        internal static string GetFriendlyName(Type type)
+        {
+            if (TypeUtility.IsNullable(type))
+            {
+                return string.Format(CultureInfo.InvariantCulture, "Nullable<{0}>", type.GetGenericArguments()[0].Name);
+            }
+            else
+            {
+                return type.Name;
+            }
+        }
+
+        internal static bool IsNullable(Type type)
+        {
+            return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
+        }
+
         /// <summary>
         /// Walk from the parameter up to the containing type, looking for an instance
         /// of the specified attribute type, returning it if found.

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/TypeUtilityTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/TypeUtilityTests.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Host.UnitTests
+{
+    public class TypeUtilityTests
+    {
+        [Theory]
+        [InlineData(typeof(TypeUtilityTests), false)]
+        [InlineData(typeof(string), false)]
+        [InlineData(typeof(int), false)]
+        [InlineData(typeof(int?), true)]
+        [InlineData(typeof(Nullable<int>), true)]
+        public void IsNullable_ReturnsExpectedResult(Type type, bool expected)
+        {
+            Assert.Equal(expected, TypeUtility.IsNullable(type));
+        }
+
+        [Theory]
+        [InlineData(typeof(TypeUtilityTests), "TypeUtilityTests")]
+        [InlineData(typeof(string), "String")]
+        [InlineData(typeof(int), "Int32")]
+        [InlineData(typeof(int?), "Nullable<Int32>")]
+        [InlineData(typeof(Nullable<int>), "Nullable<Int32>")]
+        public void GetFriendlyName(Type type, string expected)
+        {
+            Assert.Equal(expected, TypeUtility.GetFriendlyName(type));
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
@@ -224,6 +224,7 @@
     <Compile Include="TestJobHostContextFactory.cs" />
     <Compile Include="TestJobHostConfiguration.cs" />
     <Compile Include="Timers\RandomizedExponentialBackoffStrategyTests.cs" />
+    <Compile Include="TypeUtilityTests.cs" />
     <Compile Include="WebJobsShutdownWatcherTests.cs" />
     <Compile Include="Blobs\BlobPathSourceTests.cs" />
     <Compile Include="Blobs\BlobPathTests.cs" />


### PR DESCRIPTION
Currently our binding pipeline doesn't support binding method parameters to nullable types. All our current binding contract types have been non-nullable I guess.

The need for this arose in Azure Functions recently, where we have an HttpTrigger binding whose binding data contract includes route parameters, which can be **optional** (i.e. nullable). See the example below where the `int?` parameter comes from an optional route parameter `products/{category:alpha}/{id:int?}`. These changes allow this to work, whereas before we'd get casting errors / type mismatch errors.

```csharp
public class ProductInfo
{
    public string Category { get; set; }
    public int? Id { get; set; }
}

public static ProductInfo Run(ProductInfo info, string category, int? id, TraceWriter log)
{
    log.Info($"ProductInfo: Category={category} Id={id}");
    log.Info($"Parameters: category={category} id={id}");

    return info;
}
```