### PR TITLE
expanding ResolutionPolicy for public use

### DIFF
--- a/CustomDictionary.xml
+++ b/CustomDictionary.xml
@@ -73,6 +73,7 @@
       <Word>Prefetch</Word>
       <Word>ScopeId</Word>
       <Word>poco</Word>
+      <Word>ResolutionPolicyType</Word>
 	</Recognized>
     <Deprecated/>
     <Compound>

--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingFactory.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Globalization;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Listeners;

--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/DefaultResolutionPolicy.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/DefaultResolutionPolicy.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Azure.WebJobs.Host.Bindings.Path;
+
+namespace Microsoft.Azure.WebJobs
+{
+    /// <summary>
+    /// Resolution policy for { } in  binding templates. 
+    /// The default policy is just a direct substitution for the binding data. 
+    /// Derived policies can enforce formatting / escaping when they do injection. 
+    /// </summary>
+    internal class DefaultResolutionPolicy : IResolutionPolicy
+    {
+        public string TemplateBind(PropertyInfo propInfo, Attribute attribute, BindingTemplate template, IReadOnlyDictionary<string, object> bindingData)
+        {
+            return template.Bind(bindingData);
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/FunctionBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/FunctionBinding.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Protocols;
 
@@ -45,7 +46,7 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
                     bindingData[kv.Key] = kv.Value;
                 }
             }
-
+            
             BindingContext bindingContext = new BindingContext(context, bindingData);
             return bindingContext;
         }

--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/IResolutionPolicy.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/IResolutionPolicy.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.Azure.WebJobs.Host.Bindings.Path;
+
+namespace Microsoft.Azure.WebJobs.Host.Bindings
+{
+    /// <summary>
+    /// Resolution policy for "{ }" in  binding templates. 
+    /// The default policy is a direct substitution for the binding data.
+    /// Derived policies can enforce formatting or escaping when they do injection.
+    /// </summary>
+    public interface IResolutionPolicy
+    {
+        /// <summary>
+        /// Resolves the provided <see cref="BindingTemplate"/>. 
+        /// </summary>        
+        /// <param name="propInfo">The property being resolved.</param>
+        /// <param name="resolvedAttribute">The Attribute being resolved.</param>
+        /// <param name="bindingTemplate">The BindingTemplate for the current property.</param>
+        /// <param name="bindingData">The data for the current function invocation.</param>
+        /// <returns>The resolved property value.</returns>
+        string TemplateBind(PropertyInfo propInfo, Attribute resolvedAttribute, BindingTemplate bindingTemplate, IReadOnlyDictionary<string, object> bindingData);
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/ODataFilterResolutionPolicy.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/ODataFilterResolutionPolicy.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.Azure.WebJobs.Host.Bindings.Path;
+using Microsoft.Azure.WebJobs.Host.Tables;
+
+namespace Microsoft.Azure.WebJobs.Host.Bindings
+{
+    internal class ODataFilterResolutionPolicy : IResolutionPolicy
+    {
+        public string TemplateBind(PropertyInfo propInfo, Attribute attribute, BindingTemplate template, IReadOnlyDictionary<string, object> bindingData)
+        {
+            return TableFilterFormatter.Format(template, bindingData);
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
+++ b/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
@@ -392,6 +392,8 @@
     <Compile Include="Bindings\OpenType.cs" />
     <Compile Include="Bindings\Path\BindingParameterResolver.cs" />
     <Compile Include="Bindings\PatternMatcher.cs" />
+    <Compile Include="Bindings\DefaultResolutionPolicy.cs" />
+    <Compile Include="Bindings\IResolutionPolicy.cs" />
     <Compile Include="Bindings\Runtime\Binder.cs" />
     <Compile Include="Blobs\Listeners\IBlobScanInfoManager.cs" />
     <Compile Include="Blobs\Listeners\StorageBlobScanInfoManager.cs" />
@@ -425,6 +427,7 @@
     <Compile Include="Storage\IStorageAccountExtensions.cs" />
     <Compile Include="Storage\StorageAccountType.cs" />
     <Compile Include="Queues\PoisonQueueMessageEventArgs.cs" />
+    <Compile Include="Bindings\ODataFilterResolutionPolicy.cs" />
     <Compile Include="Tables\TableFilterFormatter.cs" />
     <Compile Include="Triggers\StrategyTriggerBinding.cs" />
     <Compile Include="Bindings\ConstantValueProvider.cs" />

--- a/src/Microsoft.Azure.WebJobs/AutoResolveAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs/AutoResolveAttribute.cs
@@ -26,5 +26,11 @@ namespace Microsoft.Azure.WebJobs
         /// Default value is true.
         /// </summary>
         public bool AllowTokens { get; set; }
+
+        /// <summary>
+        /// Specifies a type to use for runtime binding resolution. That type must derive from IResolutionPolicy, found
+        /// in the Microsoft.Azure.WebJobs.Host assembly.
+        /// </summary>
+        public Type ResolutionPolicyType { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs/ODataFilterResolutionPolicy.cs
+++ b/src/Microsoft.Azure.WebJobs/ODataFilterResolutionPolicy.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs
+{
+    /// <summary>
+    /// Marker type for Table resolution
+    /// </summary>
+    public sealed class ODataFilterResolutionPolicy
+    {
+    }
+}

--- a/src/Microsoft.Azure.WebJobs/TableAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs/TableAttribute.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Azure.WebJobs
         /// <summary>
         /// Allow arbitrary table filter. RowKey should be null. 
         /// </summary>
-        [AutoResolve]
+        [AutoResolve(ResolutionPolicyType = typeof(ODataFilterResolutionPolicy))]
         public string Filter
         {
             get; set;
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.WebJobs
         public int Take
         {
             get; set;
-        }        
+        }
 
         [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         private string DebuggerDisplay

--- a/src/Microsoft.Azure.WebJobs/WebJobs.csproj
+++ b/src/Microsoft.Azure.WebJobs/WebJobs.csproj
@@ -71,6 +71,7 @@
     <Compile Include="ICollector.cs" />
     <Compile Include="QueueAttribute.cs" />
     <Compile Include="QueueTriggerAttribute.cs" />
+    <Compile Include="ODataFilterResolutionPolicy.cs" />
     <Compile Include="SingletonAttribute.cs" />
     <Compile Include="SingletonMode.cs" />
     <Compile Include="SingletonScope.cs" />

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/AttributeClonerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/AttributeClonerTests.cs
@@ -4,9 +4,11 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Azure.WebJobs.Host.Bindings.Path;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Xunit;
 
@@ -40,6 +42,49 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
 
             [AutoResolve(AllowTokens = false)]
             public string ResolvedSetting { get; set; }
+        }
+
+        public class AttributeWithResolutionPolicy : Attribute
+        {
+            [AutoResolve(ResolutionPolicyType = typeof(TestResolutionPolicy))]
+            public string PropWithPolicy { get; set; }
+
+            [AutoResolve]
+            public string PropWithoutPolicy { get; set; }
+
+            [AutoResolve(ResolutionPolicyType = typeof(WebJobs.ODataFilterResolutionPolicy))]
+            public string PropWithMarkerPolicy { get; set; }
+
+            [AutoResolve(ResolutionPolicyType = typeof(AutoResolveAttribute))]
+            public string PropWithInvalidPolicy { get; set; }
+
+            [AutoResolve(ResolutionPolicyType = typeof(NoDefaultConstructorResolutionPolicy))]
+            public string PropWithConstructorlessPolicy { get; set; }
+
+            internal string ResolutionData { get; set; }
+        }
+
+        public class TestResolutionPolicy : IResolutionPolicy
+        {
+            public string TemplateBind(PropertyInfo propInfo, Attribute attribute, BindingTemplate template, IReadOnlyDictionary<string, object> bindingData)
+            {
+                // set some internal state for the binding rules to use later
+                ((AttributeWithResolutionPolicy)attribute).ResolutionData = "value1";
+
+                return template.Bind(bindingData);
+            }
+        }
+
+        public class NoDefaultConstructorResolutionPolicy : IResolutionPolicy
+        {
+            public NoDefaultConstructorResolutionPolicy(string someValue)
+            {
+            }
+
+            public string TemplateBind(PropertyInfo propInfo, Attribute attribute, BindingTemplate template, IReadOnlyDictionary<string, object> bindingData)
+            {
+                throw new NotImplementedException();
+            }
         }
 
         // Helper to easily generate a fixed binding contract.
@@ -118,8 +163,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
 
             var cloner = new AttributeCloner<Attr2>(attr, GetBindingContract("p1", "p2"));
 
-            Attr2 attrResolved = cloner.ResolveFromBindings(new Dictionary<string, object> {
-                { "p1", "v1" }, { "p2", "v2" }});
+            Attr2 attrResolved = cloner.ResolveFromBindings(new Dictionary<string, object> { { "p1", "v1" }, { "p2", "v2" } });
 
             Assert.Equal("v1", attrResolved.ResolvedProp1);
             Assert.Equal("v2", attrResolved.ResolvedProp2);
@@ -286,6 +330,58 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
 
             var ex = Assert.Throws<InvalidOperationException>(() => AttributeCloner<Attr2>.TryAutoResolveValue(attribute, prop, resolver, out resolvedValue));
             Assert.Equal("Unable to resolve value for property 'Attr2.ResolvedSetting'.", ex.Message);
+        }
+
+        [Fact]
+        public void GetPolicy_ReturnsDefault_WhenNoSpecifiedPolicy()
+        {
+            PropertyInfo propInfo = typeof(AttributeWithResolutionPolicy).GetProperty(nameof(AttributeWithResolutionPolicy.PropWithoutPolicy));
+
+            IResolutionPolicy policy = AttributeCloner<AttributeWithResolutionPolicy>.GetPolicy(propInfo);
+
+            Assert.IsType<DefaultResolutionPolicy>(policy);
+        }
+
+        [Fact]
+        public void GetPolicy_Returns_SpecifiedPolicy()
+        {
+            PropertyInfo propInfo = typeof(AttributeWithResolutionPolicy).GetProperty(nameof(AttributeWithResolutionPolicy.PropWithPolicy));
+
+            IResolutionPolicy policy = AttributeCloner<AttributeWithResolutionPolicy>.GetPolicy(propInfo);
+
+            Assert.IsType<TestResolutionPolicy>(policy);
+        }
+
+        [Fact]
+        public void GetPolicy_ReturnsODataFilterPolicy_ForMarkerType()
+        {
+            // This is a special-case marker type to handle TableAttribute.Filter. We cannot directly list ODataFilterResolutionPolicy
+            // because BindingTemplate doesn't exist in the core assembly.
+            PropertyInfo propInfo = typeof(AttributeWithResolutionPolicy).GetProperty(nameof(AttributeWithResolutionPolicy.PropWithMarkerPolicy));
+
+            IResolutionPolicy policy = AttributeCloner<AttributeWithResolutionPolicy>.GetPolicy(propInfo);
+
+            Assert.IsType<Host.Bindings.ODataFilterResolutionPolicy>(policy);
+        }
+
+        [Fact]
+        public void GetPolicy_Throws_IfPolicyDoesNotImplementInterface()
+        {
+            PropertyInfo propInfo = typeof(AttributeWithResolutionPolicy).GetProperty(nameof(AttributeWithResolutionPolicy.PropWithInvalidPolicy));
+
+            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => AttributeCloner<AttributeWithResolutionPolicy>.GetPolicy(propInfo));
+
+            Assert.Equal($"The {nameof(AutoResolveAttribute.ResolutionPolicyType)} on {nameof(AttributeWithResolutionPolicy.PropWithInvalidPolicy)} must derive from {typeof(IResolutionPolicy).Name}.", ex.Message);
+        }
+
+        [Fact]
+        public void GetPolicy_Throws_IfPolicyHasNoDefaultConstructor()
+        {
+            PropertyInfo propInfo = typeof(AttributeWithResolutionPolicy).GetProperty(nameof(AttributeWithResolutionPolicy.PropWithConstructorlessPolicy));
+
+            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => AttributeCloner<AttributeWithResolutionPolicy>.GetPolicy(propInfo));
+
+            Assert.Equal($"The {nameof(AutoResolveAttribute.ResolutionPolicyType)} on {nameof(AttributeWithResolutionPolicy.PropWithConstructorlessPolicy)} must derive from {typeof(IResolutionPolicy).Name} and have a default constructor.", ex.Message);
         }
 
         private static BindingContext GetCtx(IReadOnlyDictionary<string, object> values)

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Common/CollectorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Common/CollectorTests.cs
@@ -1,16 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using Microsoft.Azure.WebJobs.Host;
-using Microsoft.Azure.WebJobs.Host.Config;
-using Microsoft.Azure.WebJobs.Host.Indexers;
-using Microsoft.Azure.WebJobs.Host.TestCommon;
-using Newtonsoft.Json;
 using System;
-using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.Indexers;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Host.UnitTests
@@ -35,7 +32,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         {
             // Malformed 
             // Expect the 
-            public static void Func([FakeQueue(Prefix ="Error-{name%")] out string x)
+            public static void Func([FakeQueue(Prefix = "Error-{name%")] out string x)
             {
                 x = "x";
             }
@@ -70,7 +67,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         public class Functions
         {
             public static async Task SendDirectClient(
-                [FakeQueue] FakeQueueClient client)
+                [FakeQueue("CustomConstructor", CustomPolicy = "Custom")] FakeQueueClient client)
             {
                 await client.AddAsync(new FakeQueueData { Message = "abc", ExtraPropertery = "def" });
             }
@@ -182,11 +179,11 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         {
             FakeQueueClient client = new FakeQueueClient();
             var host = TestHelpers.NewJobHost<Functions>(client);
-            
+
             var p7 = Invoke(host, client, "SendDirectClient");
             Assert.Equal(1, p7.Length);
             Assert.Equal("abc", p7[0].Message);
-            Assert.Equal("def", p7[0].ExtraPropertery);            
+            Assert.Equal("def", p7[0].ExtraPropertery);
 
             var p8 = Invoke(host, client, "SendOneDerivedNative");
             Assert.Equal(1, p8.Length);
@@ -199,7 +196,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
 
             // Single items
             var p1 = InvokeJson<Payload>(host, client, "SendOnePoco");
-            Assert.Equal(1, p1.Length);            
+            Assert.Equal(1, p1.Length);
             Assert.Equal(123, p1[0].val1);
 
             var p2 = Invoke(host, client, "SendOneNative");
@@ -211,14 +208,14 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             Assert.Equal(1, p3.Length);
             Assert.Equal("stringvalue", p3[0].Message);
 
-            foreach (string methodName in new string[] { "SendDontQueue", "SendArrayNull", "SendArrayLen0"})
+            foreach (string methodName in new string[] { "SendDontQueue", "SendArrayNull", "SendArrayLen0" })
             {
                 var p6 = Invoke(host, client, methodName);
                 Assert.Equal(0, p6.Length);
             }
 
             // batching 
-            foreach(string methodName in new string[] {
+            foreach (string methodName in new string[] {
                 "SendSyncCollectorBytes", "SendArrayString", "SendSyncCollectorString", "SendAsyncCollectorString", "SendCollectorNative" })
             {
                 var p4 = Invoke(host, client, methodName);
@@ -227,13 +224,13 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 Assert.Equal("second", p4[1].Message);
             }
 
-            foreach(string methodName in new string[] { "SendCollectorPoco", "SendArrayPoco" })
+            foreach (string methodName in new string[] { "SendCollectorPoco", "SendArrayPoco" })
             {
                 var p5 = InvokeJson<Payload>(host, client, methodName);
                 Assert.Equal(2, p5.Length);
                 Assert.Equal(100, p5[0].val1);
                 Assert.Equal(200, p5[1].val1);
-            }            
+            }
         }
 
         static FakeQueueData[] Invoke(JobHost host, FakeQueueClient client, string name)
@@ -256,6 +253,6 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             var obj = Array.ConvertAll(data, x => JsonConvert.DeserializeObject<T>(x.Message));
             client._items.Clear();
             return obj;
-        }        
+        }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/FakeQueue/FakeQueueClient.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/FakeQueue/FakeQueueClient.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using Microsoft.Azure.WebJobs.Host;
-using Microsoft.Azure.WebJobs.Host.Bindings;
-using Microsoft.Azure.WebJobs.Host.Config;
-using Microsoft.Azure.WebJobs.Host.Triggers;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using System;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Azure.WebJobs.Host.Config;
+using Microsoft.Azure.WebJobs.Host.Triggers;
+using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Host.UnitTests
 {
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             {
                 this.SetConverters(cm);
             }
-            
+
             cm.AddConverter<FakeQueueData, string>(msg => msg.Message);
             cm.AddConverter<OtherFakeQueueData, FakeQueueData>(OtherFakeQueueData.ToEvent);
 
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             // Binds [FakeQueue] --> IAsyncCollector<FakeQueueData>
             var ruleOutput = bf.BindToCollector<FakeQueueAttribute, FakeQueueData>(BuildFromAttr);
 
-            // Binds [FakeQueue] --> FakeQueueClient            
+            // Binds [FakeQueue] --> FakeQueueClient
             var ruleClient = bf.BindToInput<FakeQueueAttribute, FakeQueueClient>(this);
 
             extensions.RegisterBindingRules<FakeQueueAttribute>(ruleOutput, ruleClient);
@@ -69,6 +69,10 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
 
         FakeQueueClient IConverter<FakeQueueAttribute, FakeQueueClient>.Convert(FakeQueueAttribute attr)
         {
+            // Ensure that you can access the state set by the custom IResolutionPolicy
+            Assert.Equal("value1", attr.State1);
+            Assert.Equal("value2", attr.State2);
+
             return this;
         }
 
@@ -79,7 +83,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             {
                 _parent = this,
                 _prefix = attr.Prefix
-            }; 
+            };
 
         }
 

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Logging;
 using Xunit;
 
@@ -126,7 +125,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 "StorageAccountAttribute",
                 "DisableAttribute",
                 "TimeoutAttribute",
-                "TraceLevelAttribute"
+                "TraceLevelAttribute",
+                "ODataFilterResolutionPolicy"
             };
 
             AssertPublicTypes(expected, assembly);
@@ -211,7 +211,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 "IWebJobsExceptionHandler",
                 "WebJobsExceptionHandler",
                 "FunctionTimeoutException",
-                "PoisonMessageEventArgs"
+                "PoisonMessageEventArgs",
+                "IResolutionPolicy"
             };
 
             AssertPublicTypes(expected, assembly);


### PR DESCRIPTION
I partially resurrected Mathew's PR here: https://github.com/Azure/azure-webjobs-sdk/pull/971. I'm going to need this to be able to move forward with DocDB so wanted to get an initial review out before writing lots of tests and plumbing i through everything.

One big change that @MikeStall will be interested in -- now passing the ValueBindingContext along with the resolved attribute to all of the builder methods (only ExactType is doing this for this initial PR). 