### PR TITLE
Add FunctionNameAttribute to WebJobs SDK

### DIFF
--- a/src/Microsoft.Azure.WebJobs/FunctionNameAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs/FunctionNameAttribute.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Azure.WebJobs
+{
+    /// <summary>
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+    public sealed class FunctionNameAttribute : Attribute
+    {
+        private string _name;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FunctionNameAttribute"/> class with a given name.
+        /// </summary>
+        /// <param name="name">Name of the function.</param>
+        public FunctionNameAttribute(string name)
+        {
+            this._name = name;
+        }
+
+        /// <summary>
+        /// Gets the function name.
+        /// </summary>
+        public string Name => _name;
+    }
+}

--- a/src/Microsoft.Azure.WebJobs/WebJobs.csproj
+++ b/src/Microsoft.Azure.WebJobs/WebJobs.csproj
@@ -63,6 +63,7 @@
     <Compile Include="BlobTriggerAttribute.cs" />
     <Compile Include="BinderExtensions.cs" />
     <Compile Include="DisableAttribute.cs" />
+    <Compile Include="FunctionNameAttribute.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="IAsyncCollector.cs" />
     <Compile Include="IAttributeInvokeDescriptor.cs" />

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
@@ -128,7 +128,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 "DisableAttribute",
                 "TimeoutAttribute",
                 "TraceLevelAttribute",
-                "ODataFilterResolutionPolicy"
+                "ODataFilterResolutionPolicy",
+                "FunctionNameAttribute"
             };
 
             AssertPublicTypes(expected, assembly);


### PR DESCRIPTION
This is for the new programming model for .NET where users would need to specify a function name as an attribute. 
The original ask was just for [`FunctionNameAttribute.cs`](https://github.com/Azure/azure-webjobs-sdk/compare/ahmels-function-name?expand=1#diff-9f2e8d02d4f5a4798dae27001ecc212b) though it seemed straight forward to get that consumed by the host itself, so I thought I'd include it here. If it's not as simple as I thought, then we can remove that. if this is indeed all that's needed I can update the comment that says this is not consumed by the SDK.