### PR TITLE
Change AutoResolve error message

### DIFF
--- a/src/src.ruleset
+++ b/src/src.ruleset
@@ -8,6 +8,7 @@
     <Rule Id="CA1026" Action="None" />
     <Rule Id="CA1031" Action="None" />
     <Rule Id="CA1033" Action="None" />
+    <Rule Id="CA1305" Action="None" />
     <Rule Id="CA1308" Action="None" />
     <Rule Id="CA1506" Action="None" />
     <Rule Id="CA1726" Action="None" />

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/AttributeClonerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/AttributeClonerTests.cs
@@ -273,6 +273,21 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             Assert.Throws<InvalidOperationException>(() => new AttributeCloner<Attr1>(attr, EmptyContract));
         }
 
+        [Fact]
+        public void TryAutoResolveValue_UnresolvedValue_ThrowsExpectedException()
+        {
+            var resolver = new FakeNameResolver();
+            var attribute = new Attr2(string.Empty, string.Empty)
+            {
+                ResolvedSetting = "MySetting"
+            };
+            var prop = attribute.GetType().GetProperty("ResolvedSetting");
+            string resolvedValue = null;
+
+            var ex = Assert.Throws<InvalidOperationException>(() => AttributeCloner<Attr2>.TryAutoResolveValue(attribute, prop, resolver, out resolvedValue));
+            Assert.Equal("Unable to resolve value for property 'Attr2.ResolvedSetting'.", ex.Message);
+        }
+
         private static BindingContext GetCtx(IReadOnlyDictionary<string, object> values)
         {
             BindingContext ctx = new BindingContext(


### PR DESCRIPTION
Make it less likely that users will accidentally cause their secret values to be written to error logs.