### PR TITLE
Validate storage account type against attribute bindings

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Blobs/Triggers/BlobTriggerAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Blobs/Triggers/BlobTriggerAttributeBindingProvider.cs
@@ -159,6 +159,8 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Triggers
 
             IStorageAccount hostAccount = await _accountProvider.GetStorageAccountAsync(context.CancellationToken);
             IStorageAccount dataAccount = await _accountProvider.GetStorageAccountAsync(context.Parameter, context.CancellationToken, _nameResolver);
+            // premium does not support blob logs, so disallow for blob triggers
+            dataAccount.AssertTypeOneOf(StorageAccountType.GeneralPurpose, StorageAccountType.BlobOnly);
 
             ITriggerBinding binding = new BlobTriggerBinding(parameter, argumentBinding, hostAccount, dataAccount, path,
                 _hostIdProvider, _queueConfiguration, _exceptionHandler, _blobWrittenWatcherSetter,

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/DefaultStorageAccountProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/DefaultStorageAccountProvider.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Reflection;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Storage;
@@ -176,7 +176,12 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             if (account != null)
             {
                 // On the first attempt, this will make a network call to verify the credentials work.
-                await _storageCredentialsValidator.ValidateCredentialsAsync(account, isPrimary, cancellationToken);
+                await _storageCredentialsValidator.ValidateCredentialsAsync(account, cancellationToken);
+
+                if (isPrimary)
+                {
+                    account.AssertTypeOneOf(StorageAccountType.GeneralPurpose);
+                }
             }
 
             return account;

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/IStorageCredentialsValidator.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/IStorageCredentialsValidator.cs
@@ -9,6 +9,6 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
 {
     internal interface IStorageCredentialsValidator
     {
-        Task ValidateCredentialsAsync(IStorageAccount account, bool isPrimaryAccount, CancellationToken cancellationToken);
+        Task ValidateCredentialsAsync(IStorageAccount account, CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Queues/Bindings/QueueBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Queues/Bindings/QueueBindingProvider.cs
@@ -119,6 +119,7 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Bindings
             Task<IStorageAccount> t = Task.Run(() =>
                 _accountProvider.GetStorageAccountAsync(parameter, CancellationToken.None, nameResolver));
             IStorageAccount account = t.GetAwaiter().GetResult();
+
             if (account == null)
             {
                 throw new InvalidOperationException("Unable to bind Queue because no storage account has been configured.");

--- a/src/Microsoft.Azure.WebJobs.Host/Queues/Triggers/QueueTriggerAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Queues/Triggers/QueueTriggerAttributeBindingProvider.cs
@@ -101,6 +101,9 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Triggers
             }
 
             IStorageAccount account = await _accountProvider.GetStorageAccountAsync(context.Parameter, context.CancellationToken, _nameResolver);
+            // requires storage account with queue support
+            account.AssertTypeOneOf(StorageAccountType.GeneralPurpose);
+
             StorageClientFactoryContext clientFactoryContext = new StorageClientFactoryContext
             {
                 Parameter = parameter

--- a/src/Microsoft.Azure.WebJobs.Host/Singleton/SingletonManager.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Singleton/SingletonManager.cs
@@ -330,6 +330,8 @@ namespace Microsoft.Azure.WebJobs.Host
             {
                 Task<IStorageAccount> task = _accountProvider.GetAccountAsync(accountName, CancellationToken.None);
                 IStorageAccount storageAccount = task.Result;
+                // singleton requires block blobs, cannot be premium
+                storageAccount.AssertTypeOneOf(StorageAccountType.GeneralPurpose, StorageAccountType.BlobOnly);
                 IStorageBlobClient blobClient = storageAccount.CreateBlobClient();
                 storageDirectory = blobClient.GetContainerReference(HostContainerNames.Hosts)
                                        .GetDirectoryReference(HostDirectoryNames.SingletonLocks);

--- a/src/Microsoft.Azure.WebJobs.Host/Storage/IStorageAccount.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Storage/IStorageAccount.cs
@@ -24,6 +24,9 @@ namespace Microsoft.Azure.WebJobs.Host.Storage
         /// <summary>Gets the underlying <see cref="CloudStorageAccount"/>.</summary>
         CloudStorageAccount SdkObject { get; }
 
+        /// <summary>Gets the type of the storage account.</summary>
+        StorageAccountType Type { get; set; }
+
         /// <summary>Creates a blob client.</summary>
         /// <returns>A blob client.</returns>
         IStorageBlobClient CreateBlobClient(StorageClientFactoryContext context = null);

--- a/src/Microsoft.Azure.WebJobs.Host/Storage/IStorageAccountExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Storage/IStorageAccountExtensions.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Linq;
+
+namespace Microsoft.Azure.WebJobs.Host.Storage
+{
+    internal static class StorageAccountExtensions
+    {
+        public static void AssertTypeOneOf(this IStorageAccount account, params StorageAccountType[] types)
+        {
+            if (!types.Contains(account.Type))
+            {
+                var message = string.Format(CultureInfo.CurrentCulture,
+                    "Storage account '{0}' is of unsupported type '{1}'. Supported types are '{2}'", 
+                    account.Credentials.AccountName, account.Type, String.Join("', '", types));
+                throw new InvalidOperationException(message);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Storage/StorageAccount.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Storage/StorageAccount.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Azure.WebJobs.Host.Storage
 
             _sdkAccount = sdkAccount;
             _services = services;
+            Type = StorageAccountType.GeneralPurpose;
         }
 
         /// <inheritdoc />
@@ -55,6 +56,9 @@ namespace Microsoft.Azure.WebJobs.Host.Storage
         {
             get { return _sdkAccount; }
         }
+
+        /// <inheritdoc />
+        public StorageAccountType Type { get; set; }
 
         private StorageClientFactory ClientFactory
         {

--- a/src/Microsoft.Azure.WebJobs.Host/Storage/StorageAccountType.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Storage/StorageAccountType.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Host.Storage
+{
+    internal enum StorageAccountType
+    {
+        // Supports blob/table/queue.
+        // Can be used as primary or secondary storage.
+        GeneralPurpose,
+
+        // Supports only blobs.
+        // Cannot be used as primary storage account (AzureWebJobsStorage).
+        BlobOnly,
+
+        // Supports only page blobs, no logging.
+        // Cannot be used as primary storage account (AzureWebJobsStorage).
+        // Cannot be used as blob trigger due to lack of logs.
+        Premium
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Tables/TableAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Tables/TableAttributeBindingProvider.cs
@@ -204,6 +204,9 @@ namespace Microsoft.Azure.WebJobs.Host.Tables
 
             string tableName = Resolve(tableAttribute.TableName);
             IStorageAccount account = await _accountProvider.GetStorageAccountAsync(context.Parameter, context.CancellationToken, _nameResolver);
+            // requires storage account with table support
+            account.AssertTypeOneOf(StorageAccountType.GeneralPurpose);
+
             StorageClientFactoryContext clientFactoryContext = new StorageClientFactoryContext
             {
                 Parameter = context.Parameter

--- a/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
+++ b/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
@@ -417,6 +417,8 @@
     <Compile Include="Blobs\Listeners\ScanBlobScanLogHybridPollingStrategy.cs" />
     <Compile Include="Bindings\AsyncCollector\AsyncCollectorBinding.cs" />
     <Compile Include="Config\ExtensionConfigContextExtensions.cs" />
+    <Compile Include="Storage\IStorageAccountExtensions.cs" />
+    <Compile Include="Storage\StorageAccountType.cs" />
     <Compile Include="Triggers\StrategyTriggerBinding.cs" />
     <Compile Include="Bindings\ConstantValueProvider.cs" />
     <Compile Include="Bindings\ConverterManager.cs" />

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/TestDoubles/FakeStorageAccount.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/TestDoubles/FakeStorageAccount.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests.TestDoubles
         private readonly MemoryTableStore _tableStore = new MemoryTableStore();
         private readonly CloudStorageAccount _sdkObject = new CloudStorageAccount(_credentials, _endpoint, _endpoint,
             _endpoint, _endpoint);
+        private StorageAccountType _type = StorageAccountType.GeneralPurpose;
 
         public Uri BlobEndpoint
         {
@@ -40,6 +41,12 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests.TestDoubles
         public CloudStorageAccount SdkObject
         {
             get { return _sdkObject; }
+        }
+
+        public StorageAccountType Type
+        {
+            get { return _type; }
+            set { _type = value; }
         }
 
         public IStorageBlobClient CreateBlobClient(StorageClientFactoryContext context = null)

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Singleton/SingletonManagerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Singleton/SingletonManagerTests.cs
@@ -47,7 +47,9 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Singleton
             _mockBlobDirectory = new Mock<IStorageBlobDirectory>(MockBehavior.Strict);
             _mockSecondaryBlobDirectory = new Mock<IStorageBlobDirectory>(MockBehavior.Strict);
             _mockStorageAccount = new Mock<IStorageAccount>(MockBehavior.Strict);
+            _mockStorageAccount.SetupGet(a => a.Type).Returns(StorageAccountType.GeneralPurpose);
             _mockSecondaryStorageAccount = new Mock<IStorageAccount>(MockBehavior.Strict);
+            _mockSecondaryStorageAccount.SetupGet(a => a.Type).Returns(StorageAccountType.GeneralPurpose);
             Mock<IStorageBlobClient> mockBlobClient = new Mock<IStorageBlobClient>(MockBehavior.Strict);
             Mock<IStorageBlobClient> mockSecondaryBlobClient = new Mock<IStorageBlobClient>(MockBehavior.Strict);
             Mock<IStorageBlobContainer> mockBlobContainer = new Mock<IStorageBlobContainer>(MockBehavior.Strict);


### PR DESCRIPTION
related to #810 and [script/#773](https://github.com/Azure/azure-webjobs-sdk-script/issues/773)

Looking for initial feedback before I add tests & polish.

Added `StorageAccountType` to storage accounts, which is set to `premium` or `blobonly` in `validateCredentialsAsync`.  ~~In each binding provider I test if the storage account type is compatible with that attribute.~~

When you request a StorageAccount you supply the supported storage account types.  If the account is not of the supported type, we throw an error indicating the invalid type & what types are supported.

 Added `SupportedTypes` to StorageAccountAttribute with default `All`, so that from functions we can disabled Premium storage for BlobTriggerAttributes.

``` c#
// to throw if 'somename' is a Premium storage account, you can write this:
StorageAccount('somename', ~StorageAccountTypes.Premium)
```
