### PR TITLE
Adjusting EventHub MaxBatchSize and PrefetchCount for performance

### DIFF
--- a/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubConfiguration.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubConfiguration.cs
@@ -60,7 +60,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
             if (options == null)
             {
                 options = EventProcessorOptions.DefaultOptions;
-                options.MaxBatchSize = 1000;
+                options.MaxBatchSize = 64;
+                options.PrefetchCount = options.MaxBatchSize * 4;
             }
             _partitionOptions = partitionOptions;
 


### PR DESCRIPTION
We had these two values reversed. The guidance for these values is for the prefetch size to be 3 to 4 times larger than the max batch size.

PrefetchCount defaults to 300, so before these changes, we had MaxBatchSize=1000, PrefetchCount=300.