### PR TITLE
Clear the internal TextWriterTraceAdapter when calling Flush

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/TraceWriter/TextWriterTraceAdapter.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/TraceWriter/TextWriterTraceAdapter.cs
@@ -55,6 +55,7 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
             {
                 // flush any remaining text
                 _traceWriter.Info(_text.ToString());
+                _text.Clear();
             }
 
             _traceWriter.Flush();

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Bindings/TraceWriter/TextWriterTraceAdapterTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Bindings/TraceWriter/TextWriterTraceAdapterTests.cs
@@ -75,6 +75,22 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Bindings
         }
 
         [Fact]
+        public void Flush_ClearsInternalBuffer()
+        {
+            _mockTraceWriter.Setup(p => p.Trace(It.IsAny<TraceEvent>()));
+            _mockTraceWriter.Setup(p => p.Flush());
+
+            _adapter.Write("This");
+            _adapter.Write(" is ");
+            _adapter.Write("a ");
+            _adapter.Write("test");
+            _adapter.Flush();
+            _adapter.Flush();
+
+            _mockTraceWriter.Verify(p => p.Trace(It.Is<TraceEvent>(q => q.Level == TraceLevel.Info && q.Message == "This is a test")), Times.Exactly(1));
+        }
+
+        [Fact]
         public async Task TestMultipleThreads()
         {
             // This validates a bug where writing from multiple threads throws an exception.             


### PR DESCRIPTION
I hope my assumption that calling `Flush` twice shouldn't result in the buffer being written twice is correct