### PR TITLE
Fix pattern matcher for BindingRules

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/PatternMatcher.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/PatternMatcher.cs
@@ -240,7 +240,7 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
             }
 
             // IFoo<T>, IFoo<string> 
-            if (openType.IsGenericType)
+            if (specificType.IsGenericType && openType.IsGenericType)
             {
                 if (specificType.GetGenericTypeDefinition() != openType.GetGenericTypeDefinition())
                 {

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/ConverterManagerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/ConverterManagerTests.cs
@@ -514,6 +514,32 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 PatternMatcher.ResolveGenerics(int1, genArgs));
         }
 
+        public class TestConverter :
+            IConverter<Attribute, IAsyncCollector<string>>, // binding rule converter
+            IConverter<string, byte[]> // general type converter
+        {
+            public IAsyncCollector<string> Convert(Attribute input)
+            {
+                return null;
+            }
+
+            byte[] IConverter<string, byte[]>.Convert(string input)
+            {
+                return null;
+            }
+        }
+
+        [Fact]
+        public void PatternMatcher_Succeeds_WhenBindingRuleConverterExists()
+        {
+            var pm = PatternMatcher.New(typeof(TestConverter));
+            var generalConverter = pm.TryGetConverterFunc(typeof(string), typeof(byte[]));
+            Assert.NotNull(generalConverter);
+
+            var bindingRuleConverter = pm.TryGetConverterFunc(typeof(Attribute), typeof(IAsyncCollector<string>));
+            Assert.NotNull(bindingRuleConverter);
+        }
+
         private class TestConverterFakeEntity
             : IConverter<JObject, IFakeEntity>
         {


### PR DESCRIPTION
PatternMatcher would throw (from `specificType.GetGenericTypeDefinition`) if Type -> GenericType IConverter was defined when it should return false and move to evaluate the next IConverter.

Can occur if BindingRule IConverter and general IConverter are on the same class.