### PR TITLE
Move reflection off of execution path

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/DefaultAttributeInvokerDescriptor.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/DefaultAttributeInvokerDescriptor.cs
@@ -40,19 +40,16 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
             }
         }
 
-        public static string ToInvokeString(TAttribute source)
+        public static string ToInvokeString(IDictionary<PropertyInfo, AutoResolveAttribute> resolvableProps, TAttribute source)
         {
             Dictionary<string, string> vals = new Dictionary<string, string>();
-            foreach (var prop in typeof(TAttribute).GetProperties(BindingFlags.Instance | BindingFlags.Public))
-            {
-                bool resolve = prop.GetCustomAttribute<AutoResolveAttribute>() != null;
-                if (resolve)
+            foreach (var pair in resolvableProps.AsEnumerable())
+            { 
+                var prop = pair.Key;
+                var str = (string)prop.GetValue(source);
+                if (!string.IsNullOrWhiteSpace(str))
                 {
-                    var str = (string)prop.GetValue(source);
-                    if (!string.IsNullOrWhiteSpace(str))
-                    {
-                        vals[prop.Name] = str;
-                    }
+                    vals[prop.Name] = str;
                 }
             }
 

--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/FunctionBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/FunctionBinding.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Protocols;
 
@@ -59,7 +58,7 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
             BindingContext bindingContext = NewBindingContext(context, null, parameters);
 
             // bind Singleton if specified
-            SingletonAttribute singletonAttribute = SingletonManager.GetFunctionSingletonOrNull(_descriptor.Method, isTriggered: false);
+            SingletonAttribute singletonAttribute = SingletonManager.GetFunctionSingletonOrNull(_descriptor, isTriggered: false);
             if (singletonAttribute != null)
             {
                 string boundScopeId = _singletonManager.GetBoundScopeId(singletonAttribute.ScopeId);

--- a/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexer.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexer.cs
@@ -323,13 +323,20 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
                 }
             }
 
+            // Determine the TraceLevel for this function (affecting both Console as well as Dashboard logging)
+            TraceLevelAttribute traceAttribute = TypeUtility.GetHierarchicalAttributeOrNull<TraceLevelAttribute>(method);
+
             return new FunctionDescriptor
             {
                 Id = method.GetFullName(),
                 Method = method,
                 FullName = method.GetFullName(),
                 ShortName = method.GetShortName(),
-                Parameters = parameters
+                Parameters = parameters,
+                TraceLevel = traceAttribute?.Level ?? TraceLevel.Verbose,
+                TriggerParameterDescriptor = parameters.OfType<TriggerParameterDescriptor>().FirstOrDefault(),
+                TimeoutAttribute = TypeUtility.GetHierarchicalAttributeOrNull<TimeoutAttribute>(method),
+                SingletonAttributes = method.GetCustomAttributes<SingletonAttribute>()
             };
         }
 

--- a/src/Microsoft.Azure.WebJobs.Host/Singleton/SingletonManager.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Singleton/SingletonManager.cs
@@ -14,6 +14,7 @@ using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Bindings.Path;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Listeners;
+using Microsoft.Azure.WebJobs.Host.Protocols;
 using Microsoft.Azure.WebJobs.Host.Storage;
 using Microsoft.Azure.WebJobs.Host.Storage.Blob;
 using Microsoft.Azure.WebJobs.Host.Timers;
@@ -216,15 +217,14 @@ namespace Microsoft.Azure.WebJobs.Host
             }
         }
 
-        public static SingletonAttribute GetFunctionSingletonOrNull(MethodInfo method, bool isTriggered)
+        public static SingletonAttribute GetFunctionSingletonOrNull(FunctionDescriptor descriptor, bool isTriggered)
         {
-            if (!isTriggered &&
-                method.GetCustomAttributes<SingletonAttribute>().Any(p => p.Mode == SingletonMode.Listener))
+            if (!isTriggered && descriptor.SingletonAttributes.Any(p => p.Mode == SingletonMode.Listener))
             {
                 throw new NotSupportedException("SingletonAttribute using mode 'Listener' cannot be applied to non-triggered functions.");
             }
 
-            SingletonAttribute[] singletonAttributes = method.GetCustomAttributes<SingletonAttribute>().Where(p => p.Mode == SingletonMode.Function).ToArray();
+            SingletonAttribute[] singletonAttributes = descriptor.SingletonAttributes.Where(p => p.Mode == SingletonMode.Function).ToArray();
             SingletonAttribute singletonAttribute = null;
             if (singletonAttributes.Length > 1)
             {

--- a/src/Microsoft.Azure.WebJobs.Host/Triggers/TriggeredFunctionBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Triggers/TriggeredFunctionBinding.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.WebJobs.Host.Triggers
             BindingContext bindingContext = FunctionBinding.NewBindingContext(context, bindingData, parameters);
 
             // Bind Singleton if specified
-            SingletonAttribute singletonAttribute = SingletonManager.GetFunctionSingletonOrNull(_descriptor.Method, isTriggered: true);
+            SingletonAttribute singletonAttribute = SingletonManager.GetFunctionSingletonOrNull(_descriptor, isTriggered: true);
             if (singletonAttribute != null)
             {
                 string boundScopeId = _singletonManager.GetBoundScopeId(singletonAttribute.ScopeId, bindingData);

--- a/src/Microsoft.Azure.WebJobs.Protocols/FunctionDescriptor.cs
+++ b/src/Microsoft.Azure.WebJobs.Protocols/FunctionDescriptor.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Reflection;
 using Newtonsoft.Json;
 
@@ -35,5 +36,32 @@ namespace Microsoft.Azure.WebJobs.Host.Protocols
         /// </summary>
         [JsonIgnore]
         internal MethodInfo Method { get; set; }
+
+#if PUBLICPROTOCOL
+#else
+        /// <summary>
+        /// Gets the <see cref="Protocols.TriggerParameterDescriptor"/> for this function
+        /// </summary>
+        [JsonIgnore]
+        internal TriggerParameterDescriptor TriggerParameterDescriptor { get; set; }
+
+        /// <summary>
+        /// Gets the <see cref="System.Diagnostics.TraceLevel"/> for this function
+        /// </summary>
+        [JsonIgnore]
+        internal TraceLevel TraceLevel { get; set; }
+
+        /// <summary>
+        /// Gets the <see cref="WebJobs.TimeoutAttribute"/> for this function
+        /// </summary>
+        [JsonIgnore]
+        internal TimeoutAttribute TimeoutAttribute { get; set; }
+
+        /// <summary>
+        /// Gets any <see cref="SingletonAttribute"/>s for this function
+        /// </summary>
+        [JsonIgnore]
+        internal IEnumerable<SingletonAttribute> SingletonAttributes { get; set; }
+#endif
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/FunctionExecutorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/FunctionExecutorTests.cs
@@ -329,22 +329,6 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             Assert.Equal(message, trace.Message);
         }
 
-        [Fact]
-        public void GetFunctionTraceLevel_ReturnsExpectedLevel()
-        {
-            _descriptor.Method = typeof(Functions).GetMethod("MethodLevel", BindingFlags.Static | BindingFlags.Public);
-            TraceLevel result = FunctionExecutor.GetFunctionTraceLevel(_mockFunctionInstance.Object);
-            Assert.Equal(TraceLevel.Verbose, result);
-
-            _descriptor.Method = typeof(Functions).GetMethod("TraceLevelOverride_Off", BindingFlags.Static | BindingFlags.Public);
-            result = FunctionExecutor.GetFunctionTraceLevel(_mockFunctionInstance.Object);
-            Assert.Equal(TraceLevel.Off, result);
-
-            _descriptor.Method = typeof(Functions).GetMethod("TraceLevelOverride_Error", BindingFlags.Static | BindingFlags.Public);
-            result = FunctionExecutor.GetFunctionTraceLevel(_mockFunctionInstance.Object);
-            Assert.Equal(TraceLevel.Error, result);
-        }
-
         public static void GlobalLevel(CancellationToken cancellationToken)
         {
         }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Protocols/FunctionStartedMessageExtensionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Protocols/FunctionStartedMessageExtensionsTests.cs
@@ -22,7 +22,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Protocols
             };
             FunctionDescriptor function = new FunctionDescriptor
             {
-                Parameters = new ParameterDescriptor[] { triggerParameterDescriptor }
+                Parameters = new ParameterDescriptor[] { triggerParameterDescriptor },
+                TriggerParameterDescriptor = triggerParameterDescriptor
             };
             message.Function = function;
             message.Reason = ExecutionReason.AutomaticTrigger;
@@ -41,8 +42,11 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Protocols
             {
                 Name = "paramName"
             };
-            FunctionDescriptor function = new FunctionDescriptor();
-            function.Parameters = new ParameterDescriptor[] { triggerParameterDescriptor };
+            FunctionDescriptor function = new FunctionDescriptor()
+            {
+                Parameters = new ParameterDescriptor[] { triggerParameterDescriptor },
+                TriggerParameterDescriptor = triggerParameterDescriptor
+            };
             message.Function = function;
             message.Arguments = new Dictionary<string, string>() { { "paramName", "blob/path" } };
 

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Singleton/SingletonManagerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Singleton/SingletonManagerTests.cs
@@ -17,6 +17,7 @@ using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
 using Moq;
 using Xunit;
+using Microsoft.Azure.WebJobs.Host.Protocols;
 
 namespace Microsoft.Azure.WebJobs.Host.UnitTests.Singleton
 {
@@ -402,7 +403,9 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Singleton
 
             NotSupportedException exception = Assert.Throws<NotSupportedException>(() =>
             {
-                SingletonManager.GetFunctionSingletonOrNull(method, isTriggered: true);
+                SingletonManager.GetFunctionSingletonOrNull(new FunctionDescriptor() {
+                    SingletonAttributes = method.GetCustomAttributes<SingletonAttribute>()
+                }, isTriggered: true);
             });
             Assert.Equal("Only one SingletonAttribute using mode 'Function' is allowed.", exception.Message);
         }
@@ -414,7 +417,10 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Singleton
 
             NotSupportedException exception = Assert.Throws<NotSupportedException>(() =>
             {
-                SingletonManager.GetFunctionSingletonOrNull(method, isTriggered: false);
+                SingletonManager.GetFunctionSingletonOrNull(new FunctionDescriptor()
+                {
+                    SingletonAttributes = method.GetCustomAttributes<SingletonAttribute>()
+                }, isTriggered: false);
             });
             Assert.Equal("SingletonAttribute using mode 'Listener' cannot be applied to non-triggered functions.", exception.Message);
         }


### PR DESCRIPTION
related to #1060 

Ran some instrumentation on the webjobs sdk for the event hub perf stuff.

We spent ~25% of execution time in a few reflection related functions:
- invoke string
- singleton attributes
- timeout attribute
- trigger descriptor
- trigger argument binding

Moving all these operations to the indexing path.

I can post the before/after profiling data