### PR TITLE
ServiceBus: improving BrokeredMessage string and byte[] conversions

### DIFF
--- a/src/Microsoft.Azure.WebJobs.ServiceBus/WebJobs.ServiceBus.csproj
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/WebJobs.ServiceBus.csproj
@@ -29,7 +29,7 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Microsoft.Azure.WebJobs.ServiceBus.xml</DocumentationFile>
     <Prefer32Bit>false</Prefer32Bit>
-    <LangVersion>5</LangVersion>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/BrokeredMessageToByteArrayConverterTests.cs
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/BrokeredMessageToByteArrayConverterTests.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
+using System.Runtime.Serialization;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,10 +18,10 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests
         private const string TestString = "This is a test!";
 
         [Theory]
-        [InlineData(ContentTypes.ApplicationOctetStream)]
         [InlineData(ContentTypes.TextPlain)]
         [InlineData(ContentTypes.ApplicationJson)]
-        public async Task ConvertAsync_ReturnsExpectedResult(string contentType)
+        [InlineData(ContentTypes.ApplicationOctetStream)]
+        public async Task ConvertAsync_ReturnsExpectedResult_WithStream(string contentType)
         {
             MemoryStream ms = new MemoryStream();
             StreamWriter sw = new StreamWriter(ms);
@@ -34,6 +36,81 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests
             byte[] result = await converter.ConvertAsync(message, CancellationToken.None);
             string decoded = Encoding.UTF8.GetString(result);
             Assert.Equal(TestString, decoded);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("some-other-contenttype")]
+        public async Task ConvertAsync_Throws_WithStream_UnknownContentType(string contentType)
+        {
+            MemoryStream ms = new MemoryStream();
+            StreamWriter sw = new StreamWriter(ms);
+            sw.Write(TestString);
+            sw.Flush();
+            ms.Seek(0, SeekOrigin.Begin);
+
+            BrokeredMessage message = new BrokeredMessage(ms);
+            message.ContentType = contentType;
+            BrokeredMessageToByteArrayConverter converter = new BrokeredMessageToByteArrayConverter();
+
+            var ex = await Assert.ThrowsAnyAsync<InvalidOperationException>(() => converter.ConvertAsync(message, CancellationToken.None));
+
+            Assert.IsType<SerializationException>(ex.InnerException);
+            string expectedType = contentType ?? "null";          
+            Assert.StartsWith(string.Format("The BrokeredMessage with ContentType '{0}' failed to deserialize to a byte[] with the message: ", expectedType), ex.Message);
+        }
+
+        [Theory]
+        [InlineData(ContentTypes.TextPlain)]
+        [InlineData(ContentTypes.ApplicationJson)]
+        [InlineData(ContentTypes.ApplicationOctetStream)]
+        public async Task ConvertAsync_ReturnsExpectedResult_WithSerializedByteArray_KnownContentType(string contentType)
+        {
+            byte[] bytes = Encoding.UTF8.GetBytes(TestString);
+            BrokeredMessage message = new BrokeredMessage(bytes);
+            message.ContentType = contentType;
+            BrokeredMessageToByteArrayConverter converter = new BrokeredMessageToByteArrayConverter();
+
+            byte[] result = await converter.ConvertAsync(message, CancellationToken.None);
+
+            // we expect to read back the DataContract-serialized string, since the ContentType tells us to read it back as-is.
+            string decoded = Encoding.UTF8.GetString(result);
+            Assert.Equal("@base64Binary3http://schemas.microsoft.com/2003/10/Serialization/�This is a test!", decoded);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("some-other-contenttype")]
+        public async Task ConvertAsync_ReturnsExpectedResult_WithSerializedByteArray_UnknownContentType(string contentType)
+        {
+            byte[] bytes = Encoding.UTF8.GetBytes(TestString);
+            BrokeredMessage message = new BrokeredMessage(bytes);
+            message.ContentType = contentType;
+            BrokeredMessageToByteArrayConverter converter = new BrokeredMessageToByteArrayConverter();
+
+            byte[] result = await converter.ConvertAsync(message, CancellationToken.None);
+
+            // we expect to read back the DataContract-serialized string, since the ContentType tells us to read it back as-is.
+            string decoded = Encoding.UTF8.GetString(result);
+            Assert.Equal(TestString, decoded);
+        }
+
+        [Fact]
+        public async Task ConvertAsync_Throws_WithSerializedObject()
+        {
+            BrokeredMessage message = new BrokeredMessage(new TestObject { Text = TestString });
+
+            BrokeredMessageToByteArrayConverter converter = new BrokeredMessageToByteArrayConverter();
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => converter.ConvertAsync(message, CancellationToken.None));
+
+            Assert.IsType<SerializationException>(exception.InnerException);
+            Assert.StartsWith("The BrokeredMessage with ContentType 'null' failed to deserialize to a byte[] with the message: ", exception.Message);
+        }
+
+        [Serializable]
+        public class TestObject
+        {
+            public string Text { get; set; }
         }
     }
 }


### PR DESCRIPTION
Improving `BrokeredMessageToString` by not special-casing any `ContentType`s. We'll first try to read from the Stream and return that string. If that fails (because it was serialized differently), we'll then try the default serializer used by Service Bus. If that fails, we'll provide a slightly better error message than the default. Previously, sending a plain string with a null ContentType would fail as we'd attempt to deserialize it using the default serializer.

Improving `BrokeredMessageToByteArray` by throwing a slightly better error message if we're unable to deserialize. We can't implement the fallback here because deserializing a byte[] from a Stream will always work -- so we use the ContentTypes as a hint. The behavior here hasn't changed but I wrap the exception message (which was previously confusing, especially when seen in Functions) and added a bunch more tests to make the behavior clear.

Addresses #905 