### PR TITLE
Add appveyor test support

### DIFF
--- a/WebJobs.proj
+++ b/WebJobs.proj
@@ -141,6 +141,21 @@
     <xunit Assemblies="@(UnitTestAssemblies)"/>
   </Target>
 
+  <Target Name="BuildTestBinaries" DependsOnTargets="EnableSkipStrongNames;RestorePackages">
+    <ItemGroup>
+        <TestBinaries Include="test\Microsoft.Azure.WebJobs.Host.UnitTests\WebJobs.Host.UnitTests.csproj"/>
+        <TestBinaries Include="test\Microsoft.Azure.WebJobs.Host.FunctionalTests\WebJobs.Host.FunctionalTests.csproj"/>
+        <TestBinaries Include="test\Microsoft.Azure.WebJobs.ServiceBus.UnitTests\WebJobs.ServiceBus.UnitTests.csproj"/>
+        <TestBinaries Include="test\Dashboard.UnitTests\Dashboard.UnitTests.csproj"/>
+        <TestBinaries Include="test\Microsoft.Azure.WebJobs.Host.EndToEndTests\WebJobs.Host.EndToEndTests.csproj"/>
+    </ItemGroup>
+
+    <MSBuild Projects="@(TestBinaries)"
+             Properties="$(SetConfiguration); $(SetPlatform)"
+             BuildInParallel="$(BuildInParallel)">
+    </MSBuild>
+  </Target>
+
   <Target Name="FunctionalTest" DependsOnTargets="UnitTest">
     <ItemGroup>
       <FunctionalTestProjects Include="test\Microsoft.Azure.WebJobs.Host.EndToEndTests\WebJobs.Host.EndToEndTests.csproj"/>

--- a/WebJobs.sln
+++ b/WebJobs.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{639967B0-0544-4C52-94AC-9A3D25E33256}"
 EndProject

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,9 @@
+build_script:
+  - msbuild WebJobs.proj /t:BuildTestBinaries /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /p:OutputPath=c:\projects\azure-webjobs-sdk\bin
+
+test_script:
+  - vstest.console /logger:Appveyor /TestAdapterPath:bin bin/Microsoft.Azure.WebJobs.Host.UnitTests.dll bin/Microsoft.Azure.WebJobs.Host.FunctionalTests.dll bin/Microsoft.Azure.WebJobs.ServiceBus.UnitTests.dll bin/Dashboard.UnitTests.dll bin/Microsoft.Azure.WebJobs.Host.EndToEndTests.dll
+
+# if you need to rdp into build machine to investigate
+# on_finish:
+#   - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/test/Dashboard.UnitTests/AssemblyInfo.cs
+++ b/test/Dashboard.UnitTests/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+using Xunit;
+[assembly: TestFramework("Microsoft.Azure.WebJobs.Host.TestCommon.SyncContextTestFramework", "Microsoft.Azure.WebJobs.Host.TestCommon")]

--- a/test/Dashboard.UnitTests/Dashboard.UnitTests.csproj
+++ b/test/Dashboard.UnitTests/Dashboard.UnitTests.csproj
@@ -47,6 +47,7 @@
     <Compile Include="..\Common\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="AssemblyInfo.cs" />
     <Compile Include="AutoFacTests.cs" />
     <Compile Include="Data\AccountProviderTests.cs" />
     <Compile Include="Data\ConnectionStringProviderTests.cs" />

--- a/test/Dashboard.UnitTests/RestApiTests.cs
+++ b/test/Dashboard.UnitTests/RestApiTests.cs
@@ -166,7 +166,7 @@ namespace Dashboard.UnitTests
                 ILogWriter writer = LogFactory.NewWriter(HostName, "c1", provider);
 
                 string Func1 = "alpha";
-                var time = new DateTime(2010, 3, 6, 10, 11, 20);
+                var time = new DateTime(2010, 3, 6, 18, 11, 20, DateTimeKind.Utc);
 
                 List<FunctionInstanceLogItem> list = new List<FunctionInstanceLogItem>();
                 list.Add(new FunctionInstanceLogItem

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AssemblyInfo.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+using Xunit;
+[assembly: TestFramework("Microsoft.Azure.WebJobs.Host.TestCommon.SyncContextTestFramework", "Microsoft.Azure.WebJobs.Host.TestCommon")]

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/WebJobs.Host.EndToEndTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/WebJobs.Host.EndToEndTests.csproj
@@ -101,6 +101,7 @@
     <Compile Include="..\Common\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="AssemblyInfo.cs" />
     <Compile Include="AsyncCancellationEndToEndTests.cs" />
     <Compile Include="AsyncChainEndToEndTests.cs" />
     <Compile Include="BlobBindingEndToEndTests.cs" />

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/AssemblyInfo.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+using Xunit;
+[assembly: TestFramework("Microsoft.Azure.WebJobs.Host.TestCommon.SyncContextTestFramework", "Microsoft.Azure.WebJobs.Host.TestCommon")]

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/Queues/QueueTriggerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/Queues/QueueTriggerTests.cs
@@ -13,6 +13,7 @@ using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.WindowsAzure.Storage.Queue;
 using Newtonsoft.Json;
 using Xunit;
+using System.Text.RegularExpressions;
 
 namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
 {
@@ -191,11 +192,12 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
             Exception innerException = exception.InnerException;
             Assert.IsType<InvalidOperationException>(innerException);
             const string expectedInnerMessage = "Binding parameters to complex objects (such as 'Poco') uses " +
-                "Json.NET serialization. \r\n1. Bind the parameter type as 'string' instead of 'Poco' to get the raw " +
-                "values and avoid JSON deserialization, or\r\n2. Change the queue payload to be valid json. The JSON " +
+                "Json.NET serialization. 1. Bind the parameter type as 'string' instead of 'Poco' to get the raw " +
+                "values and avoid JSON deserialization, or2. Change the queue payload to be valid json. The JSON " +
                 "parser failed: Unexpected character encountered while parsing value: n. Path '', line 0, position " +
-                "0.\r\n";
-            Assert.Equal(expectedInnerMessage, innerException.Message);
+                "0.";
+            string actual = Regex.Replace(innerException.Message, @"[\n\r]", "");
+            Assert.Equal(expectedInnerMessage, actual);
         }
 
         [Fact]
@@ -218,11 +220,12 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
             Exception innerException = exception.InnerException;
             Assert.IsType<InvalidOperationException>(innerException);
             string expectedInnerMessage = "Binding parameters to complex objects (such as 'Poco') uses Json.NET " +
-                "serialization. \r\n1. Bind the parameter type as 'string' instead of 'Poco' to get the raw values " +
-                "and avoid JSON deserialization, or\r\n2. Change the queue payload to be valid json. The JSON parser " +
+                "serialization. 1. Bind the parameter type as 'string' instead of 'Poco' to get the raw values " +
+                "and avoid JSON deserialization, or2. Change the queue payload to be valid json. The JSON parser " +
                 "failed: Error converting value 123 to type '" + typeof(Poco).FullName + "'. Path '', line 1, " +
-                "position 3.\r\n";
-            Assert.Equal(expectedInnerMessage, innerException.Message);
+                "position 3.";
+            string actual = Regex.Replace(innerException.Message, @"[\n\r]", "");
+            Assert.Equal(expectedInnerMessage, actual);
         }
 
         [Fact]

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/WebJobs.Host.FunctionalTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/WebJobs.Host.FunctionalTests.csproj
@@ -49,6 +49,7 @@
     <Compile Include="..\Common\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="AssemblyInfo.cs" />
     <Compile Include="BinderTests.cs" />
     <Compile Include="Blobs\Listeners\BlobNotificationStrategyExtensions.cs" />
     <Compile Include="Blobs\Listeners\ScanBlobScanLogHybridPollingStrategyTests.cs" />

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/SyncContextTestFramework.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/SyncContextTestFramework.cs
@@ -1,0 +1,26 @@
+﻿using System.Threading;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.Azure.WebJobs.Host.TestCommon
+{
+    /// <summary>
+    /// Swaps Xunit's sync context with a new sync context to avoid Task deadlock,
+    /// in particular for JobHost.Start / SingletonManager.HostId
+    /// </summary>
+    public class SyncContextTestFramework : XunitTestFramework
+    {
+        SynchronizationContext xunitContext;
+
+        public SyncContextTestFramework(IMessageSink messageSink) : base(messageSink)
+        {
+            xunitContext = SynchronizationContext.Current;
+            SynchronizationContext.SetSynchronizationContext(new SynchronizationContext());
+        }
+
+        ~SyncContextTestFramework()
+        {
+            SynchronizationContext.SetSynchronizationContext(xunitContext);
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/WebJobs.Host.TestCommon.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/WebJobs.Host.TestCommon.csproj
@@ -117,6 +117,7 @@
     <Compile Include="NullFunctionOutputLoggerProvider.cs" />
     <Compile Include="NullFunctionInstanceLoggerProvider.cs" />
     <Compile Include="NullHostInstanceLoggerProvider.cs" />
+    <Compile Include="SyncContextTestFramework.cs" />
     <Compile Include="TestHelpers.cs" />
     <Compile Include="TestJobHostContextFactory.cs" />
     <Compile Include="TestTraceWriter.cs" />

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/AssemblyInfo.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+using Xunit;
+[assembly: TestFramework("Microsoft.Azure.WebJobs.Host.TestCommon.SyncContextTestFramework", "Microsoft.Azure.WebJobs.Host.TestCommon")]

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/ConverterManagerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/ConverterManagerTests.cs
@@ -8,6 +8,7 @@ using Newtonsoft.Json;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Newtonsoft.Json.Linq;
 using System.Threading;
+using System.Text.RegularExpressions;
 
 namespace Microsoft.Azure.WebJobs.Host.UnitTests
 {
@@ -67,12 +68,11 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
 
             var value = new Other { Value2 = "abc" };
             Wrapper x1 = func(value, null, testContext);
+            // strip whitespace
+            string val = Regex.Replace(x1.Value, @"\s", "");
+            string expected = String.Format("{{\"Value2\":\"abc\",\"$\":\"{0}\"}}", instance);
 
-            Assert.Equal(@"{
-  ""Value2"": ""abc"",
-  ""$"": """ + instance.ToString() + @"""
-}", x1.Value);
-
+            Assert.Equal(expected, val);
     }
 
         // Explicit converters take precedence. 

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostTests.cs
@@ -661,7 +661,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 {
                     fex.Handled = true;
                     Errors.Add(fex);
-                } 
+                }
             }
         }
     }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Singleton/SingletonValueProviderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Singleton/SingletonValueProviderTests.cs
@@ -73,8 +73,9 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Singleton
             SingletonValueProvider localValueProvider = new SingletonValueProvider(_method, _attribute.ScopeId, TestInstanceId, _attribute, mockSingletonManager.Object);
             SingletonLock localSingletonLock = (SingletonLock)localValueProvider.GetValue();
 
-            DateTime startTime = DateTime.Now;
-            DateTime endTime = startTime + TimeSpan.FromSeconds(2);
+            // set start time before _minimumWaitForFirstOwnerCheck in SingletonValueProvider
+            DateTime startTime = DateTime.UtcNow - TimeSpan.FromSeconds(11);
+            DateTime endTime = DateTime.UtcNow + TimeSpan.FromSeconds(2);
             DateTime releaseTime = endTime + TimeSpan.FromSeconds(1);
 
             // before lock is called

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
@@ -115,6 +115,7 @@
     <Compile Include="..\Common\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="AssemblyInfo.cs" />
     <Compile Include="Bindings\BindingDataPathHelperTests.cs" />
     <Compile Include="Bindings\Data\DataBindingFunctionalTests.cs" />
     <Compile Include="Bindings\Data\DataBindingProviderTests.cs" />

--- a/tools/SkipStrongNames.xml
+++ b/tools/SkipStrongNames.xml
@@ -7,6 +7,7 @@
   <assembly name="Microsoft.Azure.WebJobs.Protocols"/>
   <assembly name="Microsoft.Azure.WebJobs.ServiceBus"/>
   <assembly name="Microsoft.Azure.WebJobs.Storage"/>
+  <assembly name="Microsoft.Azure.WebJobs.Logging"/>
 
   <!-- Unit test assemblies -->
   <assembly name="Dashboard.UnitTests"/>


### PR DESCRIPTION
Added 'StartSafe' extension method to avoid JobHost start deadlocks.
Couple test fixes due to UTC time issues.
Couple fixes due to line ending differences

Do we want the same 'UT' test projects for the core sdk?