### PR TITLE
Table bindings for Script

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Indexers/DefaultBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Indexers/DefaultBindingProvider.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
             innerProviders.Add(ruleQueueOutput);
 
             innerProviders.Add(new BlobAttributeBindingProvider(nameResolver, storageAccountProvider, extensionTypeLocator, blobWrittenWatcherGetter));
-            innerProviders.Add(new TableAttributeBindingProvider(nameResolver, storageAccountProvider, extensions));
+            innerProviders.Add(TableAttributeBindingProvider.Build(nameResolver, converterManager, storageAccountProvider, extensions));
 
             // add any registered extension binding providers
             foreach (IBindingProvider provider in extensions.GetExtensions(typeof(IBindingProvider)))

--- a/src/Microsoft.Azure.WebJobs.Host/Tables/CollectorArgumentBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Tables/CollectorArgumentBindingProvider.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Storage.Table;
 using Microsoft.WindowsAzure.Storage.Table;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Host.Tables
 {
@@ -22,8 +23,8 @@ namespace Microsoft.Azure.WebJobs.Host.Tables
             }
 
             Type entityType = GetCollectorItemType(parameter.ParameterType);
-
-            if (!TableClient.ImplementsOrEqualsITableEntity(entityType))
+                        
+            if (!TableClient.ImplementsOrEqualsITableEntity(entityType) && !TypeUtility.IsJObject(entityType))
             {
                 TableClient.VerifyContainsProperty(entityType, "RowKey");
                 TableClient.VerifyContainsProperty(entityType, "PartitionKey");

--- a/src/Microsoft.Azure.WebJobs.Host/Tables/PocoEntityWriter.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Tables/PocoEntityWriter.cs
@@ -51,5 +51,5 @@ namespace Microsoft.Azure.WebJobs.Host.Tables
         {
             return TableEntityWriter.GetStatus();
         }
-    }
+    }    
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Tables/TableAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Tables/TableAttributeBindingProvider.cs
@@ -2,13 +2,16 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Storage;
 using Microsoft.Azure.WebJobs.Host.Storage.Table;
 using Microsoft.WindowsAzure.Storage.Table;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Host.Tables
 {
@@ -20,7 +23,7 @@ namespace Microsoft.Azure.WebJobs.Host.Tables
         private readonly INameResolver _nameResolver;
         private readonly IStorageAccountProvider _accountProvider;
 
-        public TableAttributeBindingProvider(INameResolver nameResolver, IStorageAccountProvider accountProvider, IExtensionRegistry extensions)
+        private TableAttributeBindingProvider(INameResolver nameResolver, IStorageAccountProvider accountProvider, IExtensionRegistry extensions)
         {
             if (accountProvider == null)
             {
@@ -47,6 +50,143 @@ namespace Microsoft.Azure.WebJobs.Host.Tables
                 new CompositeEntityArgumentBindingProvider(
                 new TableEntityArgumentBindingProvider(),
                 new PocoEntityArgumentBindingProvider()); // Supports all types; must come after other providers
+        }
+
+        // [Table] has some pre-existing behavior where the storage account can be specified outside of the [Queue] attribute. 
+        // The storage account is pulled from the ParameterInfo (which could pull in a [Storage] attribute on the container class)
+        // Resolve everything back down to a single attribute so we can use the binding helpers. 
+        // This pattern should be rare since other extensions can just keep everything directly on the primary attribute. 
+        private async Task<TableAttribute> CollectAttributeInfo(TableAttribute attrResolved, ParameterInfo parameter, INameResolver nameResolver)
+        {
+            // Look for [Storage] attribute and squirrel over 
+            IStorageAccount account = await _accountProvider.GetStorageAccountAsync(parameter, CancellationToken.None, nameResolver);
+            StorageClientFactoryContext clientFactoryContext = new StorageClientFactoryContext
+            {
+                Parameter = parameter
+            };
+            IStorageTableClient client = account.CreateTableClient(clientFactoryContext);
+
+            return new ResolvedTableAttribute(attrResolved, client);
+        }
+        
+        public static IBindingProvider Build(INameResolver nameResolver, IConverterManager converterManager, IStorageAccountProvider accountProvider, IExtensionRegistry extensions)
+        {
+            var original = new TableAttributeBindingProvider(nameResolver, accountProvider, extensions);
+
+            converterManager.AddConverter<JObject, ITableEntity, TableAttribute>(original.JObjectToTableEntityConverterFunc);
+
+            var bindingFactory = new BindingFactory(nameResolver, converterManager);
+            var bindAsyncCollector = bindingFactory.BindToAsyncCollector<TableAttribute, ITableEntity>(original.BuildFromTableAttribute, null, original.CollectAttributeInfo);
+
+            var bindToJobject = bindingFactory.BindToExactAsyncType<TableAttribute, JObject>(original.BuildJObject, null, original.CollectAttributeInfo);
+            var bindToJArray = bindingFactory.BindToExactAsyncType<TableAttribute, JArray>(original.BuildJArray, null, original.CollectAttributeInfo);
+
+            // Filter to just support JObject, and use legacy bindings for everything else. 
+            // Once we have ITableEntity converters for pocos, we can remove the filter. 
+            // https://github.com/Azure/azure-webjobs-sdk/issues/887
+            bindAsyncCollector = bindingFactory.AddFilter<TableAttribute>(
+                (attr, type) => (type == typeof(IAsyncCollector<JObject>) || type == typeof(ICollector<JObject>)), 
+                bindAsyncCollector); 
+
+            var bindingProvider = new GenericCompositeBindingProvider<TableAttribute>(
+                new IBindingProvider[] { bindToJArray, bindToJobject, bindAsyncCollector, original });
+
+            return bindingProvider;
+        }
+        
+        private async Task<JObject> BuildJObject(TableAttribute attribute)
+        {
+            IStorageTable table = GetTable(attribute);
+
+            IStorageTableOperation retrieve = table.CreateRetrieveOperation<DynamicTableEntity>(
+              attribute.PartitionKey, attribute.RowKey);
+            TableResult result = await table.ExecuteAsync(retrieve, CancellationToken.None);
+            DynamicTableEntity entity = (DynamicTableEntity)result.Result;
+            if (entity == null)
+            {
+                return null;
+            }
+            else
+            {
+                var obj = ConvertEntityToJObject(entity);
+                return obj;
+            }
+        }
+
+        // Build a JArray.
+        // Used as an alternative to binding to IQueryable.
+        private async Task<JArray> BuildJArray(TableAttribute attribute)
+        {
+            var table = GetTable(attribute).SdkObject;
+
+            string finalQuery = attribute.Filter;
+            if (!string.IsNullOrEmpty(attribute.PartitionKey))
+            {
+                var partitionKeyPredicate = TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.Equal, attribute.PartitionKey);
+                if (!string.IsNullOrEmpty(attribute.Filter))
+                {
+                    finalQuery = TableQuery.CombineFilters(attribute.Filter, TableOperators.And, partitionKeyPredicate);
+                }
+                else
+                {
+                    finalQuery = partitionKeyPredicate;
+                }
+            }
+
+            TableQuery tableQuery = new TableQuery
+            {
+                TakeCount = attribute.Take, // Batch size for query. 
+                FilterString = finalQuery
+            };
+            int countRemaining = attribute.Take;
+
+            JArray entityArray = new JArray();
+            TableContinuationToken token = null;
+
+            do
+            {
+                var segment = await table.ExecuteQuerySegmentedAsync(tableQuery, token);
+                var entities = segment.Results;
+
+                token = segment.ContinuationToken;
+
+                foreach (var entity in entities)
+                {
+                    countRemaining--;
+                    entityArray.Add(ConvertEntityToJObject(entity));
+
+                    if (countRemaining == 0)
+                    {
+                        token = null;
+                        break;
+                    }
+                }                
+            }
+            while (token != null);                      
+
+            return entityArray;
+        }
+
+        private IAsyncCollector<ITableEntity> BuildFromTableAttribute(TableAttribute attribute)
+        {
+            IStorageTable table = GetTable(attribute);
+
+            var writer = new TableEntityWriter<ITableEntity>(table);
+            return writer;
+        }
+
+        // Get the storage table from the attribute.
+        private static IStorageTable GetTable(TableAttribute attribute)
+        {
+            var tableClient = ((ResolvedTableAttribute)attribute).Client;                           
+            IStorageTable table = tableClient.GetTableReference(attribute.TableName);
+            return table;
+        }
+
+        private ITableEntity JObjectToTableEntityConverterFunc(JObject source, TableAttribute attribute)
+        {
+            var result = this.CreateTableEntityFromJObject(attribute.PartitionKey, attribute.RowKey, source);
+            return result;
         }
 
         public async Task<IBinding> TryCreateAsync(BindingProviderContext context)
@@ -112,6 +252,112 @@ namespace Microsoft.Azure.WebJobs.Host.Tables
             }
 
             return _nameResolver.ResolveWholeString(queueName);
+        }
+
+        private static JObject ConvertEntityToJObject(DynamicTableEntity tableEntity)
+        {
+            JObject jsonObject = new JObject();
+            foreach (var entityProperty in tableEntity.Properties)
+            {
+                JValue value = null;
+                switch (entityProperty.Value.PropertyType)
+                {
+                    case EdmType.String:
+                        value = new JValue(entityProperty.Value.StringValue);
+                        break;
+                    case EdmType.Int32:
+                        value = new JValue(entityProperty.Value.Int32Value);
+                        break;
+                    case EdmType.Int64:
+                        value = new JValue(entityProperty.Value.Int64Value);
+                        break;
+                    case EdmType.DateTime:
+                        value = new JValue(entityProperty.Value.DateTime);
+                        break;
+                    case EdmType.Boolean:
+                        value = new JValue(entityProperty.Value.BooleanValue);
+                        break;
+                    case EdmType.Guid:
+                        value = new JValue(entityProperty.Value.GuidValue);
+                        break;
+                    case EdmType.Double:
+                        value = new JValue(entityProperty.Value.DoubleValue);
+                        break;
+                    case EdmType.Binary:
+                        value = new JValue(entityProperty.Value.BinaryValue);
+                        break;
+                }
+
+                jsonObject.Add(entityProperty.Key, value);
+            }
+
+            jsonObject.Add("PartitionKey", tableEntity.PartitionKey);
+            jsonObject.Add("RowKey", tableEntity.RowKey);
+
+            return jsonObject;
+        }
+
+        private DynamicTableEntity CreateTableEntityFromJObject(string partitionKey, string rowKey, JObject entity)
+        {
+            // any key values specified on the entity override any values
+            // specified in the binding
+            JProperty keyProperty = entity.Properties().SingleOrDefault(p => string.Compare(p.Name, "partitionKey", StringComparison.OrdinalIgnoreCase) == 0);
+            if (keyProperty != null)
+            {
+                partitionKey = Resolve((string)keyProperty.Value);
+                entity.Remove(keyProperty.Name);
+            }
+
+            keyProperty = entity.Properties().SingleOrDefault(p => string.Compare(p.Name, "rowKey", StringComparison.OrdinalIgnoreCase) == 0);
+            if (keyProperty != null)
+            {
+                rowKey = Resolve((string)keyProperty.Value);
+                entity.Remove(keyProperty.Name);
+            }
+
+            DynamicTableEntity tableEntity = new DynamicTableEntity(partitionKey, rowKey);
+            foreach (JProperty property in entity.Properties())
+            {
+                EntityProperty entityProperty = CreateEntityPropertyFromJProperty(property);
+                tableEntity.Properties.Add(property.Name, entityProperty);
+            }
+
+            return tableEntity;
+        }
+
+        private static EntityProperty CreateEntityPropertyFromJProperty(JProperty property)
+        {
+            switch (property.Value.Type)
+            {
+                case JTokenType.String:
+                    return EntityProperty.GeneratePropertyForString((string)property.Value);
+                case JTokenType.Integer:
+                    return EntityProperty.GeneratePropertyForInt((int)property.Value);
+                case JTokenType.Boolean:
+                    return EntityProperty.GeneratePropertyForBool((bool)property.Value);
+                case JTokenType.Guid:
+                    return EntityProperty.GeneratePropertyForGuid((Guid)property.Value);
+                case JTokenType.Float:
+                    return EntityProperty.GeneratePropertyForDouble((double)property.Value);
+                default:
+                    return EntityProperty.CreateEntityPropertyFromObject((object)property.Value);
+            }
+        }
+
+        // Table attributes can optionally be paired with a separate [StorageAccount]. 
+        // Consolidate the information from both attributes into a single attribute.
+        // New extensions should just place everything in the attribute or the configuration and so shouldn't need to do this. 
+        internal sealed class ResolvedTableAttribute : TableAttribute
+        {
+            public ResolvedTableAttribute(TableAttribute inner, IStorageTableClient client)
+                : base(inner.TableName, inner.PartitionKey, inner.RowKey)
+            {
+                this.Take = inner.Take;
+                this.Filter = inner.Filter;
+                this.Client = client;
+            }
+
+            internal IStorageTableClient Client { get; private set; }
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/TypeUtility.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/TypeUtility.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Globalization;
 using System.Reflection;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Host
 {
@@ -24,6 +25,11 @@ namespace Microsoft.Azure.WebJobs.Host
         internal static bool IsNullable(Type type)
         {
             return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
+        }
+
+        internal static bool IsJObject(Type type)
+        {
+            return type == typeof(JObject);
         }
 
         /// <summary>

--- a/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
+++ b/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
@@ -29,6 +29,9 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Microsoft.Azure.WebJobs.Host.xml</DocumentationFile>
     <LangVersion>5</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
+    <CodeAnalysisIgnoreGeneratedCode>true</CodeAnalysisIgnoreGeneratedCode>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/Microsoft.Azure.WebJobs/GlobalSuppressions.cs
+++ b/src/Microsoft.Azure.WebJobs/GlobalSuppressions.cs
@@ -2,3 +2,4 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1019:DefineAccessorsForAttributeArguments", Scope = "type", Target = "Microsoft.Azure.WebJobs.TimeoutAttribute")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1813:AvoidUnsealedAttributes", Scope = "type", Target = "Microsoft.Azure.WebJobs.TableAttribute")]

--- a/src/Microsoft.Azure.WebJobs/TableAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs/TableAttribute.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.WebJobs
     /// </remarks>
     [AttributeUsage(AttributeTargets.Parameter)]
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
-    public sealed class TableAttribute : Attribute
+    public class TableAttribute : Attribute
     {
         private readonly string _tableName;
         private readonly string _partitionKey;
@@ -47,6 +47,15 @@ namespace Microsoft.Azure.WebJobs
         /// <summary>Initializes a new instance of the <see cref="TableAttribute"/> class.</summary>
         /// <param name="tableName">The name of the table containing the entity.</param>
         /// <param name="partitionKey">The partition key of the entity.</param>
+        public TableAttribute(string tableName, string partitionKey)
+        {
+            _tableName = tableName;
+            _partitionKey = partitionKey;
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="TableAttribute"/> class.</summary>
+        /// <param name="tableName">The name of the table containing the entity.</param>
+        /// <param name="partitionKey">The partition key of the entity.</param>
         /// <param name="rowKey">The row key of the entity.</param>
         public TableAttribute(string tableName, string partitionKey, string rowKey)
         {
@@ -57,6 +66,7 @@ namespace Microsoft.Azure.WebJobs
 
         /// <summary>Gets the name of the table to which to bind.</summary>
         /// <remarks>When binding to a table entity, gets the name of the table containing the entity.</remarks>
+        [AutoResolve]
         public string TableName
         {
             get { return _tableName; }
@@ -64,6 +74,7 @@ namespace Microsoft.Azure.WebJobs
 
         /// <summary>When binding to a table entity, gets the partition key of the entity.</summary>
         /// <remarks>When binding to an entire table, returns <see langword="null"/>.</remarks>
+        [AutoResolve]
         public string PartitionKey
         {
             get { return _partitionKey; }
@@ -71,10 +82,28 @@ namespace Microsoft.Azure.WebJobs
 
         /// <summary>When binding to a table entity, gets the row key of the entity.</summary>
         /// <remarks>When binding to an entire table, returns <see langword="null"/>.</remarks>
+        [AutoResolve]
         public string RowKey
         {
             get { return _rowKey; }
         }
+
+        /// <summary>
+        /// Allow arbitrary table filter. RowKey should be null. 
+        /// </summary>
+        [AutoResolve]
+        public string Filter
+        {
+            get; set;
+        }
+
+        /// <summary>
+        /// Used with filter. RowKey should be null. 
+        /// </summary>
+        public int Take
+        {
+            get; set;
+        }        
 
         [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         private string DebuggerDisplay

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/StorageTableExtensions.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/StorageTableExtensions.cs
@@ -52,6 +52,19 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
             table.ExecuteAsync(operation, CancellationToken.None).GetAwaiter().GetResult();
         }
 
+
+        public static void InsertOrReplace(this IStorageTable table, ITableEntity entity)
+        {
+            if (table == null)
+            {
+                throw new ArgumentNullException("table");
+            }
+
+            IStorageTableOperation operation = table.CreateInsertOrReplaceOperation(entity);
+            table.ExecuteAsync(operation, CancellationToken.None).GetAwaiter().GetResult();
+        }
+
+
         public static TElement Retrieve<TElement>(this IStorageTable table, string partitionKey, string rowKey)
             where TElement : ITableEntity, new()
         {

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Tables/PocoToTableEntityConverterTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Tables/PocoToTableEntityConverterTests.cs
@@ -947,7 +947,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Tables
 
         private static PocoToTableEntityConverter<TInput> CreateProductUnderTest<TInput>()
         {
-            PocoToTableEntityConverter<TInput> product = PocoToTableEntityConverter<TInput>.Create();
+            var product = PocoToTableEntityConverter<TInput>.Create();
             Assert.NotNull(product); // Guard
             return product;
         }


### PR DESCRIPTION
Fix https://github.com/Azure/azure-webjobs-sdk-script/issues/753 

Add SDK Table bindings
   [Table(name)] IAsyncCollector<JObject> 
   [Table(name,pk,rk)] JObject 
   [Table(name,pk?,filter?take?)] JArray

Previously, these cases where handled via binding code in Script. 
This leverages the new Binding factory rules (rather than the older class hierarchies).  I filed https://github.com/Azure/azure-webjobs-sdk/issues/887 to track switching Tables completely over, but that's too risky now and can be done later.  

I still need fixup script to take advantage of this and verify we can remove a bunch of the code in Script's TableBinding.  I may need to come back and change things in this PR from that. 
