### PR TITLE
Logging: add Exception callback for LogWriter

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging/LogFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging/LogFactory.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.WindowsAzure.Storage.Table;
 
 namespace Microsoft.Azure.WebJobs.Logging
@@ -28,10 +29,11 @@ namespace Microsoft.Azure.WebJobs.Logging
         /// Multiple hosts can share a single set of azure tables. Logging is scoped per-host.</param>
         /// <param name="machineName">name of the compute container. Likely %COMPUTERNAME%. </param>
         /// <param name="logTableProvider">callback interface that gets invoked to get azure tables to write logging to.</param>
+        /// <param name="onException">An action to be called when the log writer throws an exception.</param>
         /// <returns></returns>
-        public static ILogWriter NewWriter(string hostName, string machineName, ILogTableProvider logTableProvider)
+        public static ILogWriter NewWriter(string hostName, string machineName, ILogTableProvider logTableProvider, Action<Exception> onException = null)
         {
-            return new LogWriter(hostName, machineName, logTableProvider);
+            return new LogWriter(hostName, machineName, logTableProvider, onException);
         }
 
         /// <summary>

--- a/test/Microsoft.Azure.WebJobs.Logging.FunctionalTests/WebJobs.Logging.FunctionalTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Logging.FunctionalTests/WebJobs.Logging.FunctionalTests.csproj
@@ -48,6 +48,10 @@
     <DelaySign>true</DelaySign>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
       <Private>True</Private>
@@ -70,6 +74,10 @@
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Storage, Version=7.2.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\WindowsAzure.Storage.7.2.1\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Moq, Version=4.5.30.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Moq.4.5.30\lib\net45\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/test/Microsoft.Azure.WebJobs.Logging.FunctionalTests/app.config
+++ b/test/Microsoft.Azure.WebJobs.Logging.FunctionalTests/app.config
@@ -1,23 +1,23 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.8.1.0" newVersion="5.8.1.0"/>
+        <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.8.1.0" newVersion="5.8.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.8.1.0" newVersion="5.8.1.0"/>
+        <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.8.1.0" newVersion="5.8.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.8.1.0" newVersion="5.8.1.0"/>
+        <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.8.1.0" newVersion="5.8.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" /></startup></configuration>

--- a/test/Microsoft.Azure.WebJobs.Logging.FunctionalTests/packages.config
+++ b/test/Microsoft.Azure.WebJobs.Logging.FunctionalTests/packages.config
@@ -1,10 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Castle.Core" version="3.3.3" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net451" />
   <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net451" />
   <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net451" />
   <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net451" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.3" targetFramework="net451" />
+  <package id="Moq" version="4.5.30" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
   <package id="System.ComponentModel.EventBasedAsync" version="4.3.0" targetFramework="net451" />
   <package id="System.Dynamic.Runtime" version="4.3.0" targetFramework="net451" />


### PR DESCRIPTION
This will enable better logging for https://github.com/Azure/azure-webjobs-sdk-script/issues/1245

In Functions, under load, you can get to a place where the logger is unable to write to Table storage because it is being throttled. Exceptions are thrown, but because they're coming from an unmonitored background Task, we never log them anywhere. This provides a callback so Exceptions can be logged.

There will be a corresponding change in Script that will log these to the TraceWriter. This will allow us to see how often this occurs. I'm not sure that there's a great solution to remove the issue completely (it would involve splitting the logs across more partitions) -- but the move to logging via Application Insights should make this less of an issue.