### PR TITLE
Emit a warning for async void functions

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexer.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexer.cs
@@ -254,6 +254,11 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
                 }
             }
 
+            if (TypeUtility.IsAsyncVoid(method))
+            {
+                this._trace.Warning($"Function '{method.Name}' is async but does not return a Task. Your function may not run correctly.");
+            }
+
             Type returnType = method.ReturnType;
 
             if (returnType != typeof(void) && returnType != typeof(Task))

--- a/src/Microsoft.Azure.WebJobs.Host/TypeUtility.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/TypeUtility.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Globalization;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Host
@@ -73,6 +74,30 @@ namespace Microsoft.Azure.WebJobs.Host
             }
 
             return null;
+        }
+
+        public static bool IsAsync(MethodInfo methodInfo)
+        {
+            if (methodInfo == null)
+            {
+                throw new ArgumentNullException(nameof(methodInfo));
+            }
+
+            var stateMachineAttribute = methodInfo.GetCustomAttribute<AsyncStateMachineAttribute>();
+            if (stateMachineAttribute != null)
+            {
+                var stateMachineType = stateMachineAttribute.StateMachineType;
+                if (stateMachineType != null)
+                {
+                    return stateMachineType.GetCustomAttribute<CompilerGeneratedAttribute>() != null;
+                }
+            }
+            return false;
+        }
+
+        public static bool IsAsyncVoid(MethodInfo methodInfo)
+        {
+            return IsAsync(methodInfo) && (methodInfo.ReturnType == typeof(void));
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/FunctionIndexerFactory.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/FunctionIndexerFactory.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
 {
     internal static class FunctionIndexerFactory
     {
-        public static FunctionIndexer Create(CloudStorageAccount account = null, INameResolver nameResolver = null, IExtensionRegistry extensionRegistry = null)
+        public static FunctionIndexer Create(CloudStorageAccount account = null, INameResolver nameResolver = null, IExtensionRegistry extensionRegistry = null, TraceWriter traceWriter = null)
         {
             Mock<IServiceProvider> services = new Mock<IServiceProvider>(MockBehavior.Strict);
             StorageClientFactory clientFactory = new StorageClientFactory();
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             ContextAccessor<IBlobWrittenWatcher> blobWrittenWatcherAccessor =
                 new ContextAccessor<IBlobWrittenWatcher>();
             ISharedContextProvider sharedContextProvider = new SharedContextProvider();
-            TestTraceWriter logger = new TestTraceWriter(TraceLevel.Verbose);
+            TraceWriter logger = traceWriter ?? new TestTraceWriter(TraceLevel.Verbose);
             SingletonManager singletonManager = new SingletonManager();
             IWebJobsExceptionHandler exceptionHandler = new WebJobsExceptionHandler();
             var blobsConfiguration = new JobHostBlobsConfiguration();
@@ -51,18 +51,17 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 extensionTypeLocator, messageEnqueuedWatcherAccessor,
                 blobWrittenWatcherAccessor, new DefaultExtensionRegistry());
 
-            TraceWriter trace = new TestTraceWriter(TraceLevel.Verbose);
             IFunctionOutputLoggerProvider outputLoggerProvider = new NullFunctionOutputLoggerProvider();
             IFunctionOutputLogger outputLogger = outputLoggerProvider.GetAsync(CancellationToken.None).Result;
 
-            IFunctionExecutor executor = new FunctionExecutor(new NullFunctionInstanceLogger(), outputLogger, exceptionHandler, trace);
+            IFunctionExecutor executor = new FunctionExecutor(new NullFunctionInstanceLogger(), outputLogger, exceptionHandler, logger);
 
             if (extensionRegistry == null)
             {
                 extensionRegistry = new DefaultExtensionRegistry();
             }
 
-            return new FunctionIndexer(triggerBindingProvider, bindingProvider, DefaultJobActivator.Instance, executor, extensionRegistry, new SingletonManager(), trace);
+            return new FunctionIndexer(triggerBindingProvider, bindingProvider, DefaultJobActivator.Instance, executor, extensionRegistry, new SingletonManager(), logger);
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/TypeUtilityTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/TypeUtilityTests.cs
@@ -2,12 +2,36 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Reflection;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Host.UnitTests
 {
     public class TypeUtilityTests
     {
+        [Theory]
+        [InlineData("VoidMethod", false)]
+        [InlineData("AsyncVoidMethod", true)]
+        [InlineData("AsyncTaskMethod", true)]
+        public void IsAsync_ReturnsExpectedResult(string methodName, bool expectedResult)
+        {
+            var method = typeof(TypeUtilityTests).GetMethod(methodName, BindingFlags.Public|BindingFlags.Static);
+            bool result = TypeUtility.IsAsync(method);
+            Assert.Equal(result, expectedResult);
+        }
+
+        [Theory]
+        [InlineData("VoidMethod", false)]
+        [InlineData("AsyncVoidMethod", true)]
+        [InlineData("AsyncTaskMethod", false)]
+        public void IsAsyncVoid_ReturnsExpectedResult(string methodName, bool expectedResult)
+        {
+            var method = typeof(TypeUtilityTests).GetMethod(methodName, BindingFlags.Public | BindingFlags.Static);
+            bool result = TypeUtility.IsAsyncVoid(method);
+            Assert.Equal(result, expectedResult);
+        }
+
         [Theory]
         [InlineData(typeof(TypeUtilityTests), false)]
         [InlineData(typeof(string), false)]
@@ -27,5 +51,9 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         {
             Assert.Equal(expected, TypeUtility.GetFriendlyName(type));
         }
+
+        public static void VoidMethod() { }
+        public static async void AsyncVoidMethod() { await Task.FromResult(0); }
+        public static async Task AsyncTaskMethod() { await Task.FromResult(0); }
     }
 }


### PR DESCRIPTION
Constantly in the forums and on StackOverflow users report issues with their job functions, and it often turns out to be that they have incorrectly defined an `async void` function. E.g. most recently on SO here: http://stackoverflow.com/questions/41876364/queue-messages-not-being-moved-to-the-poison-queue.

Since there are no good reasons to do this, any instances are most certainly a user error. So I'm throwing an indexing error in these cases.