### PR TITLE
Adding binding data contract for EventHub trigger (#1004)

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/Data/ClassDataBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/Data/ClassDataBinding.cs
@@ -53,24 +53,19 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings.Data
                 throw new ArgumentNullException("context");
             }
 
-            IReadOnlyDictionary<string, object> bindingData = context.BindingData;
-
+            var bindingData = context.BindingData;
             if (bindingData == null || !bindingData.ContainsKey(_parameterName))
             {
-                throw new InvalidOperationException(
-                    "Binding data does not contain expected value '" + _parameterName + "'.");
+                throw new InvalidOperationException($"Binding data does not contain expected value '{_parameterName}'.");
             }
 
             object untypedValue = bindingData[_parameterName];
-
             if (!(untypedValue is TBindingData))
             {
-                throw new InvalidOperationException("Binding data for '" + _parameterName +
-                    "' is not of expected type " + typeof(TBindingData).Name + ".");
+                throw new InvalidOperationException($"Binding data for '{_parameterName}' is not of expected type {typeof(TBindingData).Name}.");
             }
 
-            TBindingData typedValue = (TBindingData)untypedValue;
-            return BindAsync(typedValue, context.ValueContext);
+            return BindAsync((TBindingData)untypedValue, context.ValueContext);
         }
 
         public ParameterDescriptor ToParameterDescriptor()

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubListener.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubListener.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
                 EventHubTriggerInput value = new EventHubTriggerInput
                 {
                     Events = messages.ToArray(),
-                    Context = context
+                    PartitionContext = context
                 };
 
                 // Single dispatch 

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubTriggerInput.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubTriggerInput.cs
@@ -6,20 +6,20 @@ using Microsoft.ServiceBus.Messaging;
 namespace Microsoft.Azure.WebJobs.ServiceBus
 {
     // The core object we get when an EventHub is triggered. 
-    // This gets converter to the user type (EventData, string, poco, etc) 
+    // This gets converted to the user type (EventData, string, poco, etc) 
     internal sealed class EventHubTriggerInput      
     {        
         // If != -1, then only process a single event in this batch. 
         private int _selector = -1;
 
         internal EventData[] Events { get; set; }
-        internal PartitionContext Context { get; set; }
+        internal PartitionContext PartitionContext { get; set; }
 
         public static EventHubTriggerInput New(EventData eventData)
         {
             return new EventHubTriggerInput
             {
-                Context = null,
+                PartitionContext = null,
                 Events = new EventData[]
                 {
                       eventData
@@ -28,12 +28,20 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
             };
         }
 
+        public bool IsSingleDispatch
+        {
+            get
+            {
+                return _selector != -1;
+            }
+        }
+
         public EventHubTriggerInput GetSingleEventTriggerInput(int idx)
         {
             return new EventHubTriggerInput
             {
                 Events = this.Events,
-                Context = this.Context,
+                PartitionContext = this.PartitionContext,
                 _selector = idx
             };
         }

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubTriggerInputBindingStrategy.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubTriggerInputBindingStrategy.cs
@@ -13,25 +13,14 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
     // Binding strategy for an event hub triggers. 
     internal class EventHubTriggerBindingStrategy : ITriggerBindingStrategy<EventData, EventHubTriggerInput>
     {
-        private const string DataContractPartitionContext = "partitionContext";
-
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]
-        public EventHubTriggerInput ConvertFromString(string x)
+        public EventHubTriggerInput ConvertFromString(string input)
         {
-            byte[] bytes = Encoding.UTF8.GetBytes(x);
+            byte[] bytes = Encoding.UTF8.GetBytes(input);
             EventData eventData = new EventData(bytes);
 
             // Return a single event. Doesn't support multiple dispatch 
             return EventHubTriggerInput.New(eventData);            
-        }
-
-        // Get the static binding contract
-        //  - gets augmented 
-        public Dictionary<string, Type> GetStaticBindingContract()
-        {
-            Dictionary<string, Type> contract = new Dictionary<string, Type>();
-            contract[DataContractPartitionContext] = typeof(PartitionContext);
-            return contract;
         }
 
         // Single instance: Core --> EventData
@@ -41,8 +30,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
             {
                 throw new ArgumentNullException("value");
             }
-            EventData eventData = value.GetSingleEventData();
-            return eventData;
+            return value.GetSingleEventData();
         }
 
         public EventData[] BindMultiple(EventHubTriggerInput value, ValueBindingContext context)
@@ -54,7 +42,43 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
             return value.Events;
         }
 
-        // GEt runtime instance of binding contract 
+        // Get the static binding contract
+        //  - gets augmented 
+        public Dictionary<string, Type> GetStaticBindingContract()
+        {
+            // TODO: need to be able to determine here if we're single dispatch
+            // https://github.com/Azure/azure-webjobs-sdk/issues/1072
+            bool isSingleDispatch = true;
+
+            return GetBindingContract(isSingleDispatch);
+        }
+
+        internal static Dictionary<string, Type> GetBindingContract(bool isSingleDispatch)
+        {
+            Dictionary<string, Type> contract = new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase);
+            contract.Add("PartitionContext", typeof(PartitionContext));
+
+            // TODO: need to be able to determine here if we're single dispatch
+            // https://github.com/Azure/azure-webjobs-sdk/issues/1072
+            if (isSingleDispatch)
+            {
+                AddBindingContractMember(contract, "PartitionKey", typeof(string), isSingleDispatch);
+                AddBindingContractMember(contract, "Offset", typeof(string), isSingleDispatch);
+                AddBindingContractMember(contract, "SequenceNumber", typeof(long), isSingleDispatch);
+                AddBindingContractMember(contract, "EnqueuedTimeUtc", typeof(DateTime), isSingleDispatch);
+                AddBindingContractMember(contract, "Properties", typeof(IDictionary<string, object>), isSingleDispatch);
+                AddBindingContractMember(contract, "SystemProperties", typeof(IDictionary<string, object>), isSingleDispatch);
+            }
+
+            return contract;
+        }
+
+        private static void AddBindingContractMember(Dictionary<string, Type> contract, string name, Type type, bool isSingleDispatch)
+        {
+            contract.Add(name, isSingleDispatch ? type : type.MakeArrayType());
+        }
+
+        // Get runtime instance of binding contract 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "PartitionContext")]
         public Dictionary<string, object> GetContractInstance(EventHubTriggerInput value)
         {
@@ -63,9 +87,48 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
                 throw new ArgumentNullException("value");
             }
 
-            Dictionary<string, object> bindingData = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
-            bindingData[DataContractPartitionContext] = value.Context;
+            return GetBindingData(value);
+        }
+
+        internal static Dictionary<string, object> GetBindingData(EventHubTriggerInput input)
+        {
+            var bindingData = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+            SafeAddValue(() => bindingData.Add(nameof(input.PartitionContext), input.PartitionContext));
+
+            if (input.IsSingleDispatch)
+            {
+                AddBindingData(bindingData, input.GetSingleEventData());
+            }
+            else
+            {
+                // TODO: handle multiple dispatch
+                // https://github.com/Azure/azure-webjobs-sdk/issues/1072
+            }
+
             return bindingData;
+        }
+
+        private static void AddBindingData(Dictionary<string, object> bindingData, EventData eventData)
+        {
+            SafeAddValue(() => bindingData.Add(nameof(eventData.PartitionKey), eventData.PartitionKey));
+            SafeAddValue(() => bindingData.Add(nameof(eventData.Offset), eventData.Offset));
+            SafeAddValue(() => bindingData.Add(nameof(eventData.SequenceNumber), eventData.SequenceNumber));
+            SafeAddValue(() => bindingData.Add(nameof(eventData.EnqueuedTimeUtc), eventData.EnqueuedTimeUtc));
+            SafeAddValue(() => bindingData.Add(nameof(eventData.Properties), eventData.Properties));
+            SafeAddValue(() => bindingData.Add(nameof(eventData.SystemProperties), eventData.SystemProperties));
+        }
+
+        private static void SafeAddValue(Action addValue)
+        {
+            try
+            {
+                addValue();
+            }
+            catch
+            {
+                // some message propery getters can throw, based on the
+                // state of the message
+            }
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Triggers/ServiceBusTriggerBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Triggers/ServiceBusTriggerBinding.cs
@@ -141,6 +141,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
             contract.Add("To", typeof(string));
             contract.Add("Label", typeof(string));
             contract.Add("CorrelationId", typeof(string));
+            contract.Add("Properties", typeof(IDictionary<string, object>));
 
             if (argumentBindingContract != null)
             {
@@ -170,6 +171,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
             SafeAddValue(() => bindingData.Add(nameof(value.To), value.To));
             SafeAddValue(() => bindingData.Add(nameof(value.Label), value.Label));
             SafeAddValue(() => bindingData.Add(nameof(value.CorrelationId), value.CorrelationId));
+            SafeAddValue(() => bindingData.Add(nameof(value.Properties), value.Properties));
 
             if (bindingDataFromValueType != null)
             {

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/EventHubEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/EventHubEndToEndTests.cs
@@ -1,0 +1,164 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Microsoft.Azure.WebJobs.ServiceBus;
+using Microsoft.ServiceBus.Messaging;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
+{
+    public class EventHubEndToEndTests : IDisposable
+    {
+        private readonly JobHost _host;
+        private const string TestHubName = "testhub";
+        private const string TestHub2Name = "testhub2";
+
+        public EventHubEndToEndTests()
+        {
+            var config = new JobHostConfiguration()
+            {
+                TypeLocator = new FakeTypeLocator(typeof(EventHubTestJobs))
+            };
+            var eventHubConfig = new EventHubConfiguration();
+
+            string connection = Environment.GetEnvironmentVariable("AzureWebJobsTestHubConnection");
+            Assert.True(!string.IsNullOrEmpty(connection), "Required test connection string is missing.");
+            eventHubConfig.AddSender(TestHubName, connection);
+            eventHubConfig.AddReceiver(TestHubName, connection);
+
+            connection = Environment.GetEnvironmentVariable("AzureWebJobsTestHub2Connection");
+            Assert.True(!string.IsNullOrEmpty(connection), "Required test connection string is missing.");
+            eventHubConfig.AddSender(TestHub2Name, connection);
+            eventHubConfig.AddReceiver(TestHub2Name, connection);
+
+            config.UseEventHub(eventHubConfig);
+            _host = new JobHost(config);
+
+            EventHubTestJobs.Result = null;
+        }
+
+        [Fact]
+        public async Task EventHubTriggerTest_SingleDispatch()
+        {
+            await _host.StartAsync();
+
+            try
+            {
+                var method = typeof(EventHubTestJobs).GetMethod("SendEvent_TestHub", BindingFlags.Static | BindingFlags.Public);
+                var id = Guid.NewGuid().ToString();
+                EventHubTestJobs.EventId = id;
+                await _host.CallAsync(method, new { input = id });
+
+                await TestHelpers.Await(() =>
+                {
+                    return EventHubTestJobs.Result != null;
+                });
+
+                Assert.Equal(id, (object)EventHubTestJobs.Result);
+            }
+            finally
+            {
+                await _host.StopAsync();
+            }
+        }
+
+        [Fact]
+        public async Task EventHubTriggerTest_MultipleDispatch()
+        {
+            await _host.StartAsync();
+
+            try
+            {
+                var method = typeof(EventHubTestJobs).GetMethod("SendEvents_TestHub2", BindingFlags.Static | BindingFlags.Public);
+                var id = Guid.NewGuid().ToString();
+                EventHubTestJobs.EventId = id;
+                await _host.CallAsync(method, new { numEvents = 5, input = id });
+
+                await TestHelpers.Await(() =>
+                {
+                    return EventHubTestJobs.Result != null;
+                });
+
+                var eventsProcessed = (string[])EventHubTestJobs.Result;
+                Assert.True(eventsProcessed.Length >= 1);
+            }
+            finally
+            {
+                await _host.StopAsync();
+            }
+        }
+
+        public void Dispose()
+        {
+            _host?.Dispose();
+        }
+
+        public static class EventHubTestJobs
+        {
+            public static string EventId;
+            public static object Result { get; set; }
+
+            public static void SendEvent_TestHub(string input, [EventHub(TestHubName)] out EventData evt)
+            {
+                evt = new EventData(Encoding.UTF8.GetBytes(input))
+                {
+                    PartitionKey = "TestPartition"
+                };
+                evt.Properties.Add("TestProp1", "value1");
+                evt.Properties.Add("TestProp2", "value2");
+            }
+
+            public static void SendEvents_TestHub2(int numEvents, string input, [EventHub(TestHub2Name)] out EventData[] events)
+            {
+                events = new EventData[numEvents];
+                for (int i = 0; i < numEvents; i++)
+                {
+                    var evt = new EventData(Encoding.UTF8.GetBytes(input));
+                    evt.PartitionKey = "TestPartition";
+                    evt.Properties.Add("BatchIndex", i);
+                    evt.Properties.Add("TestProp1", "value1");
+                    evt.Properties.Add("TestProp2", "value2");
+                    events[i] = evt;
+                }
+            }
+
+            public static void ProcessSingleEvent([EventHubTrigger(TestHubName)] string evt, 
+                string partitionKey, DateTime enqueuedTimeUtc, IDictionary<string, object> properties,
+                IDictionary<string, object> systemProperties)
+            {
+                // filter for the ID the current test is using
+                if (evt == EventId)
+                {
+                    Assert.Equal("TestPartition", partitionKey);
+                    Assert.True((DateTime.Now - enqueuedTimeUtc).TotalSeconds < 30);
+
+                    Assert.Equal(2, properties.Count);
+                    Assert.Equal("value1", properties["TestProp1"]);
+                    Assert.Equal("value2", properties["TestProp2"]);
+
+                    Assert.Equal(8, systemProperties.Count);
+
+                    Result = evt;
+                }
+            }
+
+            public static void ProcessMultipleEvents([EventHubTrigger(TestHub2Name)] string[] events)
+            {
+                // TODO: verify binding data contract arrays
+                // https://github.com/Azure/azure-webjobs-sdk/issues/1072
+
+                // filter for the ID the current test is using
+                if (events[0] == EventId)
+                {
+                    Result = events;
+                }
+            }
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/WebJobs.Host.EndToEndTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/WebJobs.Host.EndToEndTests.csproj
@@ -108,6 +108,7 @@
     <Compile Include="BlobToCustomObjectBinder.cs" />
     <Compile Include="CustomObject.cs" />
     <Compile Include="AzureStorageEndToEndTests.cs" />
+    <Compile Include="EventHubEndToEndTests.cs" />
     <Compile Include="LeaseExpirationTests.cs" />
     <Compile Include="MultipleStorageAccountsEndToEndTests.cs" />
     <Compile Include="ParallelExecutionTests.cs" />

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Bindings/ServiceBusTriggerBindingTests.cs
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Bindings/ServiceBusTriggerBindingTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Bindings
         {
             IReadOnlyDictionary<string, Type> argumentContract = null;
             var bindingDataContract = ServiceBusTriggerBinding.CreateBindingDataContract(argumentContract);
-            Assert.Equal(11, bindingDataContract.Count);
+            Assert.Equal(12, bindingDataContract.Count);
             Assert.Equal(bindingDataContract["DeliveryCount"], typeof(int));
             Assert.Equal(bindingDataContract["DeadLetterSource"], typeof(string));
             Assert.Equal(bindingDataContract["ExpiresAtUtc"], typeof(DateTime));
@@ -30,6 +30,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Bindings
             Assert.Equal(bindingDataContract["To"], typeof(string));
             Assert.Equal(bindingDataContract["Label"], typeof(string));
             Assert.Equal(bindingDataContract["CorrelationId"], typeof(string));
+            Assert.Equal(bindingDataContract["Properties"], typeof(IDictionary<string, object>));
 
             // verify that argument binding values override built ins
             argumentContract = new Dictionary<string, Type>
@@ -38,7 +39,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Bindings
                 { "NewProperty", typeof(decimal) }
             };
             bindingDataContract = ServiceBusTriggerBinding.CreateBindingDataContract(argumentContract);
-            Assert.Equal(12, bindingDataContract.Count);
+            Assert.Equal(13, bindingDataContract.Count);
             Assert.Equal(bindingDataContract["DeliveryCount"], typeof(string));
             Assert.Equal(bindingDataContract["NewProperty"], typeof(decimal));
         }
@@ -54,7 +55,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Bindings
             message.CorrelationId = Guid.NewGuid().ToString();
             IReadOnlyDictionary<string, object> valueBindingData = null;
             var bindingData = ServiceBusTriggerBinding.CreateBindingData(message, valueBindingData);
-            Assert.Equal(7, bindingData.Count);
+            Assert.Equal(8, bindingData.Count);
             Assert.Equal(message.ReplyTo, bindingData["ReplyTo"]);
             Assert.Equal(message.To, bindingData["To"]);
             Assert.Equal(message.MessageId, bindingData["MessageId"]);
@@ -62,6 +63,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Bindings
             Assert.Equal(message.ContentType, bindingData["ContentType"]);
             Assert.Equal(message.Label, bindingData["Label"]);
             Assert.Equal(message.CorrelationId, bindingData["CorrelationId"]);
+            Assert.Same(message.Properties, bindingData["Properties"]);
 
             // verify that value binding data overrides built ins
             valueBindingData = new Dictionary<string, object>
@@ -70,7 +72,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Bindings
                 { "NewProperty", 123 }
             };
             bindingData = ServiceBusTriggerBinding.CreateBindingData(message, valueBindingData);
-            Assert.Equal(8, bindingData.Count);
+            Assert.Equal(9, bindingData.Count);
             Assert.Equal("override", bindingData["ReplyTo"]);
             Assert.Equal(123, bindingData["NewProperty"]);
         }


### PR DESCRIPTION
For issue https://github.com/Azure/azure-webjobs-sdk/issues/1004. See related work I did for ServiceBus here: https://github.com/Azure/azure-webjobs-sdk/pull/1069. I'm also adding the `IDictionary<string, object>` property bags (`BrokeredMessage.Properties`, `EventData.Properties`, `EventData.SystemProperties`) in this PR, which has been a customer ask, particularly in the context of Azure Functions. This particularly helps unblock non C# scenarios for Functions - Node.js functions will now be able to access all these properties, whereas they couldn't before.