### PR TITLE
First step towards enabling on prem specific triggers

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/ConnectionStringNames.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/ConnectionStringNames.cs
@@ -14,6 +14,9 @@ namespace Microsoft.Azure.WebJobs
         /// <summary>Gets the Azure Storage connection string name.</summary>
         public static readonly string Storage = "Storage";
 
+        /// <summary>Gets the lease connection string name.</summary>
+        public static readonly string Lease = "Lease";
+
         /// <summary>Gets the Azure ServiceBus connection string name.</summary>
         public static readonly string ServiceBus = "ServiceBus";
     }

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostConfigurationExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostConfigurationExtensions.cs
@@ -14,6 +14,7 @@ using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Blobs;
 using Microsoft.Azure.WebJobs.Host.Config;
 using Microsoft.Azure.WebJobs.Host.Indexers;
+using Microsoft.Azure.WebJobs.Host.Lease;
 using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Azure.WebJobs.Host.Loggers;
 using Microsoft.Azure.WebJobs.Host.Protocols;
@@ -121,7 +122,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
 
             if (singletonManager == null)
             {
-                singletonManager = new SingletonManager(storageAccountProvider, exceptionHandler, config.Singleton, trace, hostIdProvider, services.GetService<INameResolver>());
+                singletonManager = new SingletonManager(services.GetService<ILeaseProxy>(), exceptionHandler, config.Singleton, trace, hostIdProvider, services.GetService<INameResolver>());
                 services.AddService<SingletonManager>(singletonManager);
             }
 

--- a/src/Microsoft.Azure.WebJobs.Host/JobHostConfiguration.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/JobHostConfiguration.cs
@@ -10,6 +10,7 @@ using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Config;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Indexers;
+using Microsoft.Azure.WebJobs.Host.Lease;
 using Microsoft.Azure.WebJobs.Host.Loggers;
 using Microsoft.Azure.WebJobs.Host.Queues;
 using Microsoft.Azure.WebJobs.Host.Timers;
@@ -69,6 +70,7 @@ namespace Microsoft.Azure.WebJobs
             ITypeLocator typeLocator = new DefaultTypeLocator(ConsoleProvider.Out, extensions);
             IConverterManager converterManager = new ConverterManager();
             IWebJobsExceptionHandler exceptionHandler = new WebJobsExceptionHandler();
+            ILeaseProxy leaseProxy = LeaseFactory.CreateLeaseProxy(_storageAccountProvider);
 
             AddService<IQueueConfiguration>(_queueConfiguration);
             AddService<IConsoleProvider>(ConsoleProvider);
@@ -80,6 +82,7 @@ namespace Microsoft.Azure.WebJobs
             AddService<ITypeLocator>(typeLocator);
             AddService<IConverterManager>(converterManager);
             AddService<IWebJobsExceptionHandler>(exceptionHandler);
+            AddService<ILeaseProxy>(leaseProxy);
 
             string value = ConfigurationUtility.GetSettingFromConfigOrEnvironment(Constants.EnvironmentSettingName);
             IsDevelopment = string.Compare(Constants.DevelopmentEnvironmentValue, value, StringComparison.OrdinalIgnoreCase) == 0;            

--- a/src/Microsoft.Azure.WebJobs.Host/Lease/BlobLeaseProxy.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Lease/BlobLeaseProxy.cs
@@ -1,0 +1,333 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Azure.WebJobs.Host.Lease;
+using Microsoft.Azure.WebJobs.Host.Storage;
+using Microsoft.Azure.WebJobs.Host.Storage.Blob;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Blob;
+
+namespace Microsoft.Azure.WebJobs.Host.Lease
+{
+    // Azure Blob Storage based lease implementation
+    internal class BlobLeaseProxy : ILeaseProxy
+    {
+        private readonly IStorageAccountProvider _storageAccountProvider;
+        private readonly ConcurrentDictionary<string, IStorageAccount> _storageAccountMap = new ConcurrentDictionary<string, IStorageAccount>(StringComparer.OrdinalIgnoreCase);
+
+        public BlobLeaseProxy(IStorageAccountProvider storageAccountProvider)
+        {
+            if (storageAccountProvider == null)
+            {
+                throw new ArgumentNullException(nameof(storageAccountProvider));
+            }
+
+            _storageAccountProvider = storageAccountProvider;
+        }
+
+        /// <inheritdoc />
+        public async Task<string> TryAcquireLeaseAsync(LeaseDefinition leaseDefinition, CancellationToken cancellationToken)
+        {
+            try
+            {
+                return await AcquireLeaseAsync(leaseDefinition, cancellationToken);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        public async Task<string> AcquireLeaseAsync(LeaseDefinition leaseDefinition, CancellationToken cancellationToken)
+        {
+            IStorageBlockBlob lockBlob = null;
+            try
+            {
+                lockBlob = GetBlob(leaseDefinition);
+
+                // Optimistically try to acquire the lease. The blob may not exist yet.
+                // If it doesn't exist, we handle the 404, create it, and retry below.
+                return await lockBlob.AcquireLeaseAsync(leaseDefinition.Period, leaseDefinition.LeaseId, cancellationToken);
+            }
+            catch (StorageException exception)
+            {
+                if (exception.RequestInformation == null)
+                {
+                    throw new LeaseException(LeaseFailureReason.Unknown, exception);
+                }
+
+                if (exception.RequestInformation.HttpStatusCode == 404)
+                {
+                    // No action needed. We will create the blob and retry again.
+                }
+                else if (exception.RequestInformation.HttpStatusCode == 409)
+                {
+                    throw new LeaseException(LeaseFailureReason.Conflict, exception);
+                }
+                else
+                {
+                    throw new LeaseException(LeaseFailureReason.Unknown, exception);
+                }
+            }
+
+            try
+            {
+                await TryCreateBlobAsync(lockBlob, cancellationToken);
+                return await lockBlob.AcquireLeaseAsync(leaseDefinition.Period, proposedLeaseId: null, cancellationToken: cancellationToken);
+            }
+            catch (StorageException exception)
+            {
+                if (exception.RequestInformation != null &&
+                    exception.RequestInformation.HttpStatusCode == 409)
+                {
+                    throw new LeaseException(LeaseFailureReason.Conflict, exception);
+                }
+
+                throw new LeaseException(LeaseFailureReason.Unknown, exception);
+            }
+        }
+
+        /// <inheritdoc />
+        public Task RenewLeaseAsync(LeaseDefinition leaseDefinition, CancellationToken cancellationToken)
+        {
+            if (leaseDefinition == null)
+            {
+                throw new ArgumentNullException(nameof(leaseDefinition));
+            }
+
+            try
+            {
+                IStorageBlockBlob lockBlob = GetBlob(leaseDefinition);
+                var accessCondition = new AccessCondition
+                {
+                    LeaseId = leaseDefinition.LeaseId
+                };
+
+                return lockBlob.RenewLeaseAsync(accessCondition, options: null, operationContext: null, cancellationToken: cancellationToken);
+            }
+            catch (StorageException exception)
+            {
+                throw new LeaseException(LeaseFailureReason.Unknown, exception);
+            }
+        }
+
+        /// <inheritdoc />
+        public async Task WriteLeaseMetadataAsync(LeaseDefinition leaseDefinition, string key, string value, CancellationToken cancellationToken)
+        {
+            try
+            {
+                IStorageBlockBlob blob = GetBlob(leaseDefinition);
+                blob.Metadata.Add(key, value);
+
+                await blob.SetMetadataAsync(
+                    accessCondition: new AccessCondition { LeaseId = leaseDefinition.LeaseId },
+                    options: null,
+                    operationContext: null,
+                    cancellationToken: cancellationToken);
+            }
+            catch (StorageException exception)
+            {
+                throw new LeaseException(LeaseFailureReason.Unknown, exception);
+            }
+        }
+
+        /// <inheritdoc />
+        public async Task ReleaseLeaseAsync(LeaseDefinition leaseDefinition, CancellationToken cancellationToken)
+        {
+            try
+            {
+                IStorageBlockBlob blob = GetBlob(leaseDefinition);
+                // Note that this call returns without throwing if the lease is expired. See the table at:
+                // http://msdn.microsoft.com/en-us/library/azure/ee691972.aspx
+                await blob.ReleaseLeaseAsync(
+                    accessCondition: new AccessCondition { LeaseId = leaseDefinition.LeaseId },
+                    options: null,
+                    operationContext: null,
+                    cancellationToken: cancellationToken);
+            }
+            catch (StorageException exception)
+            {
+                if (exception.RequestInformation == null)
+                {
+                    throw new LeaseException(LeaseFailureReason.Unknown, exception);
+                }
+
+                if (exception.RequestInformation.HttpStatusCode == 404 ||
+                    exception.RequestInformation.HttpStatusCode == 409)
+                {
+                    // if the blob no longer exists, or there is another lease
+                    // now active, there is nothing for us to release so we can
+                    // ignore
+                }
+                else
+                {
+                    throw new LeaseException(LeaseFailureReason.Unknown, exception);
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public async Task<LeaseInformation> ReadLeaseInfoAsync(LeaseDefinition leaseDefinition, CancellationToken cancellationToken)
+        {
+            try
+            {
+                IStorageBlob lockBlob = GetBlob(leaseDefinition);
+
+                await FetchLeaseBlobMetadataAsync(lockBlob, cancellationToken);
+
+                var isLeaseAvailable = lockBlob.Properties.LeaseState == LeaseState.Available &&
+                                        lockBlob.Properties.LeaseStatus == LeaseStatus.Unlocked;
+
+                return new LeaseInformation(isLeaseAvailable, lockBlob.Metadata);
+            }
+            catch (StorageException exception)
+            {
+                throw new LeaseException(LeaseFailureReason.Unknown, exception);
+            }
+        }
+
+        private static async Task FetchLeaseBlobMetadataAsync(IStorageBlob blob, CancellationToken cancellationToken)
+        {
+            try
+            {
+                await blob.FetchAttributesAsync(cancellationToken);
+            }
+            catch (StorageException exception)
+            {
+                if (exception.RequestInformation != null &&
+                    exception.RequestInformation.HttpStatusCode == 404)
+                {
+                    // the blob no longer exists
+                }
+                else
+                {
+                    throw;
+                }
+            }
+        }
+
+        private static async Task<bool> TryCreateBlobAsync(IStorageBlockBlob blob, CancellationToken cancellationToken)
+        {
+            bool isContainerNotFoundException = false;
+
+            try
+            {
+                await blob.UploadTextAsync(string.Empty, cancellationToken: cancellationToken);
+                return true;
+            }
+            catch (StorageException exception)
+            {
+                if (exception.RequestInformation == null)
+                {
+                    throw;
+                }
+
+                if (exception.RequestInformation.HttpStatusCode == 404)
+                {
+                    isContainerNotFoundException = true;
+                }
+                else if (exception.RequestInformation.HttpStatusCode == 409 ||
+                            exception.RequestInformation.HttpStatusCode == 412)
+                {
+                    // The blob already exists, or is leased by someone else
+                    return false;
+                }
+                else
+                {
+                    throw;
+                }
+            }
+
+            Debug.Assert(isContainerNotFoundException);
+
+            // Create the container if it does not exist.
+            // Directories need not be created as they are created automatically, if needed.
+            await blob.Container.CreateIfNotExistsAsync(cancellationToken);
+
+            try
+            {
+                await blob.UploadTextAsync(string.Empty, cancellationToken: cancellationToken);
+                return true;
+            }
+            catch (StorageException exception)
+            {
+                if (exception.RequestInformation != null &&
+                    (exception.RequestInformation.HttpStatusCode == 409 || exception.RequestInformation.HttpStatusCode == 412))
+                {
+                    // The blob already exists, or is leased by someone else
+                    return false;
+                }
+                else
+                {
+                    throw;
+                }
+            }
+        }
+
+        internal IStorageBlockBlob GetBlob(LeaseDefinition leaseDefinition)
+        {
+            var accountName = leaseDefinition.AccountName;
+
+            if (string.IsNullOrWhiteSpace(accountName))
+            {
+                throw new InvalidOperationException("No lease account name specified");
+            }
+
+            IStorageAccount storageAccount;
+            if (!_storageAccountMap.TryGetValue(accountName, out storageAccount))
+            {
+                storageAccount = _storageAccountProvider.GetStorageAccountAsync(accountName, CancellationToken.None).Result;
+                
+                // singleton requires block blobs, cannot be premium
+                storageAccount.AssertTypeOneOf(StorageAccountType.GeneralPurpose, StorageAccountType.BlobOnly);
+
+                _storageAccountMap[accountName] = storageAccount;
+            }
+
+            string containerName, directoryName;
+            GetBlobPathComponents(leaseDefinition, out containerName, out directoryName);
+
+            IStorageBlobClient blobClient = storageAccount.CreateBlobClient();
+            IStorageBlobContainer container = blobClient.GetContainerReference(containerName);
+
+            IStorageBlockBlob blob;
+            if (string.IsNullOrWhiteSpace(directoryName))
+            {
+                blob = container.GetBlockBlobReference(leaseDefinition.Name);
+            }
+            else
+            {
+                IStorageBlobDirectory blobDirectory = container.GetDirectoryReference(directoryName);
+                blob = blobDirectory.GetBlockBlobReference(leaseDefinition.Name);
+            }
+
+            return blob;
+        }
+
+        // Gets the storage container and directory names from the lease definition
+        private static void GetBlobPathComponents(LeaseDefinition leaseDefinition, out string containerName, out string directoryName)
+        {
+            containerName = directoryName = null;
+
+            if (leaseDefinition.Namespaces == null || leaseDefinition.Namespaces.Count < 1 || leaseDefinition.Namespaces.Count > 2)
+            {
+                throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, "Invalid LeaseDefinition Namespaces: {0}", leaseDefinition.Namespaces));
+            }
+
+            containerName = leaseDefinition.Namespaces[0];
+
+            if (leaseDefinition.Namespaces.Count == 2)
+            {
+                directoryName = leaseDefinition.Namespaces[1];
+            }
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Lease/ILeaseProxy.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Lease/ILeaseProxy.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.Lease;
+
+namespace Microsoft.Azure.WebJobs.Host.Lease
+{
+    /// <summary>
+    /// Interface for lease management
+    /// </summary>
+    public interface ILeaseProxy
+    {
+        /// <summary>
+        /// Try acquiring lease.
+        /// <returns>If successful, returns lease ID. Otherwise, returns null</returns>
+        /// </summary>
+        Task<string> TryAcquireLeaseAsync(LeaseDefinition leaseDefinition, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Acquire lease.
+        /// <returns>If successful, returns lease ID. Otherwise, throws a <see cref="LeaseException"/> exception</returns>
+        /// </summary>
+        Task<string> AcquireLeaseAsync(LeaseDefinition leaseDefinition, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Renews lease.
+        /// <returns>Throws a <see cref="LeaseException"/> exception if the operation fails</returns>
+        /// </summary>
+        Task RenewLeaseAsync(LeaseDefinition leaseDefinition, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Releases lease.
+        /// <returns>Throws a <see cref="LeaseException"/> exception if the operation fails</returns>
+        /// </summary>
+        Task ReleaseLeaseAsync(LeaseDefinition leaseDefinition, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Writes lease metadata.
+        /// <returns>Throws a <see cref="LeaseException"/> exception if the operation fails</returns>
+        /// </summary>
+        Task WriteLeaseMetadataAsync(LeaseDefinition leaseDefinition, string key, string value, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Reads information about the lease
+        /// <returns>If successful, returns the lease information. Otherwise, it throws a <see cref="LeaseException"/> exception</returns>
+        /// </summary>
+        Task<LeaseInformation> ReadLeaseInfoAsync(LeaseDefinition leaseDefinition, CancellationToken cancellationToken);
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Lease/LeaseDefinition.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Lease/LeaseDefinition.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.WebJobs.Host.Lease
+{
+    /// <summary>
+    /// Lease definition
+    /// </summary>
+    public class LeaseDefinition
+    {
+        /// <summary>
+        /// Account name associated with this lease
+        /// </summary>
+        public string AccountName { get; set; }
+
+        /// <summary>
+        /// List of nested logical namespaces that will contain the lease.
+        /// Currently, the allowed number of namespaces is either 1 or 2.
+        /// Implementations of <see cref="ILeaseProxy"/> can use this property in different ways.
+        /// For example, a blob storage based lease implementation will map.
+        /// Namespaces[0] to a container name and Namespaces[1] to a directory name in it.
+        /// </summary>
+        public IReadOnlyList<string> Namespaces { get; set; }
+
+        /// <summary>
+        /// The lease name.
+        /// Implementations of <see cref="ILeaseProxy"/> can use this property in different ways.
+        /// For example, a blob storage based lease implementation will map this to a blob name
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The ID of a previously acquired lease
+        /// </summary>
+        public string LeaseId { get; set; }
+
+        /// <summary>
+        /// Duration of the lease
+        /// </summary>
+        public TimeSpan Period { get; set; }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Lease/LeaseException.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Lease/LeaseException.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.Serialization;
+
+namespace Microsoft.Azure.WebJobs.Host.Lease
+{
+    /// <summary>
+    /// A Lease Exception
+    /// </summary>
+    [Serializable]
+    public class LeaseException : Exception
+    {
+        /// <inheritdoc />
+        public LeaseException() : base()
+        {
+        }
+
+        /// <inheritdoc />
+        public LeaseException(String message) : base(message)
+        {
+        }
+
+        /// <inheritdoc />
+        public LeaseException(String message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        /// <inheritdoc />
+        protected LeaseException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+            if (info == null)
+            {
+                throw new ArgumentNullException("info");
+            }
+
+            FailureReason = (LeaseFailureReason)Enum.Parse(typeof(LeaseFailureReason), info.GetString("FailureReason"));
+        }
+
+        /// <inheritdoc />
+        public LeaseException(LeaseFailureReason failureReason, Exception innerException)
+            : this("Lease Exception", innerException)
+        {
+            FailureReason = failureReason;
+        }
+
+        /// <summary>
+        /// Lease failure reason
+        /// </summary>
+        public LeaseFailureReason FailureReason { get; protected set; }
+
+        /// <inheritdoc />
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            if (info == null)
+            {
+                throw new ArgumentNullException("info");
+            }
+
+            info.AddValue("FailureReason", FailureReason);
+
+            base.GetObjectData(info, context);
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Lease/LeaseFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Lease/LeaseFactory.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Azure.WebJobs.Host.Lease;
+using Microsoft.Azure.WebJobs.Host.Storage;
+
+namespace Microsoft.Azure.WebJobs.Host.Lease
+{
+    /// <summary>
+    /// ILeaseProxy factory
+    /// </summary>
+    internal class LeaseFactory
+    {
+        public static ILeaseProxy CreateLeaseProxy(IStorageAccountProvider storageAccountProvider)
+        {
+            ILeaseProxy leaseProxy = null;
+
+            // Choose between Sql and Blob based lease implementations
+            if (SqlLeaseProxy.IsSqlLeaseType())
+            {
+                leaseProxy = new SqlLeaseProxy();
+            }
+            else
+            {
+                leaseProxy = new BlobLeaseProxy(storageAccountProvider);
+            }
+
+            return leaseProxy;
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Lease/LeaseFailureReason.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Lease/LeaseFailureReason.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Host.Lease
+{
+    /// <summary>
+    /// Cause of lease failure
+    /// </summary>
+    public enum LeaseFailureReason
+    {
+        /// <summary>
+        /// Conflict
+        /// </summary>
+        Conflict,
+
+        /// <summary>
+        /// Unknown failure
+        /// </summary>
+        Unknown
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Lease/LeaseInformation.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Lease/LeaseInformation.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Data;
+
+namespace Microsoft.Azure.WebJobs.Host.Lease
+{
+    /// <summary>
+    /// Lease info
+    /// </summary>
+    public class LeaseInformation
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        public LeaseInformation(bool isLeaseAvailable, IDictionary<string, string> metadata)
+        {
+            this.IsLeaseAvailable = isLeaseAvailable;
+            this.Metadata = metadata;
+        }
+
+        /// <summary>
+        /// Specifies if the lease is available and can be acquired
+        /// </summary>
+        public bool IsLeaseAvailable { get; private set; }
+
+        /// <summary>
+        /// The lease metadata
+        /// </summary>
+        public IDictionary<string, string> Metadata { get; private set; }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Lease/SqlLeaseProxy.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Lease/SqlLeaseProxy.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Data.Odbc;
+using System.Data.SqlClient;
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.Lease;
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.WebJobs.Host.Lease
+{
+    // Sql based lease implementation
+    internal class SqlLeaseProxy : ILeaseProxy
+    {
+        public static bool IsSqlLeaseType()
+        {
+            try
+            {
+                string connectionString = GetConnectionString(ConnectionStringNames.Lease);
+
+                if (string.IsNullOrWhiteSpace(connectionString))
+                {
+                    return false;
+                }
+
+                // Try creating a SQL connection. This will implicitly parse the connection string
+                // and throw an exception if it fails.
+                using (SqlConnection connection = new SqlConnection(connectionString))
+                {
+                }
+
+                return true;
+            }
+            catch (Exception)
+            {
+            }
+
+            return false;
+        }
+
+        /// <inheritdoc />
+        public Task<string> TryAcquireLeaseAsync(LeaseDefinition leaseDefinition, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public Task<string> AcquireLeaseAsync(LeaseDefinition leaseDefinition, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public Task RenewLeaseAsync(LeaseDefinition leaseDefinition, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public Task WriteLeaseMetadataAsync(LeaseDefinition leaseDefinition, string key,
+            string value, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public Task<LeaseInformation> ReadLeaseInfoAsync(LeaseDefinition leaseDefinition, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public Task ReleaseLeaseAsync(LeaseDefinition leaseDefinition, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static string GetConnectionString(string accountName)
+        {
+            if (string.IsNullOrWhiteSpace(accountName))
+            {
+                throw new InvalidOperationException("Lease account name not specified");
+            }
+
+            return AmbientConnectionStringProvider.Instance.GetConnectionString(accountName);
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Singleton/SingletonManager.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Singleton/SingletonManager.cs
@@ -13,13 +13,13 @@ using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Bindings.Path;
 using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Azure.WebJobs.Host.Lease;
 using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Azure.WebJobs.Host.Protocols;
 using Microsoft.Azure.WebJobs.Host.Storage;
 using Microsoft.Azure.WebJobs.Host.Storage.Blob;
 using Microsoft.Azure.WebJobs.Host.Timers;
 using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Blob;
 
 namespace Microsoft.Azure.WebJobs.Host
 {
@@ -32,21 +32,20 @@ namespace Microsoft.Azure.WebJobs.Host
         private readonly INameResolver _nameResolver;
         private readonly IWebJobsExceptionHandler _exceptionHandler;
         private readonly SingletonConfiguration _config;
-        private readonly IStorageAccountProvider _accountProvider;
-        private ConcurrentDictionary<string, IStorageBlobDirectory> _lockDirectoryMap = new ConcurrentDictionary<string, IStorageBlobDirectory>(StringComparer.OrdinalIgnoreCase);
         private TimeSpan _minimumLeaseRenewalInterval = TimeSpan.FromSeconds(1);
         private TraceWriter _trace;
         private IHostIdProvider _hostIdProvider;
         private string _hostId;
+        private ILeaseProxy _leaseProxy;
 
         // For mock testing only
         internal SingletonManager()
         {
         }
 
-        public SingletonManager(IStorageAccountProvider accountProvider, IWebJobsExceptionHandler exceptionHandler, SingletonConfiguration config, TraceWriter trace, IHostIdProvider hostIdProvider, INameResolver nameResolver = null)
+        public SingletonManager(ILeaseProxy leaseProxy, IWebJobsExceptionHandler exceptionHandler, SingletonConfiguration config, TraceWriter trace, IHostIdProvider hostIdProvider, INameResolver nameResolver = null)
         {
-            _accountProvider = accountProvider;
+            _leaseProxy = leaseProxy;
             _nameResolver = nameResolver;
             _exceptionHandler = exceptionHandler;
             _config = config;
@@ -104,10 +103,17 @@ namespace Microsoft.Azure.WebJobs.Host
 
         public async virtual Task<object> TryLockAsync(string lockId, string functionInstanceId, SingletonAttribute attribute, CancellationToken cancellationToken, bool retry = true)
         {
-            IStorageBlobDirectory lockDirectory = GetLockDirectory(attribute.Account);
-            IStorageBlockBlob lockBlob = lockDirectory.GetBlockBlobReference(lockId);
             TimeSpan lockPeriod = GetLockPeriod(attribute, _config);
-            string leaseId = await TryAcquireLeaseAsync(lockBlob, lockPeriod, cancellationToken);
+            var leaseDefinition = new LeaseDefinition
+            {
+                AccountName = GetAccountName(attribute),
+                Namespaces = new List<string> { HostContainerNames.Hosts, HostDirectoryNames.SingletonLocks },
+                Name = lockId,
+                Period = lockPeriod
+            };
+
+            string leaseId = await _leaseProxy.TryAcquireLeaseAsync(leaseDefinition, cancellationToken);
+ 
             if (string.IsNullOrEmpty(leaseId) && retry)
             {
                 // Someone else has the lease. Continue trying to periodically get the lease for
@@ -121,7 +127,7 @@ namespace Microsoft.Azure.WebJobs.Host
                 {
                     await Task.Delay(_config.LockAcquisitionPollingInterval);
                     timeWaited += _config.LockAcquisitionPollingInterval;
-                    leaseId = await TryAcquireLeaseAsync(lockBlob, lockPeriod, cancellationToken);
+                    leaseId = await _leaseProxy.TryAcquireLeaseAsync(leaseDefinition, cancellationToken);
                 }
             }
 
@@ -130,19 +136,20 @@ namespace Microsoft.Azure.WebJobs.Host
                 return null;
             }
 
+            leaseDefinition.LeaseId = leaseId;
+
             _trace.Verbose(string.Format(CultureInfo.InvariantCulture, "Singleton lock acquired ({0})", lockId), source: TraceSource.Execution);
 
             if (!string.IsNullOrEmpty(functionInstanceId))
             {
-                await WriteLeaseBlobMetadata(lockBlob, leaseId, functionInstanceId, cancellationToken);
+                await _leaseProxy.WriteLeaseMetadataAsync(leaseDefinition, FunctionInstanceMetadataKey, functionInstanceId,
+                    cancellationToken);
             }
 
             SingletonLockHandle lockHandle = new SingletonLockHandle
             {
-                LeaseId = leaseId,
-                LockId = lockId,
-                Blob = lockBlob,
-                LeaseRenewalTimer = CreateLeaseRenewalTimer(lockBlob, leaseId, lockId, lockPeriod, _exceptionHandler)
+                LeaseDefinition = leaseDefinition,
+                LeaseRenewalTimer = CreateLeaseRenewalTimer(_leaseProxy, leaseDefinition, _exceptionHandler)
             };
 
             // start the renewal timer, which ensures that we maintain our lease until
@@ -161,9 +168,9 @@ namespace Microsoft.Azure.WebJobs.Host
                 await singletonLockHandle.LeaseRenewalTimer.StopAsync(cancellationToken);
             }
 
-            await ReleaseLeaseAsync(singletonLockHandle.Blob, singletonLockHandle.LeaseId, cancellationToken);
+            await _leaseProxy.ReleaseLeaseAsync(singletonLockHandle.LeaseDefinition, cancellationToken);
 
-            _trace.Verbose(string.Format(CultureInfo.InvariantCulture, "Singleton lock released ({0})", singletonLockHandle.LockId), source: TraceSource.Execution);
+            _trace.Verbose(string.Format(CultureInfo.InvariantCulture, "Singleton lock released ({0})", singletonLockHandle.LeaseDefinition.Name), source: TraceSource.Execution);
         }
 
         public string FormatLockId(MethodInfo method, SingletonScope scope, string scopeId)
@@ -296,46 +303,26 @@ namespace Microsoft.Azure.WebJobs.Host
 
         public async virtual Task<string> GetLockOwnerAsync(SingletonAttribute attribute, string lockId, CancellationToken cancellationToken)
         {
-            IStorageBlobDirectory lockDirectory = GetLockDirectory(attribute.Account);
-            IStorageBlockBlob lockBlob = lockDirectory.GetBlockBlobReference(lockId);
+            var leaseDefinition = new LeaseDefinition
+            {
+                AccountName = GetAccountName(attribute),
+                Namespaces = new List<string> { HostContainerNames.Hosts, HostDirectoryNames.SingletonLocks },
+                Name = lockId,
+            };
 
-            await ReadLeaseBlobMetadata(lockBlob, cancellationToken);
+            LeaseInformation leaseInfo = await _leaseProxy.ReadLeaseInfoAsync(leaseDefinition, cancellationToken);
 
             // if the lease is Available, then there is no current owner
             // (any existing owner value is the last owner that held the lease)
-            if (lockBlob.Properties.LeaseState == LeaseState.Available &&
-                lockBlob.Properties.LeaseStatus == LeaseStatus.Unlocked)
+            if (leaseInfo.IsLeaseAvailable)
             {
                 return null;
             }
 
             string owner = string.Empty;
-            lockBlob.Metadata.TryGetValue(FunctionInstanceMetadataKey, out owner);
+            leaseInfo.Metadata.TryGetValue(FunctionInstanceMetadataKey, out owner);
 
             return owner;
-        }
-
-        internal IStorageBlobDirectory GetLockDirectory(string accountName)
-        {
-            if (string.IsNullOrEmpty(accountName))
-            {
-                accountName = ConnectionStringNames.Storage;
-            }
-
-            IStorageBlobDirectory storageDirectory = null;
-            if (!_lockDirectoryMap.TryGetValue(accountName, out storageDirectory))
-            {
-                Task<IStorageAccount> task = _accountProvider.GetStorageAccountAsync(accountName, CancellationToken.None);
-                IStorageAccount storageAccount = task.Result;
-                // singleton requires block blobs, cannot be premium
-                storageAccount.AssertTypeOneOf(StorageAccountType.GeneralPurpose, StorageAccountType.BlobOnly);
-                IStorageBlobClient blobClient = storageAccount.CreateBlobClient();
-                storageDirectory = blobClient.GetContainerReference(HostContainerNames.Hosts)
-                                       .GetDirectoryReference(HostDirectoryNames.SingletonLocks);
-                _lockDirectoryMap[accountName] = storageDirectory;
-            }
-
-            return storageDirectory;
         }
 
         internal static TimeSpan GetLockPeriod(SingletonAttribute attribute, SingletonConfiguration config)
@@ -344,222 +331,37 @@ namespace Microsoft.Azure.WebJobs.Host
                     config.ListenerLockPeriod : config.LockPeriod;
         }
 
-        private ITaskSeriesTimer CreateLeaseRenewalTimer(IStorageBlockBlob leaseBlob, string leaseId, string lockId, TimeSpan leasePeriod,
-            IWebJobsExceptionHandler exceptionHandler)
+        private ITaskSeriesTimer CreateLeaseRenewalTimer(ILeaseProxy leaseProxy, LeaseDefinition leaseDefinition, IWebJobsExceptionHandler exceptionHandler)
         {
             // renew the lease when it is halfway to expiring   
-            TimeSpan normalUpdateInterval = new TimeSpan(leasePeriod.Ticks / 2);
+            TimeSpan normalUpdateInterval = new TimeSpan(leaseDefinition.Period.Ticks / 2);
 
             IDelayStrategy speedupStrategy = new LinearSpeedupStrategy(normalUpdateInterval, MinimumLeaseRenewalInterval);
-            ITaskSeriesCommand command = new RenewLeaseCommand(leaseBlob, leaseId, lockId, speedupStrategy, _trace, leasePeriod);
+            ITaskSeriesCommand command = new RenewLeaseCommand(leaseProxy, leaseDefinition, speedupStrategy, _trace, leaseDefinition.Period);
             return new TaskSeriesTimer(command, exceptionHandler, Task.Delay(normalUpdateInterval));
-        }
-
-        private static async Task<string> TryAcquireLeaseAsync(IStorageBlockBlob blob, TimeSpan leasePeriod, CancellationToken cancellationToken)
-        {
-            bool blobDoesNotExist = false;
-            try
-            {
-                // Optimistically try to acquire the lease. The blob may not yet
-                // exist. If it doesn't we handle the 404, create it, and retry below
-                return await blob.AcquireLeaseAsync(leasePeriod, null, cancellationToken);
-            }
-            catch (StorageException exception)
-            {
-                if (exception.RequestInformation != null)
-                {
-                    if (exception.RequestInformation.HttpStatusCode == 409)
-                    {
-                        return null;
-                    }
-                    else if (exception.RequestInformation.HttpStatusCode == 404)
-                    {
-                        blobDoesNotExist = true;
-                    }
-                    else
-                    {
-                        throw;
-                    }
-                }
-                else
-                {
-                    throw;
-                }
-            }
-
-            if (blobDoesNotExist)
-            {
-                await TryCreateAsync(blob, cancellationToken);
-
-                try
-                {
-                    return await blob.AcquireLeaseAsync(leasePeriod, null, cancellationToken);
-                }
-                catch (StorageException exception)
-                {
-                    if (exception.RequestInformation != null &&
-                        exception.RequestInformation.HttpStatusCode == 409)
-                    {
-                        return null;
-                    }
-                    else
-                    {
-                        throw;
-                    }
-                }
-            }
-
-            return null;
-        }
-
-        private static async Task ReleaseLeaseAsync(IStorageBlockBlob blob, string leaseId, CancellationToken cancellationToken)
-        {
-            try
-            {
-                // Note that this call returns without throwing if the lease is expired. See the table at:
-                // http://msdn.microsoft.com/en-us/library/azure/ee691972.aspx
-                await blob.ReleaseLeaseAsync(
-                    accessCondition: new AccessCondition { LeaseId = leaseId },
-                    options: null,
-                    operationContext: null,
-                    cancellationToken: cancellationToken);
-            }
-            catch (StorageException exception)
-            {
-                if (exception.RequestInformation != null)
-                {
-                    if (exception.RequestInformation.HttpStatusCode == 404 ||
-                        exception.RequestInformation.HttpStatusCode == 409)
-                    {
-                        // if the blob no longer exists, or there is another lease
-                        // now active, there is nothing for us to release so we can
-                        // ignore
-                    }
-                    else
-                    {
-                        throw;
-                    }
-                }
-                else
-                {
-                    throw;
-                }
-            }
-        }
-
-        private static async Task<bool> TryCreateAsync(IStorageBlockBlob blob, CancellationToken cancellationToken)
-        {
-            bool isContainerNotFoundException = false;
-
-            try
-            {
-                await blob.UploadTextAsync(string.Empty, cancellationToken: cancellationToken);
-                return true;
-            }
-            catch (StorageException exception)
-            {
-                if (exception.RequestInformation != null)
-                {
-                    if (exception.RequestInformation.HttpStatusCode == 404)
-                    {
-                        isContainerNotFoundException = true;
-                    }
-                    else if (exception.RequestInformation.HttpStatusCode == 409 ||
-                             exception.RequestInformation.HttpStatusCode == 412)
-                    {
-                        // The blob already exists, or is leased by someone else
-                        return false;
-                    }
-                    else
-                    {
-                        throw;
-                    }
-                }
-                else
-                {
-                    throw;
-                }
-            }
-
-            Debug.Assert(isContainerNotFoundException);
-            await blob.Container.CreateIfNotExistsAsync(cancellationToken);
-
-            try
-            {
-                await blob.UploadTextAsync(string.Empty, cancellationToken: cancellationToken);
-                return true;
-            }
-            catch (StorageException exception)
-            {
-                if (exception.RequestInformation != null &&
-                    (exception.RequestInformation.HttpStatusCode == 409 || exception.RequestInformation.HttpStatusCode == 412))
-                {
-                    // The blob already exists, or is leased by someone else
-                    return false;
-                }
-                else
-                {
-                    throw;
-                }
-            }
-        }
-
-        private static async Task WriteLeaseBlobMetadata(IStorageBlockBlob blob, string leaseId, string functionInstanceId, CancellationToken cancellationToken)
-        {
-            blob.Metadata.Add(FunctionInstanceMetadataKey, functionInstanceId);
-
-            await blob.SetMetadataAsync(
-                accessCondition: new AccessCondition { LeaseId = leaseId },
-                options: null,
-                operationContext: null,
-                cancellationToken: cancellationToken);
-        }
-
-        private static async Task ReadLeaseBlobMetadata(IStorageBlockBlob blob, CancellationToken cancellationToken)
-        {
-            try
-            {
-                await blob.FetchAttributesAsync(cancellationToken);
-            }
-            catch (StorageException exception)
-            {
-                if (exception.RequestInformation != null &&
-                    exception.RequestInformation.HttpStatusCode == 404)
-                {
-                    // the blob no longer exists
-                }
-                else
-                {
-                    throw;
-                }
-            }
         }
 
         internal class SingletonLockHandle
         {
-            public string LeaseId { get; set; }
-            public string LockId { get; set; }
-            public IStorageBlockBlob Blob { get; set; }
+            public LeaseDefinition LeaseDefinition { get; set; }
             public ITaskSeriesTimer LeaseRenewalTimer { get; set; }
         }
 
         internal class RenewLeaseCommand : ITaskSeriesCommand
         {
-            private readonly IStorageBlockBlob _leaseBlob;
-            private readonly string _leaseId;
-            private readonly string _lockId;
+            private readonly ILeaseProxy _leaseProxy;
+            private readonly LeaseDefinition _leaseDefinition;
             private readonly IDelayStrategy _speedupStrategy;
             private readonly TraceWriter _trace;
             private DateTimeOffset _lastRenewal;
             private TimeSpan _lastRenewalLatency;
             private TimeSpan _leasePeriod;
-
-            public RenewLeaseCommand(IStorageBlockBlob leaseBlob, string leaseId, string lockId, IDelayStrategy speedupStrategy, TraceWriter trace, TimeSpan leasePeriod)
+            
+            public RenewLeaseCommand(ILeaseProxy leaseProxy, LeaseDefinition leaseDefinition, IDelayStrategy speedupStrategy, TraceWriter trace, TimeSpan leasePeriod)
             {
                 _lastRenewal = DateTimeOffset.UtcNow;
-                _leaseBlob = leaseBlob;
-                _leaseId = leaseId;
-                _lockId = lockId;
+                _leaseProxy = leaseProxy;
+                _leaseDefinition = leaseDefinition;
                 _speedupStrategy = speedupStrategy;
                 _trace = trace;
                 _leasePeriod = leasePeriod;
@@ -571,12 +373,8 @@ namespace Microsoft.Azure.WebJobs.Host
 
                 try
                 {
-                    AccessCondition condition = new AccessCondition
-                    {
-                        LeaseId = _leaseId
-                    };
                     DateTimeOffset requestStart = DateTimeOffset.UtcNow;
-                    await _leaseBlob.RenewLeaseAsync(condition, null, null, cancellationToken);
+                    await _leaseProxy.RenewLeaseAsync(_leaseDefinition, cancellationToken);
                     _lastRenewal = DateTime.UtcNow;
                     _lastRenewalLatency = _lastRenewal - requestStart;
 
@@ -590,7 +388,7 @@ namespace Microsoft.Azure.WebJobs.Host
                         // The next execution should occur more quickly (try to renew the lease before it expires).
                         delay = _speedupStrategy.GetNextDelay(executionSucceeded: false);
                         _trace.Warning(string.Format(CultureInfo.InvariantCulture, "Singleton lock renewal failed for blob '{0}' with error code {1}. Retry renewal in {2} milliseconds.",
-                            _lockId, FormatErrorCode(exception), delay.TotalMilliseconds), source: TraceSource.Execution);
+                            _leaseDefinition.Name, FormatErrorCode(exception), delay.TotalMilliseconds), source: TraceSource.Execution);
                     }
                     else
                     {
@@ -601,7 +399,7 @@ namespace Microsoft.Azure.WebJobs.Host
                         int lastRenewalMilliseconds = (int)_lastRenewalLatency.TotalMilliseconds;
 
                         _trace.Error(string.Format(CultureInfo.InvariantCulture, "Singleton lock renewal failed for blob '{0}' with error code {1}. The last successful renewal completed at {2} ({3} milliseconds ago) with a duration of {4} milliseconds. The lease period was {5} milliseconds.",
-                            _lockId, FormatErrorCode(exception), lastRenewalFormatted, millisecondsSinceLastSuccess, lastRenewalMilliseconds, leasePeriodMilliseconds));
+                            _leaseDefinition.Name, FormatErrorCode(exception), lastRenewalFormatted, millisecondsSinceLastSuccess, lastRenewalMilliseconds, leasePeriodMilliseconds));
 
                         // If we've lost the lease or cannot re-establish it, we want to fail any
                         // in progress function execution
@@ -630,6 +428,23 @@ namespace Microsoft.Azure.WebJobs.Host
 
                 return message;
             }
+        }
+
+        private static string GetAccountName(SingletonAttribute attribute)
+        {
+            string accountName = attribute.Account;
+
+            if (string.IsNullOrWhiteSpace(accountName))
+            {
+                accountName = ConnectionStringNames.Lease;
+            }
+
+            if (string.IsNullOrWhiteSpace(AmbientConnectionStringProvider.Instance.GetConnectionString(accountName)))
+            {
+                accountName = ConnectionStringNames.Storage;
+            }
+
+            return accountName;
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
+++ b/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
@@ -414,7 +414,15 @@
     <Compile Include="FuncConverter.cs" />
     <Compile Include="FunctionTimeoutException.cs" />
     <Compile Include="Exceptions\RecoverableException.cs" />
+    <Compile Include="Lease\ILeaseProxy.cs" />
     <Compile Include="JobHostBlobsConfiguration.cs" />
+    <Compile Include="Lease\BlobLeaseProxy.cs" />
+    <Compile Include="Lease\LeaseDefinition.cs" />
+    <Compile Include="Lease\LeaseInformation.cs" />
+    <Compile Include="Lease\LeaseException.cs" />
+    <Compile Include="Lease\LeaseFailureReason.cs" />
+    <Compile Include="Lease\LeaseFactory.cs" />
+    <Compile Include="Lease\SqlLeaseProxy.cs" />
     <Compile Include="Listeners\FunctionListener.cs" />
     <Compile Include="Loggers\TraceEventExtensions.cs" />
     <Compile Include="Exceptions\FunctionException.cs" />

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncChainEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncChainEndToEndTests.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 Assert.True(queueProcessorFactory.CustomQueueProcessors.Sum(p => p.BeginProcessingCount) >= 2);
                 Assert.True(queueProcessorFactory.CustomQueueProcessors.Sum(p => p.CompleteProcessingCount) >= 2);
 
-                Assert.Equal(19, storageClientFactory.TotalBlobClientCount);
+                Assert.Equal(20, storageClientFactory.TotalBlobClientCount);
                 Assert.Equal(15, storageClientFactory.TotalQueueClientCount);
                 Assert.Equal(0, storageClientFactory.TotalTableClientCount);
 

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/SingletonEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/SingletonEndToEndTests.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Azure.WebJobs.Host.Lease;
 using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Azure.WebJobs.Host.Protocols;
 using Microsoft.Azure.WebJobs.Host.TestCommon;

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/BlobTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/BlobTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.FunctionalTests.TestDoubles;
+using Microsoft.Azure.WebJobs.Host.Lease;
 using Microsoft.Azure.WebJobs.Host.Storage;
 using Microsoft.Azure.WebJobs.Host.Storage.Blob;
 using Microsoft.Azure.WebJobs.Host.Storage.Queue;

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/FunctionalTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/FunctionalTest.cs
@@ -12,6 +12,7 @@ using Microsoft.Azure.WebJobs.Host.Blobs;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.FunctionalTests.TestDoubles;
 using Microsoft.Azure.WebJobs.Host.Indexers;
+using Microsoft.Azure.WebJobs.Host.Lease;
 using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Azure.WebJobs.Host.Loggers;
 using Microsoft.Azure.WebJobs.Host.Queues;
@@ -223,6 +224,7 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
                 activator,
                 extensions,
                 exceptionHandler,
+                LeaseFactory.CreateLeaseProxy(storageAccountProvider),
                 new NullFunctionInstanceLoggerProvider(functionInstanceLogger),
                 new NullHostInstanceLoggerProvider(),
                 new NullFunctionOutputLoggerProvider()

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/TestDoubles/FakeStorageAccountProvider.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/TestDoubles/FakeStorageAccountProvider.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests.TestDoubles
         {
             IStorageAccount account;
 
-            if (connectionStringName == ConnectionStringNames.Storage)
+            if (connectionStringName == ConnectionStringNames.Storage || connectionStringName == ConnectionStringNames.Lease)
             {
                 account = StorageAccount;
             }

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/TestHelpers.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/TestHelpers.cs
@@ -12,6 +12,7 @@ using System;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.Lease;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Host.TestCommon
@@ -130,6 +131,7 @@ namespace Microsoft.Azure.WebJobs.Host.TestCommon
 
             var types = new Type[] {
                 typeof(IHostInstanceLoggerProvider),
+                typeof(ILeaseProxy),
                 typeof(IFunctionInstanceLoggerProvider),
                 typeof(IFunctionOutputLoggerProvider),
                 typeof(IConsoleProvider),

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Lease/BlobLeaseProxyTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Lease/BlobLeaseProxyTests.cs
@@ -1,0 +1,153 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Azure.WebJobs.Host.Lease;
+using Microsoft.Azure.WebJobs.Host.Storage;
+using Microsoft.Azure.WebJobs.Host.Storage.Blob;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Host.UnitTests.Lease
+{
+    public class BlobLeaseProxyTests
+    {
+        const string Namespace1 = "Namespace1";
+        const string Namespace2 = "Namespace2";
+        const string Namespace1LeaseName = "Namespace1LeaseName";
+        const string Namespace2LeaseName = "Namespace2LeaseName";
+
+        [Fact]
+        public void GetBlob_DifferentNestedNamespaces()
+        {
+            var leaseDefinition = new LeaseDefinition
+            {
+                AccountName = "someaccount",
+            };
+
+            var accountProvider = GetMockInstanceOfType<IStorageAccountProvider>();
+            var account = GetMockInstanceOfType<IStorageAccount>();
+            var blobClient = GetMockInstanceOfType<IStorageBlobClient>();
+            var container = GetMockInstanceOfType<IStorageBlobContainer>();
+            var directory = GetMockInstanceOfType<IStorageBlobDirectory>();
+            var containerBlob = GetMockInstanceOfType<IStorageBlockBlob>();
+            var directoryBlob = GetMockInstanceOfType<IStorageBlockBlob>();
+
+            accountProvider
+                .Setup(p => p.TryGetAccountAsync(leaseDefinition.AccountName, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(account.Object);
+
+            // Creates Mock objects to represent a lease structure like the following:
+            // 
+            // Container (Namespace1) -> Directory (Namespace2) -> DirectoryBlob (Namespace2LeaseName)
+            //    |
+            //    +-------> ContainerBlob (Namespace1LeaseName)
+            //
+
+            account
+                .SetupGet(a => a.Type)
+                .Returns(StorageAccountType.GeneralPurpose);
+
+            account
+                .Setup(p => p.CreateBlobClient(null))
+                .Returns(blobClient.Object);
+
+            blobClient
+                .Setup(p => p.GetContainerReference(Namespace1))
+                .Returns(container.Object);
+
+            container
+                .Setup(p => p.GetDirectoryReference(Namespace2))
+                .Returns(directory.Object);
+
+            container
+                .Setup(p => p.GetBlockBlobReference(Namespace1LeaseName))
+                .Returns(containerBlob.Object);
+
+            directory
+                .Setup(p => p.GetBlockBlobReference(Namespace2LeaseName))
+                .Returns(directoryBlob.Object);
+
+            leaseDefinition.Namespaces = new List<string> { Namespace1 };
+            leaseDefinition.Name = Namespace1LeaseName;
+            var blobLeaseProxy = new BlobLeaseProxy(accountProvider.Object);
+            var blob = blobLeaseProxy.GetBlob(leaseDefinition);
+            Assert.Same(containerBlob.Object, blob);
+
+            leaseDefinition.Namespaces = new List<string> { Namespace1, Namespace2 };
+            leaseDefinition.Name = Namespace2LeaseName;
+            blobLeaseProxy = new BlobLeaseProxy(accountProvider.Object);
+            blob = blobLeaseProxy.GetBlob(leaseDefinition);
+            Assert.Same(directoryBlob.Object, blob);
+        }
+
+        [Fact]
+        public void GetBlob_MultipleAccounts()
+        {
+            var leaseDefinition = new LeaseDefinition
+            {
+                Namespaces = new List<string> { Namespace1 },
+                Name = Namespace1LeaseName
+            };
+
+            var accountProvider = GetMockInstanceOfType<IStorageAccountProvider>();
+
+            var blobLeaseProxy = new BlobLeaseProxy(accountProvider.Object);
+
+            leaseDefinition.AccountName = ConnectionStringNames.Lease;
+            var containerBlob = SetupMocks(accountProvider, leaseDefinition.AccountName);
+            var blob = blobLeaseProxy.GetBlob(leaseDefinition);
+            Assert.Same(containerBlob.Object, blob);
+
+            leaseDefinition.AccountName = ConnectionStringNames.Storage;
+            containerBlob = SetupMocks(accountProvider, leaseDefinition.AccountName);
+            blob = blobLeaseProxy.GetBlob(leaseDefinition);
+            Assert.Same(containerBlob.Object, blob);
+
+            leaseDefinition.AccountName = "some-account-name";
+            containerBlob = SetupMocks(accountProvider, leaseDefinition.AccountName);
+            blob = blobLeaseProxy.GetBlob(leaseDefinition);
+            Assert.Same(containerBlob.Object, blob);
+        }
+
+        // Creates Mock objects to represent a lease structure like the following:
+        // 
+        // Container (Namespace1) -> ContainerBlob (Namespace1LeaseName)
+        private static Mock<IStorageBlockBlob> SetupMocks(Mock<IStorageAccountProvider> accountProvider, string accountName)
+        {
+            var account = GetMockInstanceOfType<IStorageAccount>();
+            var blobClient = GetMockInstanceOfType<IStorageBlobClient>();
+            var container = GetMockInstanceOfType<IStorageBlobContainer>();
+            var containerBlob = GetMockInstanceOfType<IStorageBlockBlob>();
+
+            accountProvider
+                .Setup(p => p.TryGetAccountAsync(accountName, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(account.Object);
+
+            account
+                .SetupGet(a => a.Type)
+                .Returns(StorageAccountType.GeneralPurpose);
+
+            account
+                .Setup(p => p.CreateBlobClient(null))
+                .Returns(blobClient.Object);
+
+            blobClient
+                .Setup(p => p.GetContainerReference(Namespace1))
+                .Returns(container.Object);
+
+            container
+                .Setup(p => p.GetBlockBlobReference(Namespace1LeaseName))
+                .Returns(containerBlob.Object);
+
+            return containerBlob;
+        }
+
+        private static Mock<T> GetMockInstanceOfType<T>() where T: class
+        {
+            return new Mock<T>(MockBehavior.Strict);
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
@@ -226,7 +226,12 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 "RecoverableException",
                 "FunctionException",
                 "FunctionListenerException",
-                "ExceptionFormatter"
+                "ExceptionFormatter",
+                "ILeaseProxy",
+                "LeaseDefinition",
+                "LeaseException",
+                "LeaseFailureReason",
+                "LeaseInformation",
             };
 
             AssertPublicTypes(expected, assembly);

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
@@ -195,6 +195,7 @@
     <Compile Include="FunctionInstanceTraceWriterTests.cs" />
     <Compile Include="JobHostContextTests.cs" />
     <Compile Include="JobHostQueuesConfigurationTests.cs" />
+    <Compile Include="Lease\BlobLeaseProxyTests.cs" />
     <Compile Include="Listeners\FunctionListenerTests.cs" />
     <Compile Include="Listeners\HostListenerFactoryTests.cs" />
     <Compile Include="Loggers\TraceWriterFunctionInstanceLoggerTests.cs" />


### PR DESCRIPTION
**What change is this?**
- This commit is the first set of changes for running Azure Functions without Azure Storage
- With this change and similar changes in the azure-webjobs-script repo (details below), triggers and bindings that aren't storage specific would be able to work without a storage account (would need SQL instead for the lease management).

**Details**
- BlobLeaseProxy and SqlLeaseProxy provide blob and sql based implementations respectively.
- A complete SQL based implementation will be added in a subsequent commit
- With just AzureWebJobsStorage defined in the environment variables, there won't be any change in behavior
- Optionally, AzureWebJobsLease can be set to either a SQL connection string or an Azure Storage connection string. LeaseFactory will initialize the appropriate lease implementation accordingly.
- ILeaseProxy is made public interface so that BlobLeaseManager in the azure-webjobs-script repo can start using the same implementation. Ideally, the lease implementation can be in a repo of its own but I am just keeping everything here to keep things simple.

**Testing**
- BlobLeaseProxyTests.cs re-works a few existing tests. Full fledged functional testing of the ILeaseProxy implementations will be added in a follow-up commit. (PR to be merged only after that)
- Some of the tests rely on AzureWebJobsLease to be same as AzureWebJobsStorage (if AzureWebJobsLease is defined). They will be updated separately.