### PR TITLE
Fix a regression in table binding.

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Tables/TableAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Tables/TableAttributeBindingProvider.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Azure.WebJobs.Host.Tables
                 ValidateAttribute, nameResolver,
                 new IBindingProvider[]
                 {
-                    AllowMultipleRows(bindingFactory, bindAsyncCollector),
+                    bindAsyncCollector,
                     AllowMultipleRows(bindingFactory, bindToExactCloudTable),
                     AllowMultipleRows(bindingFactory, bindToExactTestCloudTable),
                     bindToJArray,

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/TableTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/TableTests.cs
@@ -166,6 +166,23 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
             AssertPropertyValue(entity, "ValueNum", 123);
         }
 
+        // Partition and RowKey values are in the attribute
+        [Fact]
+        public void Table_IfBoundToICollectorJObject__WithAttrKeys_AddInsertsEntity()
+        {
+            // Arrange
+            const string expectedValue = "abcdef";
+            IStorageAccount account = CreateFakeStorageAccount();
+            var config = TestHelpers.NewConfig(typeof(BindToICollectorJObjectProgramKeysInAttr), account);
+
+            // Act
+            var host = new TestJobHost<BindToICollectorJObjectProgramKeysInAttr>(config);
+            host.Call("Run");
+
+            // Assert
+            AssertStringProperty(account, "ValueStr", expectedValue);            
+        }
+
         [Fact]
         public void Table_IfBoundToICollectorITableEntity_AddInsertsEntity()
         {
@@ -467,6 +484,22 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
                 {
                     PartitionKey = PartitionKey,
                     RowKey = RowKey,
+                    ValueStr = "abcdef",
+                    ValueNum = 123
+                }));
+            }
+        }
+
+        // Partition and RowKey are missing from JObject, get them from the attribute. 
+        private class BindToICollectorJObjectProgramKeysInAttr
+        {
+            [NoAutomaticTrigger]
+            public static void Run(
+                [Table(TableName, PartitionKey, RowKey)] ICollector<JObject> table)
+            {
+                table.Add(JObject.FromObject(new
+                {
+                    // no partition and row key! USe from attribute instead. 
                     ValueStr = "abcdef",
                     ValueNum = 123
                 }));


### PR DESCRIPTION
Hit by Script Powershell binding.

IAsyncCollector rule is allowed even if the attribute includes a Partition or RowKey. Powershell uses this for outputing a singleton.