### PR TITLE
Stop special-casing StorageAccountAttribute.

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingProviders/AsyncCollectorBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingProviders/AsyncCollectorBindingProvider.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
                 var patternMatcher = parent._patternMatcher;
 
                 var parameter = context.Parameter;
-                TAttribute attributeSource = parameter.GetCustomAttribute<TAttribute>(inherit: false);
+                TAttribute attributeSource = TypeUtility.GetAttr<TAttribute>(parameter);
 
                 Func<TAttribute, Task<TAttribute>> hookWrapper = null;
                 if (parent.PostResolveHook != null)

--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingProviders/BindToInputBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingProviders/BindToInputBindingProvider.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
                 var patternMatcher = parent._patternMatcher;
 
                 var parameter = context.Parameter;
-                TAttribute attributeSource = parameter.GetCustomAttribute<TAttribute>(inherit: false);
+                TAttribute attributeSource = TypeUtility.GetAttr<TAttribute>(parameter);
 
                 Func<TAttribute, Task<TAttribute>> hookWrapper = null;
                 if (parent.PostResolveHook != null)

--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/StorageAccount/CloudStorageAccountBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/StorageAccount/CloudStorageAccountBindingProvider.cs
@@ -33,7 +33,10 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings.StorageAccount
                 return null;
             }
 
-            IStorageAccount account = await _accountProvider.GetStorageAccountAsync(context.Parameter, context.CancellationToken);
+            var attr = TypeUtility.GetAttr<StorageAccountAttribute>(parameter) ?? new StorageAccountAttribute(null);
+
+            INameResolver nameResolver = null; // $$ bug?
+            IStorageAccount account = await _accountProvider.GetStorageAccountAsync(attr, context.CancellationToken, nameResolver);
             IBinding binding = new CloudStorageAccountBinding(parameter.Name, account.SdkObject);
             return binding;
         }

--- a/src/Microsoft.Azure.WebJobs.Host/Blobs/Bindings/BlobAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Blobs/Bindings/BlobAttributeBindingProvider.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
         public async Task<IBinding> TryCreateAsync(BindingProviderContext context)
         {
             ParameterInfo parameter = context.Parameter;
-            BlobAttribute blobAttribute = parameter.GetCustomAttribute<BlobAttribute>(inherit: false);
+            BlobAttribute blobAttribute = TypeUtility.GetAttr<BlobAttribute>(parameter);
 
             if (blobAttribute == null)
             {
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
 
             string resolvedPath = Resolve(blobAttribute.BlobPath);
             IBindableBlobPath path = null;
-            IStorageAccount account = await _accountProvider.GetStorageAccountAsync(context.Parameter, context.CancellationToken, _nameResolver);
+            IStorageAccount account = await _accountProvider.GetStorageAccountAsync(blobAttribute, context.CancellationToken, _nameResolver);
             StorageClientFactoryContext clientFactoryContext = new StorageClientFactoryContext
             {
                 Parameter = context.Parameter

--- a/src/Microsoft.Azure.WebJobs.Host/Blobs/Triggers/BlobTriggerAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Blobs/Triggers/BlobTriggerAttributeBindingProvider.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Triggers
         public async Task<ITriggerBinding> TryCreateAsync(TriggerBindingProviderContext context)
         {
             ParameterInfo parameter = context.Parameter;
-            BlobTriggerAttribute blobTriggerAttribute = parameter.GetCustomAttribute<BlobTriggerAttribute>(inherit: false);
+            BlobTriggerAttribute blobTriggerAttribute = TypeUtility.GetAttr<BlobTriggerAttribute>(parameter);
 
             if (blobTriggerAttribute == null)
             {
@@ -166,7 +166,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Triggers
             }
 
             IStorageAccount hostAccount = await _accountProvider.GetStorageAccountAsync(context.CancellationToken);
-            IStorageAccount dataAccount = await _accountProvider.GetStorageAccountAsync(context.Parameter, context.CancellationToken, _nameResolver);
+            IStorageAccount dataAccount = await _accountProvider.GetStorageAccountAsync(blobTriggerAttribute, context.CancellationToken, _nameResolver);
             // premium does not support blob logs, so disallow for blob triggers
             dataAccount.AssertTypeOneOf(StorageAccountType.GeneralPurpose, StorageAccountType.BlobOnly);
 

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/StorageAccountProviderExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/StorageAccountProviderExtensions.cs
@@ -45,14 +45,14 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             ValidateStorageAccount(account, connectionStringName);
             return account;
         }
-        public static async Task<IStorageAccount> GetStorageAccountAsync(this IStorageAccountProvider provider, ParameterInfo parameter, CancellationToken cancellationToken, INameResolver nameResolver = null)
-        {
-            if (provider == null)
-            {
-                throw new ArgumentNullException("provider");
-            }
 
-            string connectionStringName = GetAccountOverrideOrNull(parameter);
+        public static Task<IStorageAccount> GetStorageAccountAsync(this IStorageAccountProvider provider, StorageAccountAttribute attribute, CancellationToken cancellationToken, INameResolver nameResolver)
+        {
+            return provider.GetStorageAccountAsync(attribute.Account, cancellationToken, nameResolver);
+        }
+
+        public static async Task<IStorageAccount> GetStorageAccountAsync(this IStorageAccountProvider provider, string connectionStringName, CancellationToken cancellationToken, INameResolver nameResolver = null)
+        {
             if (string.IsNullOrEmpty(connectionStringName))
             {
                 connectionStringName = ConnectionStringNames.Storage;
@@ -79,20 +79,6 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
                 string message = StorageAccountParser.FormatParseAccountErrorMessage(StorageAccountParseResult.MissingOrEmptyConnectionStringError, connectionStringName);
                 throw new InvalidOperationException(message);
             }
-        }
-
-        /// <summary>
-        /// Walk from the parameter up to the containing type, looking for a
-        /// <see cref="StorageAccountAttribute"/>. If found, return the account.
-        /// </summary>
-        internal static string GetAccountOverrideOrNull(ParameterInfo parameter)
-        {
-            StorageAccountAttribute attribute = TypeUtility.GetHierarchicalAttributeOrNull<StorageAccountAttribute>(parameter);
-            if (attribute != null)
-            {
-                return attribute.Account;
-            }
-            return null;
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Queues/Bindings/QueueBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Queues/Bindings/QueueBindingProvider.cs
@@ -22,15 +22,18 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Bindings
     {
         // Fields that the various binding funcs need to close over. 
         private readonly IStorageAccountProvider _accountProvider;
+        private readonly INameResolver _nameResolver;
         private readonly IContextGetter<IMessageEnqueuedWatcher> _messageEnqueuedWatcherGetter;
 
         // Use the static Build method to create. 
         // Constructor is just for capturing instance fields used in func closures. 
         private QueueBindingProvider(
                IStorageAccountProvider accountProvider,
+               INameResolver nameResolver,
                IContextGetter<IMessageEnqueuedWatcher> messageEnqueuedWatcherGetter)
         {
             _accountProvider = accountProvider;
+            _nameResolver = nameResolver;
             _messageEnqueuedWatcherGetter = messageEnqueuedWatcherGetter;
         }
 
@@ -40,7 +43,7 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Bindings
             INameResolver nameResolver,
             IConverterManager converterManager)
         {
-            var closure = new QueueBindingProvider(accountProvider, messageEnqueuedWatcherGetter);
+            var closure = new QueueBindingProvider(accountProvider, nameResolver, messageEnqueuedWatcherGetter);
             var bindingProvider = closure.New(nameResolver, converterManager);
             return bindingProvider;
         }
@@ -64,13 +67,13 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Bindings
             var bindingFactory = new BindingFactory(nameResolver, converterManager);
 
             var bindAsyncCollector = bindingFactory.BindToCollector<QueueAttribute, IStorageQueueMessage>(BuildFromQueueAttribute)
-                .SetPostResolveHook<QueueAttribute>(ToWriteParameterDescriptorForCollector, CollectAttributeInfo);
+                .SetPostResolveHook<QueueAttribute>(ToWriteParameterDescriptorForCollector);
 
-            var bindClient = bindingFactory.BindToInput<QueueAttribute, IStorageQueue>(typeof(QueueBuilder))
-                .SetPostResolveHook<QueueAttribute>(ToReadWriteParameterDescriptorForCollector, CollectAttributeInfo);
+            var bindClient = bindingFactory.BindToInput<QueueAttribute, IStorageQueue>(typeof(QueueBuilder), this)
+                .SetPostResolveHook<QueueAttribute>(ToReadWriteParameterDescriptorForCollector);
 
-            var bindSdkClient = bindingFactory.BindToInput<QueueAttribute, CloudQueue>(typeof(QueueBuilder))
-                .SetPostResolveHook<QueueAttribute>(ToReadWriteParameterDescriptorForCollector, CollectAttributeInfo);
+            var bindSdkClient = bindingFactory.BindToInput<QueueAttribute, CloudQueue>(typeof(QueueBuilder), this)
+                .SetPostResolveHook<QueueAttribute>(ToReadWriteParameterDescriptorForCollector);
 
             var bindingProvider = new GenericCompositeBindingProvider<QueueAttribute>(
                 ValidateQueueAttribute, nameResolver, bindClient, bindSdkClient, bindAsyncCollector);
@@ -86,23 +89,6 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Bindings
             QueueCausalityManager.SetOwner(functionInstanceId, objectToken);
 
             return objectToken;
-        }
-
-        // [Queue] has some pre-existing behavior where the storage account can be specified outside of the [Queue] attribute. 
-        // The storage account is pulled from the ParameterInfo (which could pull in a [Storage] attribute on the container class)
-        // Resolve everything back down to a single attribute so we can use the binding helpers. 
-        // This pattern should be rare since other extensions can just keep everything directly on the primary attribute. 
-        private async Task<QueueAttribute> CollectAttributeInfo(QueueAttribute attrResolved, ParameterInfo parameter, INameResolver nameResolver)
-        {
-            // Look for [Storage] attribute and squirrel over 
-            IStorageAccount account = await _accountProvider.GetStorageAccountAsync(parameter, CancellationToken.None, nameResolver);
-            StorageClientFactoryContext clientFactoryContext = new StorageClientFactoryContext
-            {
-                Parameter = parameter
-            };
-            IStorageQueueClient client = account.CreateQueueClient(clientFactoryContext);
-                    
-            return new ResolvedQueueAttribute(attrResolved.QueueName, client);
         }
 
         // ParameterDescriptor for binding to CloudQueue. Whereas the output bindings are FileAccess.Write; CloudQueue exposes Peek() 
@@ -122,7 +108,7 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Bindings
         private ParameterDescriptor ToParameterDescriptorForCollector(QueueAttribute attr, ParameterInfo parameter, INameResolver nameResolver, FileAccess access)
         {
             Task<IStorageAccount> t = Task.Run(() =>
-                _accountProvider.GetStorageAccountAsync(parameter, CancellationToken.None, nameResolver));
+                _accountProvider.GetStorageAccountAsync(attr, CancellationToken.None, nameResolver));
             IStorageAccount account = t.GetAwaiter().GetResult();
 
             string accountName = account.Credentials.AccountName;
@@ -195,10 +181,15 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Bindings
             return new QueueAsyncCollector(queue, _messageEnqueuedWatcherGetter.Value);
         }
 
-        private static IStorageQueue GetQueue(QueueAttribute attrResolved)
+        private IStorageQueue GetQueue(QueueAttribute attrResolved)
         {
-            var attr = (ResolvedQueueAttribute)attrResolved;
-            IStorageQueue queue = attr.GetQueue();
+            IStorageAccount account = Task.Run(() => this._accountProvider.GetStorageAccountAsync(attrResolved, CancellationToken.None, this._nameResolver)).GetAwaiter().GetResult();
+            IStorageQueueClient client = account.CreateQueueClient();
+
+            string queueName = attrResolved.QueueName.ToLowerInvariant();
+            QueueClient.ValidateQueueName(queueName);
+
+            IStorageQueue queue = client.GetQueueReference(queueName);
             return queue;
         }
 
@@ -206,11 +197,17 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Bindings
             IAsyncConverter<QueueAttribute, IStorageQueue>, 
             IAsyncConverter<QueueAttribute, CloudQueue>
         {
+            private readonly QueueBindingProvider _parent;
+            public QueueBuilder(QueueBindingProvider parent)
+            {
+                _parent = parent;
+            }
+
             async Task<IStorageQueue> IAsyncConverter<QueueAttribute, IStorageQueue>.ConvertAsync(
                 QueueAttribute attrResolved,
                 CancellationToken cancellation)
             {
-                IStorageQueue queue = GetQueue(attrResolved);
+                IStorageQueue queue = _parent.GetQueue(attrResolved);
                 await queue.CreateIfNotExistsAsync(CancellationToken.None);
                 return queue;
             }
@@ -222,31 +219,6 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Bindings
                 IAsyncConverter<QueueAttribute, IStorageQueue> convert = this;
                 var queue = await convert.ConvertAsync(attrResolved, cancellation);
                 return queue.SdkObject;
-            }
-        }
-
-        // Queue attributes can optionally be paired with a separate [StorageAccount]. 
-        // Consolidate the information from both attributes into a single attribute.
-        // New extensions should just place everything in the attribute or the configuration and so shouldn't need to do this. 
-        internal sealed class ResolvedQueueAttribute : QueueAttribute
-        {
-            public ResolvedQueueAttribute(string queueName, IStorageQueueClient client)
-                : base(queueName)
-            {
-                this.Client = client;
-            }
-
-            internal IStorageQueueClient Client { get; private set; }
-
-            public IStorageQueue GetQueue()
-            {
-                // Azure Queues must be lowercase. 
-                // pre-existing behavior: coerce name to lowercase to be nice. 
-                string queueName = this.QueueName.ToLowerInvariant();
-
-                QueueClient.ValidateQueueName(queueName);
-
-                return this.Client.GetQueueReference(queueName);
             }
         }
 

--- a/src/Microsoft.Azure.WebJobs.Host/Queues/Triggers/QueueTriggerAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Queues/Triggers/QueueTriggerAttributeBindingProvider.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Triggers
         public async Task<ITriggerBinding> TryCreateAsync(TriggerBindingProviderContext context)
         {
             ParameterInfo parameter = context.Parameter;
-            QueueTriggerAttribute queueTrigger = parameter.GetCustomAttribute<QueueTriggerAttribute>(inherit: false);
+            QueueTriggerAttribute queueTrigger = TypeUtility.GetAttr<QueueTriggerAttribute>(parameter);
 
             if (queueTrigger == null)
             {
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Triggers
                     "Can't bind QueueTrigger to type '" + parameter.ParameterType + "'.");
             }
 
-            IStorageAccount account = await _accountProvider.GetStorageAccountAsync(context.Parameter, context.CancellationToken, _nameResolver);
+            IStorageAccount account = await _accountProvider.GetStorageAccountAsync(queueTrigger, context.CancellationToken, _nameResolver);
             // requires storage account with queue support
             account.AssertTypeOneOf(StorageAccountType.GeneralPurpose);
 

--- a/src/Microsoft.Azure.WebJobs/BlobAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs/BlobAttribute.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.WebJobs
     [SuppressMessage("Microsoft.Design", "CA1019:DefineAccessorsForAttributeArguments", Justification = "There is an accessor for FileAccess")]
     [AttributeUsage(AttributeTargets.Parameter)]
     [DebuggerDisplay("{BlobPath,nq}")]
-    public sealed class BlobAttribute : Attribute
+    public sealed class BlobAttribute : StorageAccountAttribute
     {
         private readonly string _blobPath;
         private readonly FileAccess? _access;

--- a/src/Microsoft.Azure.WebJobs/BlobTriggerAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs/BlobTriggerAttribute.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.WebJobs
     /// </remarks>
     [AttributeUsage(AttributeTargets.Parameter)]
     [DebuggerDisplay("{BlobPath,nq}")]
-    public sealed class BlobTriggerAttribute : Attribute
+    public sealed class BlobTriggerAttribute : StorageAccountAttribute
     {
         private readonly string _blobPath;
 

--- a/src/Microsoft.Azure.WebJobs/GlobalSuppressions.cs
+++ b/src/Microsoft.Azure.WebJobs/GlobalSuppressions.cs
@@ -3,3 +3,4 @@
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1019:DefineAccessorsForAttributeArguments", Scope = "type", Target = "Microsoft.Azure.WebJobs.TimeoutAttribute")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1813:AvoidUnsealedAttributes", Scope = "type", Target = "Microsoft.Azure.WebJobs.TableAttribute")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1813:AvoidUnsealedAttributes", Scope = "type", Target = "Microsoft.Azure.WebJobs.StorageAccountAttribute")]

--- a/src/Microsoft.Azure.WebJobs/QueueAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs/QueueAttribute.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.WebJobs
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1813:AvoidUnsealedAttributes")]
     [AttributeUsage(AttributeTargets.Parameter)]
     [DebuggerDisplay("{QueueName,nq}")]
-    public class QueueAttribute : Attribute
+    public class QueueAttribute : StorageAccountAttribute
     {
         private readonly string _queueName;
 

--- a/src/Microsoft.Azure.WebJobs/QueueTriggerAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs/QueueTriggerAttribute.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.WebJobs
     /// </remarks>
     [AttributeUsage(AttributeTargets.Parameter)]
     [DebuggerDisplay("{QueueName,nq}")]
-    public sealed class QueueTriggerAttribute : Attribute
+    public sealed class QueueTriggerAttribute : StorageAccountAttribute
     {
         private readonly string _queueName;
 

--- a/src/Microsoft.Azure.WebJobs/StorageAccountAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs/StorageAccountAttribute.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.WebJobs
     /// is in that order.
     /// </remarks>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Parameter)]
-    public sealed class StorageAccountAttribute : Attribute
+    public class StorageAccountAttribute : Attribute
     {
         /// <summary>
         /// Constructs a new instance.
@@ -33,8 +33,15 @@ namespace Microsoft.Azure.WebJobs
         }
 
         /// <summary>
+        /// Use public setting property. 
+        /// </summary>
+        protected StorageAccountAttribute()
+        {
+        }
+
+        /// <summary>
         /// Gets the name of the Azure Storage connection string to use.
         /// </summary>
-        public string Account { get; private set; }
+        public string Account { get; protected set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs/TableAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs/TableAttribute.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.WebJobs
     /// </remarks>
     [AttributeUsage(AttributeTargets.Parameter)]
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
-    public class TableAttribute : Attribute
+    public class TableAttribute : StorageAccountAttribute
     {
         private readonly string _tableName;
         private readonly string _partitionKey;

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/MultipleStorageAccountsEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/MultipleStorageAccountsEndToEndTests.cs
@@ -178,7 +178,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             output = input;
         }
 
-
         public static void QueueToQueue_DifferentAccounts_PrimaryToSecondary(
             [QueueTrigger(Input)] string input,
             [Queue(Output), StorageAccount(Secondary)] out string output)


### PR DESCRIPTION
Make the storage attributes (Blob,Table,Queue) derive from StorageAccountAttribute.  This gives Blob* attribute a Connection property, just like all the other attributes.
This is not a breaking change - and no change to public tests.

The key is in TypeUtility's new GetAttr function. It still walks the hierarchy and collapses attributes into a single attr.

The motivation here is:
1. Stop special-casing blob storage. All other resources need something similar here.
2. Provides a 1:1 between Attributes and Function.json that lets us removes corner cases in Script and tooling