### PR TITLE
Fixing BindingDataProvider to enable binding to less derived types

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingDataProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingDataProvider.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
         /// <inheritdoc/>
         public IReadOnlyDictionary<string, object> GetBindingData(object value)
         {
-            if (value != null && value.GetType() != _type)
+            if (value != null && !_type.IsAssignableFrom(value.GetType()))
             {
                 throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "The supplied value was not of type '{0}'.", _type), "value");
             }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Bindings/BindingDataProviderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Bindings/BindingDataProviderTests.cs
@@ -127,6 +127,25 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Bindings
         }
 
         [Fact]
+        public void GetBindingData_WithDerivedValue_ReturnsValidBindingData()
+        {
+            // Arrange
+            IBindingDataProvider provider = BindingDataProvider.FromType(typeof(Base));
+
+            Derived value = new Derived { A = 1, B = 2 };
+
+            // Act
+            var bindingData = provider.GetBindingData(value);
+
+            // Assert
+            Assert.NotNull(bindingData);
+
+            // Get binding data for the type used when creating the provider
+            Assert.Equal(1, bindingData.Count);
+            Assert.Equal(1, bindingData["a"]);
+        }
+
+        [Fact]
         public void FromTemplate_IgnoreCase_CreatesCaseInsensitiveProvider()
         {
             var provider = BindingDataProvider.FromTemplate(@"A/b/{c}", ignoreCase: true);
@@ -201,6 +220,11 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Bindings
         private class DerivedWithNew : Base
         {
             new public int A { get; set; }
+        }
+
+        private class Derived : Base
+        {
+            public int B { get; set; }
         }
     }
 }


### PR DESCRIPTION
This fix enables scenarios where the value provided is a type derived from the type used for binding. A concrete example is when binding to WebHooks (e.g. Slack) that read the payload as form data, which will result in a value of an internal ASP.NET type (`HttpValueCollection`), derived from NameValueCollection, which is the type intended to be used in user code.