### PR TITLE
Adding UT (unittest) project for appveyor

### DIFF
--- a/test/Dashboard.UnitTests/AutoFacTests.cs
+++ b/test/Dashboard.UnitTests/AutoFacTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 
 namespace Dashboard.UnitTests
 {
+    [Trait("SecretsRequired", "true")]
     public class AutoFacTests
     {
         private const string FunctionLogTableAppSettingName = "AzureWebJobsLogTableName";

--- a/test/Dashboard.UnitTests/Data/AccountProviderTests.cs
+++ b/test/Dashboard.UnitTests/Data/AccountProviderTests.cs
@@ -10,6 +10,7 @@ namespace Dashboard.UnitTests.Data
     public class AccountProviderTests
     {
         [Fact]
+        [Trait("SecretsRequired", "true")]
         public void GetAccounts_ReturnsExpectedResults()
         {
             // TODO: add a couple env accounts and verify

--- a/test/Dashboard.UnitTests/RestApiTests.cs
+++ b/test/Dashboard.UnitTests/RestApiTests.cs
@@ -21,6 +21,7 @@ namespace Dashboard.UnitTests
     // Test calling the REST API surface. 
     // This surface area is important because the APIs are public and called by the Portal.
     // This explicitly goes through the HttpClient and tests things like serialization, rest interfaces, etc. 
+    [Trait("SecretsRequired", "true")]
     public class RestApiTests : IClassFixture<RestApiTests.Fixture>
     {
         private readonly Fixture _fixture;

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/HostCallTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/HostCallTests.cs
@@ -1070,6 +1070,7 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
         }
 
         [Fact]
+        [Trait("SecretsRequired", "true")]
         public void TableEntity_IfBoundToJArray_CanCall()
         {
             IStorageAccount account = GetRealStorage(); // Fake storage doesn't implement table filters

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/Queues/QueueProcessorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/Queues/QueueProcessorTests.cs
@@ -15,6 +15,7 @@ using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
 {
+    [Trait("SecretsRequired", "true")]
     public class QueueProcessorTests : IClassFixture<QueueProcessorTests.TestFixture>
     {
         private CloudQueue _queue;

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/StorageAccountTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/StorageAccountTests.cs
@@ -14,6 +14,7 @@ using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Storage.IntegrationTests
 {
+    [Trait("SecretsRequired", "true")]
     public class StorageAccountTests
     {
         [Fact]

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostTests.cs
@@ -472,13 +472,13 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         }
 
         [Fact]
+        [Trait("SecretsRequired", "true")]
         public void IndexingExceptions_CanBeHandledByTraceWriter()
         {
             JobHostConfiguration config = new JobHostConfiguration();
             TestTraceWriter traceWriter = new TestTraceWriter(TraceLevel.Verbose);
             config.Tracing.Tracers.Add(traceWriter);
             config.TypeLocator = new FakeTypeLocator(typeof(BindingErrorsProgram));
-
             FunctionErrorTraceWriter errorTraceWriter = new FunctionErrorTraceWriter(TraceLevel.Error);
             config.Tracing.Tracers.Add(errorTraceWriter);
 

--- a/test/Microsoft.Azure.WebJobs.Logging.FunctionalTests/LoggerTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Logging.FunctionalTests/LoggerTest.cs
@@ -14,6 +14,7 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Azure.WebJobs.Logging.FunctionalTests
 {
+    [Trait("SecretsRequired", "true")]
     public class LoggerTest : IDisposable, ILogTableProvider
     {
         static string DefaultHost = "host";


### PR DESCRIPTION
resolves #1061 

Trying to get CI running for webjobs-sdk pull requests.

Rather than reorganize the test projects, added a 'SecretsRequired' trait to tests/test classes that require AzureWebJobsDashboard, etc.
Test command runs with /TestCaseFilter:"SecretsRequired!=true" to filter out these tests.
I don't run the end to end test dll at all.

Here's the appveyor project: https://ci.appveyor.com/project/appsvc/azure-webjobs-sdk-881mw/settings

@fabiocav let's get this hooked up to your function which differentiates between `script` and `script (UT)` tomorrow if you've got the time