### PR TITLE
Tweak rules around Binding to object to be more intuitive.

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/ConverterManager.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/ConverterManager.cs
@@ -200,11 +200,18 @@ namespace Microsoft.Azure.WebJobs
             // Inheritence (also covers idempotency)
             if (typeDest.IsAssignableFrom(typeSource))
             {
-                return (src, attr, context) =>
+                // Skip implicit conversions to object since that's everybody's base 
+                // class and BindToInput<attr,Object> would catch everything. 
+                // Users can still register an explicit T-->object converter if they want to 
+                // support it. 
+                if (typeDest != typeof(Object))
                 {
-                    object obj = (object)src;
-                    return (TDest)obj;
-                };
+                    return (src, attr, context) =>
+                    {
+                        object obj = (object)src;
+                        return (TDest)obj;
+                    };
+                }
             }
 
             // Object --> TDest

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Common/BindToGenericItemTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Common/BindToGenericItemTests.cs
@@ -187,6 +187,68 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Common
             }
         }
 
+        // Test binding to object. 
+        [Fact]
+        public void TestObjectInheritence()
+        {
+            TestWorker<ConfigObjectInheritence>();
+        }
+
+        public class ConfigObjectInheritence : IExtensionConfigProvider, ITest<ConfigObjectInheritence>, IConverter<TestAttribute, object>
+        {
+            public void Initialize(ExtensionConfigContext context)
+            {
+                var bf = context.Config.BindingFactory;
+                // No explicit converters -  just use implicit ones like inheritence
+                var rule1 = bf.BindToInput<TestAttribute, AlphaDerivedType>(typeof(GeneralBuilder<>));
+                var rule2 = bf.BindToInput<TestAttribute, object>(this); // 2nd rule
+                context.RegisterBindingRules<TestAttribute>(rule1, rule2);
+            }
+
+            public void Test(TestJobHost<ConfigObjectInheritence> host)
+            {
+                // 1st rule
+                host.Call("FuncDerived", new { k = 1 });
+                Assert.Equal("GeneralBuilder_AlphaDerivedType(1)", _log);
+
+                // 1st rule + implicit converter
+                host.Call("Func", new { k = 1 });
+                Assert.Equal("GeneralBuilder_AlphaDerivedType(1)", _log);
+
+                // 2nd rule, object isn't matched in an inheritence converter
+                host.Call("FuncObject", new { k = 1 });
+                Assert.Equal("[obj!]", _log);
+            }
+
+            string _log;
+
+            public void FuncDerived([Test("{k}")] AlphaDerivedType w)
+            {                
+                _log = w._value;
+            }
+
+            // builds AlphaDerivedType, and then applies an implicit inheritence converter.
+            public void Func([Test("{k}")] AlphaType w)
+            {
+                // Actually passed in a derived instance
+                Assert.IsType<AlphaDerivedType>(w);
+
+                _log = w._value;
+            }
+
+            // Uses the direct -->object binding rule 
+            public void FuncObject([Test("{k}")] object w)
+            {
+                var beta = Assert.IsType<BetaType>(w);
+                _log = beta._value;
+            }         
+
+            public object Convert(TestAttribute input)
+            {
+                return BetaType.New("[obj!]");
+            }
+        }
+
         // Test collectors and object[] bindings. 
         // Object[] --> multiple items 
         [Fact]


### PR DESCRIPTION
Converter manager has some implicit rules, like X-->Y is Y is assignable to X.
So
  BindToInput<attr,X>
would bind to
  Func(X x) and Func(Y y)

But Object is a base class of everything, and so any BindToInput would also bind to Func(object x), which is not what we want.

The change is to not allow implicit converters to Object.

This subtly was introduced last round after removing the "allowConverter manager" flag and having all bindings implicitly use a converter manager.