### PR TITLE
Fix null setting name bug

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/AttributeCloner.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/AttributeCloner.cs
@@ -127,7 +127,8 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
         internal static BindingDataResolver GetAppSettingResolver(string originalValue, AppSettingAttribute attr, INameResolver nameResolver, PropertyInfo propInfo)
         {
             string appSettingName = originalValue ?? attr.Default;
-            string resolvedValue = nameResolver.Resolve(appSettingName);
+            string resolvedValue = string.IsNullOrEmpty(appSettingName) ?
+                originalValue : nameResolver.Resolve(appSettingName);
 
             // If a value is non-null and cannot be found, we throw to match the behavior
             // when %% values are not found in ResolveWholeString below.

--- a/src/Microsoft.Azure.WebJobs.Host/ConfigurationUtility.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/ConfigurationUtility.cs
@@ -10,6 +10,11 @@ namespace Microsoft.Azure.WebJobs.Host
     {
         public static string GetSettingFromConfigOrEnvironment(string settingName)
         {
+            if (string.IsNullOrEmpty(settingName))
+            {
+                return null;
+            }
+
             string configValue = ConfigurationManager.AppSettings[settingName];
             if (!string.IsNullOrEmpty(configValue))
             {

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/FakeNameResolver.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/FakeNameResolver.cs
@@ -12,6 +12,11 @@ namespace Microsoft.Azure.WebJobs.Host.TestCommon
 
         public string Resolve(string name)
         {
+            // some name resolvers can't handle null values
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
             string value;
             if (_dict.TryGetValue(name, out value))
             {

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/AttributeClonerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/AttributeClonerTests.cs
@@ -340,6 +340,20 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         }
 
         [Fact]
+        public void AppSettingAttribute_DoesNotThrowIfNullValueAndNoDefault()
+        {
+            Attr4 a4 = new Attr4();
+            a4.AutoResolve = "auto";
+            a4.AppSetting = null;
+
+            var nameResolver = new FakeNameResolver();
+            var cloner = new AttributeCloner<Attr4>(a4, EmptyContract, nameResolver);
+            var cloned = cloner.GetNameResolvedAttribute();
+            Assert.Equal("auto", cloned.AutoResolve);
+            Assert.Equal(null, cloned.AppSetting);
+        }
+
+        [Fact]
         public void AttributeCloner_Throws_IfAppSettingAndAutoResolve()
         {
             InvalidAnnotation a = new InvalidAnnotation();

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/ConfigurationUtilityTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/ConfigurationUtilityTests.cs
@@ -16,6 +16,13 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         }
 
         [Fact]
+        public void GetSettingFromConfigOrEnvironment_NameNull_ReturnsEmpty()
+        {
+            string value = ConfigurationUtility.GetSettingFromConfigOrEnvironment(null);
+            Assert.Equal(null, value);
+        }
+
+        [Fact]
         public void GetSettingFromConfigOrEnvironment_ConfigSetting_NoEnvironmentSetting()
         {
             string value = ConfigurationUtility.GetSettingFromConfigOrEnvironment("DisableSetting0");


### PR DESCRIPTION
Fixed nameResolver.resolve(null) in `GetAppSettingResolver`

Also added null handling to ConfigurationUtility