### PR TITLE
Propagate trigger listener exceptions

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Exceptions/FunctionException.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Exceptions/FunctionException.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.Serialization;
+
+namespace Microsoft.Azure.WebJobs.Host
+{
+    /// <summary>
+    /// Exception that is tied to a specific job method
+    /// </summary>
+    [SuppressMessage("Microsoft.Design", "CA1032:ImplementStandardExceptionConstructors")]
+    [Serializable]
+    public class FunctionException : RecoverableException
+    {
+        /// <summary>
+        /// Constructs a new instance.
+        /// </summary>
+        /// <param name="message">The exception message.</param>
+        /// <param name="methodName">The name of the method in error.</param>
+        /// <param name="innerException">The inner exception.</param>
+        public FunctionException(string message, string methodName, Exception innerException)
+            : base(message, innerException)
+        {
+            MethodName = methodName;
+        }
+
+        /// <summary>
+        /// Constructs a new instance.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/>.</param>
+        /// <param name="context">The <see cref="StreamingContext"/>.</param>
+        protected FunctionException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+            if (info == null)
+            {
+                throw new ArgumentNullException("info");
+            }
+
+            MethodName = info.GetString("MethodName");
+        }
+
+        /// <summary>
+        /// The name of the method in error.
+        /// </summary>
+        public string MethodName { get; private set; }
+
+        /// <inheritdoc/>
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            if (info == null)
+            {
+                throw new ArgumentNullException("info");
+            }
+
+            info.AddValue("MethodName", this.MethodName);
+
+            base.GetObjectData(info, context);
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Exceptions/RecoverableException.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Exceptions/RecoverableException.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.Serialization;
+
+namespace Microsoft.Azure.WebJobs.Host
+{
+    /// <summary>
+    /// A recoverable exception, i.e. can be handled.
+    /// </summary>
+    [Serializable]
+    public class RecoverableException : Exception
+    {
+        /// <inheritdoc/>
+        public RecoverableException() : base()
+        {
+        }
+
+        /// <inheritdoc/>
+        public RecoverableException(string message) : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a new instance.
+        /// </summary>
+        /// <param name="message">The exception message.</param>
+        /// <param name="innerException">The inner exception.</param>
+        public RecoverableException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a new instance.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/>.</param>
+        /// <param name="context">The <see cref="StreamingContext"/>.</param>
+        protected RecoverableException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+            if (info == null)
+            {
+                throw new ArgumentNullException("info");
+            }
+
+            Handled = bool.Parse(info.GetString("Handled"));
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the exception should be treated
+        /// as handled.
+        /// </summary>
+        public bool Handled { get; set; }
+
+        /// <inheritdoc/>
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            if (info == null)
+            {
+                throw new ArgumentNullException("info");
+            }
+
+            info.AddValue("Handled", this.Handled);
+
+            base.GetObjectData(info, context);
+        }
+
+        /// <summary>
+        /// Tries to recover by propagating exception through trace pipeline.
+        /// Recovers if exception is handled by trace pipeline, else throws.
+        /// </summary>
+        /// <param name="trace"></param>
+        public void TryRecover(TraceWriter trace)
+        {
+            if (trace == null)
+            {
+                throw this;
+            }
+
+            trace.Error(Message, this);
+            if (!Handled)
+            {
+                throw this;
+            }
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/FunctionInvocationException.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/FunctionInvocationException.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 
 namespace Microsoft.Azure.WebJobs.Host
@@ -9,24 +10,10 @@ namespace Microsoft.Azure.WebJobs.Host
     /// <summary>
     /// Exception thrown when a job function invocation fails.
     /// </summary>
+    [SuppressMessage("Microsoft.Design", "CA1032:ImplementStandardExceptionConstructors")]
     [Serializable]
-    public class FunctionInvocationException : Exception
+    public class FunctionInvocationException : FunctionException
     {
-        /// <inheritdoc/>
-        public FunctionInvocationException() : base()
-        {
-        }
-
-        /// <inheritdoc/>
-        public FunctionInvocationException(string message) : base(message)
-        {
-        }
-
-        /// <inheritdoc/>
-        public FunctionInvocationException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
-
         /// <summary>
         /// Constructs a new instance.
         /// </summary>
@@ -40,7 +27,6 @@ namespace Microsoft.Azure.WebJobs.Host
             }
 
             InstanceId = Guid.Parse(info.GetString("InstanceId"));
-            MethodName = info.GetString("MethodName");
         }
 
         /// <summary>
@@ -51,10 +37,9 @@ namespace Microsoft.Azure.WebJobs.Host
         /// <param name="methodName">The fully qualified method name.</param>
         /// <param name="innerException">The exception that is the cause of the current exception (or null).</param>
         public FunctionInvocationException(string message, Guid instanceId, string methodName, Exception innerException)
-            : base(message, innerException)
+            : base(methodName, message, innerException)
         {
             InstanceId = instanceId;
-            MethodName = methodName;
         }
 
         /// <summary>
@@ -62,11 +47,6 @@ namespace Microsoft.Azure.WebJobs.Host
         /// to the Dashboard logs.
         /// </summary>
         public Guid InstanceId { get; set; }
-
-        /// <summary>
-        /// Gets the fully qualified name of the function.
-        /// </summary>
-        public string MethodName { get; set; }
 
         /// <inheritdoc/>
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
@@ -77,7 +57,6 @@ namespace Microsoft.Azure.WebJobs.Host
             }
 
             info.AddValue("InstanceId", this.InstanceId);
-            info.AddValue("MethodName", this.MethodName);
 
             base.GetObjectData(info, context);
         }

--- a/src/Microsoft.Azure.WebJobs.Host/FunctionTimeoutException.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/FunctionTimeoutException.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
 
@@ -10,24 +11,10 @@ namespace Microsoft.Azure.WebJobs.Host
     /// <summary>
     /// Exception thrown when a job function invocation fails due to a timeout.
     /// </summary>
+    [SuppressMessage("Microsoft.Design", "CA1032:ImplementStandardExceptionConstructors")]
     [Serializable]
     public class FunctionTimeoutException : FunctionInvocationException
     {
-        /// <inheritdoc/>
-        public FunctionTimeoutException() : base()
-        {
-        }
-
-        /// <inheritdoc/>
-        public FunctionTimeoutException(string message) : base(message)
-        {
-        }
-
-        /// <inheritdoc/>
-        public FunctionTimeoutException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
-
         /// <inheritdoc/>
         protected FunctionTimeoutException(SerializationInfo info, StreamingContext context) : base(info, context)
         {

--- a/src/Microsoft.Azure.WebJobs.Host/Triggers/FunctionTriggerException.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Triggers/FunctionTriggerException.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace Microsoft.Azure.WebJobs.Host.Indexers
+namespace Microsoft.Azure.WebJobs.Host.Triggers
 {
     /// <summary>
     /// Exception that occurs when the <see cref="JobHost"/> encounters errors when trying
@@ -12,15 +12,15 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
     /// </summary>
     [SuppressMessage("Microsoft.Design", "CA1032:ImplementStandardExceptionConstructors")]
     [Serializable]
-    public class FunctionIndexingException : FunctionException
+    public class FunctionListenerException : FunctionException
     {
         /// <summary>
         /// Constructs a new instance.
         /// </summary>
         /// <param name="methodName">The name of the method in error.</param>
         /// <param name="innerException">The inner exception.</param>
-        public FunctionIndexingException(string methodName, Exception innerException)
-            : base($"Error indexing method '{methodName}'", methodName, innerException)
+        public FunctionListenerException(string methodName, Exception innerException)
+            : base($"The listener for function '{methodName}' was unable to start.", methodName, innerException)
         {
         }
     }

--- a/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
+++ b/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
@@ -404,8 +404,10 @@
     <Compile Include="Extensions\ExceptionExtensions.cs" />
     <Compile Include="FuncConverter.cs" />
     <Compile Include="FunctionTimeoutException.cs" />
+    <Compile Include="Exceptions\RecoverableException.cs" />
     <Compile Include="JobHostBlobsConfiguration.cs" />
     <Compile Include="Loggers\TraceEventExtensions.cs" />
+    <Compile Include="Exceptions\FunctionException.cs" />
     <Compile Include="Queues\Bindings\QueueBindingProvider.cs" />
     <Compile Include="Bindings\TraceWriter\TextWriterTraceAdapter.cs" />
     <Compile Include="Bindings\TraceWriter\TraceWriterBinding.cs" />
@@ -430,6 +432,7 @@
     <Compile Include="Queues\PoisonQueueMessageEventArgs.cs" />
     <Compile Include="Bindings\ODataFilterResolutionPolicy.cs" />
     <Compile Include="Tables\TableFilterFormatter.cs" />
+    <Compile Include="Triggers\FunctionTriggerException.cs" />
     <Compile Include="Triggers\StrategyTriggerBinding.cs" />
     <Compile Include="Bindings\ConstantValueProvider.cs" />
     <Compile Include="Bindings\ConverterManager.cs" />

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Listeners/ListenerFactoryTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Listeners/ListenerFactoryTests.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.Indexers;
+using Microsoft.Azure.WebJobs.Host.Listeners;
+using Microsoft.Azure.WebJobs.Host.Protocols;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Microsoft.Azure.WebJobs.Host.Triggers;
+using Moq;
+using Xunit;
+using System.Collections.ObjectModel;
+
+namespace Microsoft.Azure.WebJobs.Host.UnitTests.Listeners
+{
+    public class ListenerFactoryTests
+    {
+        CancellationToken ct = default(CancellationToken);
+
+        private async Task<IListener> GetListener(TraceWriter trace)
+        {
+            var fd = new FunctionDescriptor()
+            {
+                ShortName = "testfunc"
+            };
+
+            Mock<IListener> badListener = new Mock<IListener>(MockBehavior.Strict);
+            badListener.Setup(bl => bl.StartAsync(It.IsAny<CancellationToken>()))
+                .Throws(new Exception("listener"));
+
+            Mock<ITriggerBinding> triggerBinding = new Mock<ITriggerBinding>(MockBehavior.Strict);
+            triggerBinding.Setup(tb => tb.CreateListenerAsync(It.IsAny<ListenerFactoryContext>()))
+                .ReturnsAsync(badListener.Object);
+            var lf = new FunctionIndexer.ListenerFactory(fd, null, triggerBinding.Object, trace);
+
+            return await lf.CreateAsync(ct);
+        }
+
+        [Fact]
+        public async Task GeneratedListener_Throws_IfListenerExceptionOnStartAsync()
+        {
+            var trace = new TestTraceWriter(TraceLevel.Error);
+            var listener = await GetListener(trace);
+            var e = await Assert.ThrowsAsync<FunctionListenerException>(async () => await listener.StartAsync(ct));
+            var exc = trace.Traces[0].Exception as FunctionException;
+            Assert.Equal("testfunc", exc.MethodName);
+            Assert.False(exc.Handled);
+        }
+
+        [Fact]
+        public async Task GeneratedListener_DoesNotThrow_IfHandled()
+        {
+            HandlingTraceWriter trace = new HandlingTraceWriter(TraceLevel.Error, (te) => (te.Exception as RecoverableException).Handled = true);
+            var listener = await GetListener(trace);
+            await listener.StartAsync(ct);
+            Assert.Equal("The listener for function 'testfunc' was unable to start.", trace.Traces[0].Message);
+            var exc = trace.Traces[0].Exception as FunctionException;
+            Assert.Equal("testfunc", exc.MethodName);
+            Assert.True(exc.Handled);
+        }
+
+        private class HandlingTraceWriter : TraceWriter
+        {
+            public Collection<TraceEvent> Traces = new Collection<TraceEvent>();
+            public Action<TraceEvent> _handler;
+
+            public HandlingTraceWriter(TraceLevel level, Action<TraceEvent> handler) : base(level)
+            {
+                _handler = handler;
+            }
+
+            public override void Trace(TraceEvent traceEvent)
+            {
+                Traces.Add(traceEvent);
+                _handler(traceEvent);
+            }
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
@@ -192,6 +192,7 @@
     <Compile Include="JobHostContextTests.cs" />
     <Compile Include="JobHostQueuesConfigurationTests.cs" />
     <Compile Include="Listeners\HostListenerFactoryTests.cs" />
+    <Compile Include="Listeners\ListenerFactoryTests.cs" />
     <Compile Include="Loggers\TraceWriterFunctionInstanceLoggerTests.cs" />
     <Compile Include="NullExtensionTypeLocator.cs" />
     <Compile Include="Protocols\FunctionStartedMessageExtensionsTests.cs" />


### PR DESCRIPTION
resolves #996 

Wrap function trigger listeners to catch errors and trace FunctionIndexingExceptions (which will be picked up by script). If handled, swallow, otherwise throw.

Also changed the `CreateTriggeredFunctionDefinition` method to be a bit less unwieldy (static -> instance and removed intermediate method to lessen parameter passing)

**REQUIRES CHANGES IN SCRIPT TO HANDLE NEW EXCEPTIONS**