### PR TITLE
Fix logging perf bug 

### DIFF
--- a/src/Dashboard/ApiControllers/FunctionsController.cs
+++ b/src/Dashboard/ApiControllers/FunctionsController.cs
@@ -249,7 +249,7 @@ namespace Dashboard.ApiControllers
             {
                  StartBucket = entity.TimeBucket,
                  Start = entity.Time,
-                 TotalPass = entity.TotalPass,
+                 TotalPass = entity.TotalPass, 
                  TotalFail = entity.TotalFail,
                  TotalRun = entity.TotalRun
             });
@@ -466,7 +466,10 @@ namespace Dashboard.ApiControllers
 
         // If host is specified, then only return definitions for that host. If null, return all hosts. 
         [Route("api/functions/definitions")]
-        public IHttpActionResult GetFunctionDefinitions([FromUri]PagingInfo pagingInfo, string host = null)
+        public IHttpActionResult GetFunctionDefinitions(
+            [FromUri]PagingInfo pagingInfo, 
+            string host = null,
+            bool skipStats = false)
         {
             if (pagingInfo == null)
             {
@@ -519,7 +522,9 @@ namespace Dashboard.ApiControllers
                 model.IsOldHost = OnlyBeta1HostExists(alreadyFoundNoNewerEntries: true);
             }
 
-            if (model.Entries != null)
+            // This is very slow. Allow a flag to skip it, and then client can query the stats independently 
+            // via the /timeline API. 
+            if ((model.Entries != null) && !skipStats)
             {
                 foreach (FunctionStatisticsViewModel statisticsModel in model.Entries)
                 {

--- a/src/Microsoft.Azure.WebJobs.Logging/Internal/TimeBucket.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging/Internal/TimeBucket.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.WebJobs.Logging
     // Use minutes since a baseline.  
     internal static class TimeBucket
     {
-        static DateTime _baselineTime = new DateTime(2000, 1, 1);
+        static DateTime _baselineTime = new DateTime(2000, 1, 1, 0,0,0, DateTimeKind.Utc);
 
         public static DateTime ConvertToDateTime(long bucket)
         {

--- a/test/Dashboard.UnitTests/RestApiModels/Models.cs
+++ b/test/Dashboard.UnitTests/RestApiModels/Models.cs
@@ -80,4 +80,12 @@ namespace Dashboard.UnitTests.RestProtocol
         public string exceptionType { get; set; }
     }
 
+    class TimelineResponseEntry
+    {
+        public string Start { get; set; } // DateTime
+        public int TotalPass { get; set; }
+        public int TotalFail { get; set; }
+        public int TotalRun { get; set; }
+    }
+
 }


### PR DESCRIPTION
Fix https://github.com/Azure/azure-webjobs-sdk/issues/930
In logging API, /definitions endpoint is taking too long because it does a fan out.
Add flag to skip the fan out, and client can use existing /timeline API to get that data.
Add REST test for /timeline API.