### PR TITLE
Fix handly empty connection string, 

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Executors/StorageAccountProviderExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/StorageAccountProviderExtensions.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
                 throw new ArgumentNullException("provider");
             }
 
-            connectionStringName = connectionStringName ?? ConnectionStringNames.Storage;
+            connectionStringName = string.IsNullOrWhiteSpace(connectionStringName) ? ConnectionStringNames.Storage : connectionStringName;
 
             if (nameResolver != null)
             {

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/StorageAccountProviderExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/StorageAccountProviderExtensions.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
                 throw new ArgumentNullException("provider");
             }
 
-            connectionStringName = string.IsNullOrWhiteSpace(connectionStringName) ? ConnectionStringNames.Storage : connectionStringName;
+            connectionStringName = string.IsNullOrEmpty(connectionStringName) ? ConnectionStringNames.Storage : connectionStringName;
 
             if (nameResolver != null)
             {

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/Queues/QueueTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/Queues/QueueTests.cs
@@ -143,8 +143,9 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
 
             // BindingData is case insensitive. 
             // And queue name is normalized to lowercase. 
+            // Connection="" is same as Connection=null
             public const string QueueOutName = "qName-{XYZ}";
-            public void Func([QueueTrigger(QueueName)] Poco triggers,  [Queue(QueueOutName)] ICollector<string> q)
+            public void Func([QueueTrigger(QueueName, Connection ="")] Poco triggers,  [Queue(QueueOutName)] ICollector<string> q)
             {
                 q.Add("123");
             }        
@@ -173,7 +174,6 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
             Assert.Equal(1, msgs.Length);
             Assert.Equal("123", msgs[0].AsString);
         }
-
 
         public class ProgramSimple
         {

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/DefaultStorageAccountProviderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/DefaultStorageAccountProviderTests.cs
@@ -268,6 +268,26 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             Assert.Equal("Storage account 'name' is of unsupported type 'Premium'. Supported types are 'General Purpose'", exception.Message);
         }
 
+        [Fact]
+        public async Task GetStorageAccountAsyncTest()
+        {
+            string cxEmpty= "";
+            var accountDefault = new Mock<IStorageAccount>().Object;
+
+            string cxReal = "MyAccount";
+            var accountReal = new Mock<IStorageAccount>().Object;
+
+            var provider = new Mock<IStorageAccountProvider>();
+            provider.Setup(c => c.TryGetAccountAsync(ConnectionStringNames.Storage, CancellationToken.None)).Returns(Task.FromResult<IStorageAccount>(accountDefault));
+            provider.Setup(c => c.TryGetAccountAsync(cxReal, CancellationToken.None)).Returns(Task.FromResult<IStorageAccount>(accountReal));
+
+            var account = await StorageAccountProviderExtensions.GetStorageAccountAsync(provider.Object, cxEmpty, CancellationToken.None);
+            Assert.Equal(accountDefault, account);
+
+            account = await StorageAccountProviderExtensions.GetStorageAccountAsync(provider.Object, cxReal, CancellationToken.None);
+            Assert.Equal(accountReal, account);
+        }
+
         private static IConnectionStringProvider CreateConnectionStringProvider(string connectionStringName,
             string connectionString)
         {

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/ToolingTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/ToolingTests.cs
@@ -107,7 +107,18 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             Assert.Equal("x", blobAttr.BlobPath);
             Assert.Equal(FileAccess.Read, blobAttr.Access);
             Assert.Equal("cx1", blobAttr.Connection);
-            
+
+            blobAttr = GetAttr<BlobAttribute>(tooling,
+              new
+              {
+                  path = "x",
+                  direction = "in",
+                  connection = "" // empty, not null 
+              });
+            Assert.Equal("x", blobAttr.BlobPath);
+            Assert.Equal(FileAccess.Read, blobAttr.Access);
+            Assert.Equal("", blobAttr.Connection); // empty is passed straight through. 
+
             var blobTriggerAttr = GetAttr<BlobTriggerAttribute>(tooling, new { path = "x" });
             Assert.Equal("x", blobTriggerAttr.BlobPath);
 


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-webjobs-sdk-script/issues/1456
Add unit tests