### PR TITLE
improving singleton logging

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Listeners/HostListenerFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Listeners/HostListenerFactory.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.WebJobs.Host.Listeners
                 SingletonAttribute singletonAttribute = SingletonManager.GetListenerSingletonOrNull(listener.GetType(), method);
                 if (singletonAttribute != null)
                 {
-                    listener = new SingletonListener(method, singletonAttribute, _singletonManager, listener);
+                    listener = new SingletonListener(method, singletonAttribute, _singletonManager, listener, _trace);
                 }
 
                 listeners.Add(listener);

--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/TraceWriterFunctionInstanceLogger.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/TraceWriterFunctionInstanceLogger.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.WebJobs.Host.Loggers
 
         public Task<string> LogFunctionStartedAsync(FunctionStartedMessage message, CancellationToken cancellationToken)
         {
-            string traceMessage = string.Format(CultureInfo.InvariantCulture, "Executing: '{0}' - Reason: '{1}'", message.Function.ShortName, message.FormatReason());
+            string traceMessage = string.Format(CultureInfo.InvariantCulture, "Executing '{0}' (Reason='{1}', Id={2})", message.Function.ShortName, message.FormatReason(), message.FunctionInstanceId);
             Trace(TraceLevel.Info, message.HostInstanceId, message.Function, message.FunctionInstanceId, traceMessage, TraceSource.Execution);
             return Task.FromResult<string>(null);
         }
@@ -34,12 +34,12 @@ namespace Microsoft.Azure.WebJobs.Host.Loggers
         {
             if (message.Succeeded)
             {
-                string traceMessage = string.Format(CultureInfo.InvariantCulture, "Executed: '{0}' (Succeeded)", message.Function.ShortName);
+                string traceMessage = string.Format(CultureInfo.InvariantCulture, "Executed '{0}' (Succeeded, Id={1})", message.Function.ShortName, message.FunctionInstanceId);
                 Trace(TraceLevel.Info, message.HostInstanceId, message.Function, message.FunctionInstanceId, traceMessage, TraceSource.Execution);
             }
             else
             {
-                string traceMessage = string.Format(CultureInfo.InvariantCulture, "Executed: '{0}' (Failed)", message.Function.ShortName);
+                string traceMessage = string.Format(CultureInfo.InvariantCulture, "Executed '{0}' (Failed, Id={1})", message.Function.ShortName, message.FunctionInstanceId);
                 Trace(TraceLevel.Error, message.HostInstanceId, message.Function, message.FunctionInstanceId, traceMessage, TraceSource.Execution, message.Failure.Exception);
 
                 // Also log the eror message using TraceSource.Host, to ensure

--- a/src/Microsoft.Azure.WebJobs.Storage/StorageExceptionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Storage/StorageExceptionExtensions.cs
@@ -744,5 +744,60 @@ namespace Microsoft.Azure.WebJobs.Host.Storage
 
             return extendedInformation.ErrorCode == "LeaseLost";
         }
+
+        /// <summary>
+        /// Returns the status code from the storage exception, or null.
+        /// </summary>
+        /// <param name="exception">The storage exception.</param>
+        /// <param name="statusCode">When this method returns, contains the status code.</param>
+        /// <returns>Returns true if there was a status code; otherwise, false.</returns>
+        public static bool TryGetStatusCode(this StorageException exception, out int statusCode)
+        {
+            statusCode = 0;
+
+            if (exception == null)
+            {
+                throw new ArgumentNullException("exception");
+            }
+
+            RequestResult result = exception.RequestInformation;
+
+            if (result == null)
+            {
+                return false;
+            }
+
+            statusCode = result.HttpStatusCode;
+            return true;
+        }
+
+        /// <summary>
+        /// Returns the error code from storage exception, or null.
+        /// </summary>
+        /// <param name="exception">The storage exception.</param>
+        /// <returns>The error code, or null.</returns>
+        public static string GetErrorCode(this StorageException exception)
+        {
+            if (exception == null)
+            {
+                throw new ArgumentNullException("exception");
+            }
+
+            RequestResult result = exception.RequestInformation;
+
+            if (result == null)
+            {
+                return null;
+            }
+
+            StorageExtendedErrorInformation extendedInformation = result.ExtendedErrorInformation;
+
+            if (extendedInformation == null)
+            {
+                return null;
+            }
+
+            return extendedInformation.ErrorCode;
+        }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/BlobTriggerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/BlobTriggerTests.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 string[] consoleOutputLines = consoleOutput.ToString().Trim().Split(new string[] { Environment.NewLine }, StringSplitOptions.None);
                 var executions = consoleOutputLines.Where(p => p.Contains("Executing"));
                 Assert.Equal(1, executions.Count());
-                Assert.Equal(string.Format("Executing: 'BlobTriggerTests.SingleBlobTrigger' - Reason: 'New blob detected: {0}/{1}'", blob.Container.Name, blob.Name), executions.Single());
+                Assert.StartsWith(string.Format("Executing 'BlobTriggerTests.SingleBlobTrigger' (Reason='New blob detected: {0}/{1}', Id=", blob.Container.Name, blob.Name), executions.Single());
             }
 
             // Then start again and make sure the blob doesn't get reprocessed

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ServiceBusEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ServiceBusEndToEndTests.cs
@@ -262,25 +262,25 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     string.Format("{0}.SBTopicListener1", jobContainerType.FullName),
                     string.Format("{0}.SBTopicListener2", jobContainerType.FullName),
                     "Job host started",
-                    string.Format("Executing: '{0}.SBQueue2SBQueue' - Reason: 'New ServiceBus message detected on '{1}'.'", jobContainerType.Name, startQueueName),
-                    string.Format("Executed: '{0}.SBQueue2SBQueue' (Succeeded)", jobContainerType.Name),
-                    string.Format("Executing: '{0}.SBQueue2SBTopic' - Reason: 'New ServiceBus message detected on '{1}'.'", jobContainerType.Name, secondQueueName),
-                    string.Format("Executed: '{0}.SBQueue2SBTopic' (Succeeded)", jobContainerType.Name),
-                    string.Format("Executing: '{0}.SBTopicListener1' - Reason: 'New ServiceBus message detected on '{1}'.'", jobContainerType.Name, firstTopicName),
-                    string.Format("Executed: '{0}.SBTopicListener1' (Succeeded)", jobContainerType.Name),
-                    string.Format("Executing: '{0}.SBTopicListener2' - Reason: 'New ServiceBus message detected on '{1}'.'", jobContainerType.Name, secondTopicName),
-                    string.Format("Executed: '{0}.SBTopicListener2' (Succeeded)", jobContainerType.Name),
+                    string.Format("Executing '{0}.SBQueue2SBQueue' (Reason='New ServiceBus message detected on '{1}'.', Id=", jobContainerType.Name, startQueueName),
+                    string.Format("Executed '{0}.SBQueue2SBQueue' (Succeeded, Id=", jobContainerType.Name),
+                    string.Format("Executing '{0}.SBQueue2SBTopic' (Reason='New ServiceBus message detected on '{1}'.', Id=", jobContainerType.Name, secondQueueName),
+                    string.Format("Executed '{0}.SBQueue2SBTopic' (Succeeded, Id=", jobContainerType.Name),
+                    string.Format("Executing '{0}.SBTopicListener1' (Reason='New ServiceBus message detected on '{1}'.', Id=", jobContainerType.Name, firstTopicName),
+                    string.Format("Executed '{0}.SBTopicListener1' (Succeeded, Id=", jobContainerType.Name),
+                    string.Format("Executing '{0}.SBTopicListener2' (Reason='New ServiceBus message detected on '{1}'.', Id=", jobContainerType.Name, secondTopicName),
+                    string.Format("Executed '{0}.SBTopicListener2' (Succeeded, Id=", jobContainerType.Name),
                     "Job host stopped"
                 }.OrderBy(p => p).ToArray();
 
                 bool hasError = consoleOutputLines.Any(p => p.Contains("Function had errors"));
                 if (!hasError)
                 {
-                    Assert.Equal(
-                        string.Join(Environment.NewLine, expectedOutputLines),
-                        string.Join(Environment.NewLine, consoleOutputLines)
-                    );
-                } 
+                    for (int i = 0; i < expectedOutputLines.Length; i++)
+                    {
+                        Assert.StartsWith(expectedOutputLines[i], consoleOutputLines[i]);
+                    }
+                }
             }
         }
 

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostTests.cs
@@ -491,7 +491,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             Assert.Equal("BindingErrorsProgram.Invalid", fex.MethodName);
 
             // verify that the binding error was logged
-            Assert.Equal(5, traceWriter.Traces.Count);
+            Assert.Equal(4, traceWriter.Traces.Count);
             TraceEvent traceEvent = traceWriter.Traces[0];
             Assert.Equal("Error indexing method 'BindingErrorsProgram.Invalid'", traceEvent.Message);
             Assert.Same(fex, traceEvent.Exception);
@@ -503,7 +503,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             Assert.True(traceEvent.Message.Contains("BindingErrorsProgram.Valid"));
 
             // verify that the job host was started successfully
-            traceEvent = traceWriter.Traces[4];
+            traceEvent = traceWriter.Traces[3];
             Assert.Equal("Job host started", traceEvent.Message);
 
             host.Stop();

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/TraceWriterFunctionInstanceLoggerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/TraceWriterFunctionInstanceLoggerTests.cs
@@ -43,7 +43,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             TraceEvent traceEvent = _traceWriter.Traces[0];
             Assert.Equal(TraceLevel.Info, traceEvent.Level);
             Assert.Equal(Host.TraceSource.Execution, traceEvent.Source);
-            Assert.Equal("Executing: 'TestJob' - Reason: 'TestReason'", traceEvent.Message);
+
+            Assert.Equal(string.Format("Executing 'TestJob' (Reason='TestReason', Id={0})", message.FunctionInstanceId), traceEvent.Message);
             Assert.Equal(3, traceEvent.Properties.Count);
             Assert.Equal(message.HostInstanceId, traceEvent.Properties["MS_HostInstanceId"]);
             Assert.Equal(message.FunctionInstanceId, traceEvent.Properties["MS_FunctionInvocationId"]);
@@ -82,7 +83,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             TraceEvent traceEvent = _traceWriter.Traces[0];
             Assert.Equal(TraceLevel.Info, traceEvent.Level);
             Assert.Equal(Host.TraceSource.Execution, traceEvent.Source);
-            Assert.Equal("Executed: 'TestJob' (Succeeded)", traceEvent.Message);
+            Assert.Equal(string.Format("Executed 'TestJob' (Succeeded, Id={0})", successMessage.FunctionInstanceId), traceEvent.Message);
             Assert.Equal(successMessage.HostInstanceId, traceEvent.Properties["MS_HostInstanceId"]);
             Assert.Equal(successMessage.FunctionInstanceId, traceEvent.Properties["MS_FunctionInvocationId"]);
             Assert.Same(successMessage.Function, traceEvent.Properties["MS_FunctionDescriptor"]);
@@ -90,7 +91,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             traceEvent = _traceWriter.Traces[1];
             Assert.Equal(TraceLevel.Error, traceEvent.Level);
             Assert.Equal(Host.TraceSource.Execution, traceEvent.Source);
-            Assert.Equal("Executed: 'TestJob' (Failed)", traceEvent.Message);
+            Assert.Equal(string.Format("Executed 'TestJob' (Failed, Id={0})", failureMessage.FunctionInstanceId), traceEvent.Message);
             Assert.Same(ex, traceEvent.Exception);
             Assert.Equal(failureMessage.HostInstanceId, traceEvent.Properties["MS_HostInstanceId"]);
             Assert.Equal(failureMessage.FunctionInstanceId, traceEvent.Properties["MS_FunctionInvocationId"]);

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Singleton/SingletonListenerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Singleton/SingletonListenerTests.cs
@@ -5,10 +5,11 @@ using System;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Listeners;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Moq;
 using Xunit;
-using Microsoft.Azure.WebJobs.Host.Executors;
 
 namespace Microsoft.Azure.WebJobs.Host.UnitTests.Singleton
 {
@@ -24,7 +25,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Singleton
 
         public SingletonListenerTests()
         {
-            MethodInfo methodInfo = this.GetType().GetMethod("TestJob", BindingFlags.Static|BindingFlags.NonPublic);
+            MethodInfo methodInfo = this.GetType().GetMethod("TestJob", BindingFlags.Static | BindingFlags.NonPublic);
             _attribute = new SingletonAttribute();
             _config = new SingletonConfiguration
             {
@@ -33,7 +34,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Singleton
             _mockSingletonManager = new Mock<SingletonManager>(MockBehavior.Strict, null, null, null, null, new FixedHostIdProvider(TestHostId), null);
             _mockSingletonManager.SetupGet(p => p.Config).Returns(_config);
             _mockInnerListener = new Mock<IListener>(MockBehavior.Strict);
-            _listener = new SingletonListener(methodInfo, _attribute, _mockSingletonManager.Object, _mockInnerListener.Object);
+            _listener = new SingletonListener(methodInfo, _attribute, _mockSingletonManager.Object, _mockInnerListener.Object, new TestTraceWriter(System.Diagnostics.TraceLevel.Verbose));
             _lockId = SingletonManager.FormatLockId(methodInfo, SingletonScope.Function, TestHostId, _attribute.ScopeId) + ".Listener";
         }
 

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Singleton/SingletonManagerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Singleton/SingletonManagerTests.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Singleton
             TestHelpers.SetField(_singletonConfig, "_lockPeriod", TimeSpan.FromMilliseconds(500));
             _singletonConfig.LockAcquisitionTimeout = TimeSpan.FromMilliseconds(200);
 
-            _nameResolver = new TestNameResolver(); 
+            _nameResolver = new TestNameResolver();
             _singletonManager = new SingletonManager(_mockAccountProvider.Object, _mockExceptionDispatcher.Object, _singletonConfig, _trace, new FixedHostIdProvider(TestHostId), _nameResolver);
 
             _singletonManager.MinimumLeaseRenewalInterval = TimeSpan.FromMilliseconds(250);
@@ -166,9 +166,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Singleton
             await _singletonManager.ReleaseLockAsync(lockHandle, cancellationToken);
 
             // verify the traces
-            Assert.Equal(1, _trace.Traces.Count(p => p.ToString().Contains("Verbose Waiting for Singleton lock (testid)")));
             Assert.Equal(1, _trace.Traces.Count(p => p.ToString().Contains("Verbose Singleton lock acquired (testid)")));
-            Assert.Equal(renewCount, _trace.Traces.Count(p => p.ToString().Contains("Renewing Singleton lock (testid)")));
             Assert.Equal(1, _trace.Traces.Count(p => p.ToString().Contains("Verbose Singleton lock released (testid)")));
 
             renewCount = 0;


### PR DESCRIPTION
This removes our very verbose singleton logging (half of https://github.com/Azure/azure-webjobs-sdk-script/issues/728) and adds detailed debugging information should a renewal fail. Also adds function invocation ids to some of our other logging as it's currently tough to correlate events when looking through the logs.
