### PR TITLE
Enabling dashboard tests on appveyor

### DIFF
--- a/appveyorDashboard.yml
+++ b/appveyorDashboard.yml
@@ -1,0 +1,15 @@
+install:
+  - git clone https://github.com/azure/azure-webjobs-sdk-dashboard-tests %APPVEYOR_BUILD_FOLDER%\dashboard-tests
+  - ps: '& ${env:APPVEYOR_BUILD_FOLDER}\dashboard-tests\SetupAppveyor.ps1'
+
+build_script:
+  - msbuild WebJobs.proj /t:Build /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+  - msbuild ./dashboard-tests/Dashboard.proj /t:BuildFunctionalTest /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /p:OutputPath=%APPVEYOR_BUILD_FOLDER%\bin
+
+test_script:
+# appveyor hangs if child processes are running & testeasy fails to properly dispose iis servers
+  - appveyorDashboardTest.cmd
+
+# if you need to rdp into build machine to investigate
+# init:
+#   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyorDashboardTest.cmd
+++ b/appveyorDashboardTest.cmd
@@ -1,0 +1,5 @@
+vstest.console /logger:Appveyor /TestAdapterPath:bin bin/Dashboard.EndToEndTests.dll
+set testexit=%errorlevel%
+REM appveyor hangs if child processes are running & testeasy fails to properly dispose iis processes
+taskkill /IM iis*
+exit %testexit%


### PR DESCRIPTION
#681 @mathewc 

https://github.com/Azure/azure-webjobs-sdk-dashboard-tests/pull/26

Ugly but green, issues & workarounds:
- task deadlock
  - use `IAsyncCollector` instead of `ICollector` in tests & `Task.Run`
- `TestEasySupportPath`
  - mounting an azure files drive on appv vm
- Dashboard strong name validation
  - setting registry key for `*,*` on appv vm
- TestEasy expects nonexistant 'website1' as root
  - create dummy `web.config` where the TestEasy-generated `applicationhost.config` expects
- [Appveyor hangs if child processes running after test completion](http://help.appveyor.com/discussions/problems/2590-it-hangs-when-theres-spawned-process-running-in-background)
  - run `taskkill /IM iis*` after test have completed