### PR TITLE
Adding a new Bind extension method to Binder

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/Runtime/BinderExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/Runtime/BinderExtensions.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Azure.WebJobs
+{
+    /// <summary>
+    /// Provides extension methods for <see cref="Binder"/>.
+    /// </summary>
+    public static class BinderExtensions
+    {
+        /// <summary>
+        /// Binds the specified attribute.
+        /// </summary>
+        /// <typeparam name="T">The type to which to bind.</typeparam>
+        /// <param name="binder">The binder to use to bind.</param>
+        /// <param name="attributes">The collection of attributes to bind. The first attribute in the
+        /// collection should be the primary attribute.</param>
+        /// <returns></returns>
+        public static T Bind<T>(this Binder binder, Attribute[] attributes)
+        {
+            if (binder == null)
+            {
+                throw new ArgumentNullException(nameof(binder));
+            }
+
+            return binder.BindAsync<T>(attributes).GetAwaiter().GetResult();
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
+++ b/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
@@ -391,6 +391,7 @@
     <Compile Include="Bindings\IArgumentBindingProvider.cs" />
     <Compile Include="Bindings\Path\BindingParameterResolver.cs" />
     <Compile Include="Bindings\Runtime\Binder.cs" />
+    <Compile Include="Bindings\Runtime\BinderExtensions.cs" />
     <Compile Include="Blobs\Listeners\IBlobScanInfoManager.cs" />
     <Compile Include="Blobs\Listeners\StorageBlobScanInfoManager.cs" />
     <Compile Include="Blobs\StorageBlobToCloudAppendBlobConverter.cs" />

--- a/src/Microsoft.Azure.WebJobs/IBinderExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs/IBinderExtensions.cs
@@ -5,8 +5,10 @@ using System;
 
 namespace Microsoft.Azure.WebJobs
 {
-    /// <summary>Provides extension methods for the <see cref="IBinder"/> interface.</summary>
-    public static class BinderExtensions
+    /// <summary>
+    /// Provides extension methods for the <see cref="IBinder"/> interface.
+    /// </summary>
+    public static class IBinderExtensions
     {
         /// <summary>Binds the specified attribute.</summary>
         /// <typeparam name="T">The type to which to bind.</typeparam>

--- a/src/Microsoft.Azure.WebJobs/WebJobs.csproj
+++ b/src/Microsoft.Azure.WebJobs/WebJobs.csproj
@@ -60,7 +60,7 @@
     </Compile>
     <Compile Include="AutoResolveAttribute.cs" />
     <Compile Include="BlobTriggerAttribute.cs" />
-    <Compile Include="BinderExtensions.cs" />
+    <Compile Include="IBinderExtensions.cs" />
     <Compile Include="DisableAttribute.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="IAsyncCollector.cs" />

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             {
                 "IAttributeInvokeDescriptor`1",
                 "AutoResolveAttribute",
-                "BinderExtensions",
+                "IBinderExtensions",
                 "BlobAttribute",
                 "BlobTriggerAttribute",
                 "IBinder",
@@ -206,6 +206,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 "BindingTemplateExtensions",
                 "FunctionIndexingException",
                 "Binder",
+                "BinderExtensions",
                 "IWebJobsExceptionHandler",
                 "WebJobsExceptionHandler",
                 "FunctionTimeoutException",


### PR DESCRIPTION
IBinder has a non-async Bind extension method that calls the underlying async impl. Adding a corresponding symmetric one for Binder's BindAsync method that takes a collection of attributes.

This comes up often in Functions and makes the code users have to write harder.