### PR TITLE
Add Logging, and Retry Logic Delete in Queue Processor. 

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/JobHostQueuesConfiguration.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/JobHostQueuesConfiguration.cs
@@ -21,11 +21,14 @@ namespace Microsoft.Azure.WebJobs.Host
         // the runtime error message the user would receive from the SDK otherwise is not as helpful.
         private const int MaxBatchSize = 32;
 
+        private const int DefaultRetryCount = 0;
+
         private int _batchSize = DefaultBatchSize;
         private int _newBatchThreshold;
         private TimeSpan _maxPollingInterval = QueuePollingIntervals.DefaultMaximum;
         private TimeSpan _visibilityTimeout = TimeSpan.Zero;
         private int _maxDequeueCount = DefaultMaxDequeueCount;
+        private int _deleteRetryCount = DefaultRetryCount;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="JobHostQueuesConfiguration"/> class.
@@ -64,14 +67,14 @@ namespace Microsoft.Azure.WebJobs.Host
         /// </summary>
         public int NewBatchThreshold
         {
-            get 
-            { 
+            get
+            {
                 if (_newBatchThreshold == -1)
                 {
                     // if this hasn't been set explicitly, default it
                     return _batchSize / 2;
                 }
-                return _newBatchThreshold; 
+                return _newBatchThreshold;
             }
 
             set
@@ -84,7 +87,7 @@ namespace Microsoft.Azure.WebJobs.Host
                 _newBatchThreshold = value;
             }
         }
-         
+
         /// <summary>
         /// Gets or sets the longest period of time to wait before checking for a message to arrive when a queue remains
         /// empty.
@@ -172,10 +175,28 @@ namespace Microsoft.Azure.WebJobs.Host
         /// <see cref="QueueProcessor"/> instances that will be used to process messages.
         /// </summary>
         [CLSCompliant(false)]
-        public IQueueProcessorFactory QueueProcessorFactory 
-        { 
-            get; 
-            set; 
+        public IQueueProcessorFactory QueueProcessorFactory
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Get's or sets the delete retry count
+        /// In some cases a queue may be unavailable temporarily. Retrying in some cases can
+        /// reduce the chance that a successfully processed message can return to the queue.
+        /// The default is 0
+        /// </summary>
+        public int DeleteRetryCount
+        {
+            get
+            {
+                return _deleteRetryCount;
+            }
+            set
+            {
+                _deleteRetryCount = value;
+            }
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Queues/IQueueConfiguration.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Queues/IQueueConfiguration.cs
@@ -17,6 +17,8 @@ namespace Microsoft.Azure.WebJobs.Host.Queues
 
         TimeSpan VisibilityTimeout { get; }
 
+        int DeleteRetryCount { get; }
+
         IQueueProcessorFactory QueueProcessorFactory { get; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Queues/QueueProcessorFactoryContext.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Queues/QueueProcessorFactoryContext.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Azure.WebJobs.Host.Queues
             NewBatchThreshold = queueConfiguration.NewBatchThreshold;
             VisibilityTimeout = queueConfiguration.VisibilityTimeout;
             MaxPollingInterval = queueConfiguration.MaxPollingInterval;
+            DeleteRetryCount = queueConfiguration.DeleteRetryCount;
         }
 
         /// <summary>
@@ -104,5 +105,10 @@ namespace Microsoft.Azure.WebJobs.Host.Queues
         /// fail processing.
         /// </summary>
         public TimeSpan VisibilityTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of retries for deleting the message
+        /// </summary>
+        public int DeleteRetryCount { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Storage/StorageExceptionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Storage/StorageExceptionExtensions.cs
@@ -746,6 +746,30 @@ namespace Microsoft.Azure.WebJobs.Host.Storage
         }
 
         /// <summary>
+        /// Determines if the error code is related to a 503 service unavailable this can transient so needs to be retried
+        /// </summary>
+        /// <param name="exception" > The storage exception </param>
+        /// <returns>
+        /// <see langword="true"/> if the exception is equal to a 503; otherwise <see langword="false"/> 
+        /// </returns> 
+        public static bool IsServiceUnavailable(this StorageException exception)
+        {
+            if (exception == null)
+            {
+                throw new ArgumentNullException("exception");
+            }
+
+            RequestResult result = exception.RequestInformation;
+
+            if (result == null)
+            {
+                return false;
+            }
+
+            return result.HttpStatusCode == 503;
+        }
+
+        /// <summary>
         /// Returns the status code from the storage exception, or null.
         /// </summary>
         /// <param name="exception">The storage exception.</param>

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/Queues/QueueProcessorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/Queues/QueueProcessorTests.cs
@@ -167,10 +167,10 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
             QueueProcessor localProcessor = new QueueProcessor(qpfc);
             string messageContent = Guid.NewGuid().ToString();
             CloudQueueMessage cqm = new CloudQueueMessage(messageContent);
-            await retryQueue.AddMessageAsync(cqm);
+            // Delete Message from queue and avoid  test exception
+            await _queue.AddMessageAsync(cqm);
             var functionResult = new FunctionResult(true);
             cqm = await retryQueue.GetMessageAsync();
-            // removing with _queue to avoid affecting the count
             await _queue.DeleteMessageAsync(cqm,CancellationToken.None);
 
             await localProcessor.CompleteProcessingMessageAsync(cqm, functionResult, CancellationToken.None);

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/TestDoubles/FakeQueueConfiguration.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/TestDoubles/FakeQueueConfiguration.cs
@@ -56,6 +56,14 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests.TestDoubles
                 return _queueProcessorFactory;
             }
         }
+        
+        public int DeleteRetryCount
+        {
+            get
+            {
+                return 0;
+            }
+        }
 
         private class FakeQueueProcessorFactory : DefaultQueueProcessorFactory
         {

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/app.config
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/app.config
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
+  <connectionStrings>
+    <add name="AzureWebJobsStorage" connectionString="UseDevelopmentStorage=true"/>
+  </connectionStrings>
   <appSettings>
   </appSettings>
   <runtime>

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/CloudQueueWithDeleteCounter.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/CloudQueueWithDeleteCounter.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.WindowsAzure.Storage.Queue;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Auth;
+using System.Threading;
+
+namespace Microsoft.Azure.WebJobs.Host.TestCommon
+{
+    public class CloudQueueWithDeleteCounter:CloudQueue
+    {
+        public int DeleteCount = 0;
+        public CloudQueueWithDeleteCounter(Uri uri):base(uri) { }
+        public CloudQueueWithDeleteCounter(StorageUri uri, StorageCredentials creds ):base(uri,creds) { }
+        public CloudQueueWithDeleteCounter(Uri uri, StorageCredentials creds) : base(uri, creds) { }
+
+        public async override Task DeleteMessageAsync(CloudQueueMessage message, CancellationToken token)
+        {
+            DeleteCount++;
+            await base.DeleteMessageAsync(message,token);
+            return;
+        }
+
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/CloudQueueWithDeleteCounter.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/CloudQueueWithDeleteCounter.cs
@@ -20,8 +20,12 @@ namespace Microsoft.Azure.WebJobs.Host.TestCommon
         public async override Task DeleteMessageAsync(CloudQueueMessage message, CancellationToken token)
         {
             DeleteCount++;
-            await base.DeleteMessageAsync(message,token);
-            return;
+            await Task.Delay(1);
+            //simulate 503
+            RequestResult rr = new RequestResult();
+            rr.HttpStatusCode = 503;
+            throw new StorageException(rr,"Fake Exception",new Exception());
+            
         }
 
     }

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/SimpleQueueConfiguration.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/SimpleQueueConfiguration.cs
@@ -50,5 +50,12 @@ namespace Microsoft.Azure.WebJobs.Host.TestCommon
                 return new DefaultQueueProcessorFactory();
             }
         }
+        public int DeleteRetryCount
+        {
+            get
+            {
+                return 0;
+            }
+        }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/WebJobs.Host.TestCommon.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/WebJobs.Host.TestCommon.csproj
@@ -194,6 +194,7 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="AzureSdk\CloudQueueClientExtensions.cs" />
+    <Compile Include="CloudQueueWithDeleteCounter.cs" />
     <Compile Include="ExtensionTypeLocator.cs" />
     <Compile Include="FakeActivator.cs" />
     <Compile Include="FakeExtensionTypeLocator.cs" />


### PR DESCRIPTION
This is added in response to the issue I logged #1120 .

I've added retry logic for message, or queue not found, tied to a new parameter in IQueueConfiguration. This is defaulted to 0 so basic behavior is unchanged, however retries will be attempted if the number increases.

I've also added log entries for exceptions so that if a logger is provided it is easier to track an issue caused by the queue being temporarily available. 

The goal is to make it easier to troubleshoot and resolve issues related to transient 503 errors being raised by the storage layer. In some cases with heavily used queues I've seen 503's being raised for messages that still exist. This can cause the existing logic to leave the message on the queue, because those exceptions are being dropped.
