### PR TITLE
Allow optional/null parameter bindings for strings

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/Data/ClassDataBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/Data/ClassDataBinding.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings.Data
             }
 
             object untypedValue = bindingData[_parameterName];
-            if (!(untypedValue is TBindingData))
+            if (!(untypedValue is TBindingData) && untypedValue != null)
             {
                 throw new InvalidOperationException($"Binding data for '{_parameterName}' is not of expected type {typeof(TBindingData).Name}.");
             }

--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/Invoke/ClassInvokeBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/Invoke/ClassInvokeBinding.cs
@@ -39,9 +39,9 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings.Invoke
         {
             TValue typedValue = null;
 
-            if (!Converter.TryConvert(value, out typedValue))
+            if (value != null && !Converter.TryConvert(value, out typedValue))
             {
-                throw new InvalidOperationException("Unable to convert value to " + typeof(TValue).Name + ".");
+                throw new InvalidOperationException($"Unable to convert value to {typeof(TValue).Name}.");
             }
 
             return BindAsync(typedValue, context);
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings.Invoke
 
         public Task<IValueProvider> BindAsync(BindingContext context)
         {
-            throw new InvalidOperationException("No value was provided for parameter '" + _parameterName + "'.");
+            throw new InvalidOperationException($"No value was provided for parameter '{_parameterName}'.");
         }
 
         public ParameterDescriptor ToParameterDescriptor()

--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/Invoke/StructInvokeBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/Invoke/StructInvokeBinding.cs
@@ -10,7 +10,6 @@ using Microsoft.Azure.WebJobs.Host.Protocols;
 namespace Microsoft.Azure.WebJobs.Host.Bindings.Invoke
 {
     internal class StructInvokeBinding<TValue> : IBinding
-        where TValue : struct
     {
         private static readonly IObjectToTypeConverter<TValue> Converter =
             ObjectToTypeConverterFactory.CreateForStruct<TValue>();
@@ -39,9 +38,9 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings.Invoke
         {
             TValue typedValue = default(TValue);
 
-            if (!Converter.TryConvert(value, out typedValue))
+            if (value != null && !Converter.TryConvert(value, out typedValue))
             {
-                throw new InvalidOperationException("Unable to convert value to " + typeof(TValue).Name + ".");
+                throw new InvalidOperationException($"Unable to convert value to {TypeUtility.GetFriendlyName(typeof(TValue))}.");
             }
 
             return BindAsync(typedValue, context);

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Bindings/Data/DataBindingProviderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Bindings/Data/DataBindingProviderTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Bindings.Data
     public class DataBindingProviderTests
     {
         [Fact]
-        public async Task Create_HandlesNullableTypes()
+        public async Task Create_HandlesNullableInteger()
         {
             // Arrange
             IBindingProvider product = new DataBindingProvider();
@@ -40,6 +40,40 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Bindings.Data
             var valueProvider = await binding.BindAsync(bindingContext);
             var value = await valueProvider.GetValueAsync();
             Assert.Equal(123, value);
+
+            bindingData["p"] = null;
+            bindingContext = new BindingContext(valueBindingContext, bindingData);
+            valueProvider = await binding.BindAsync(bindingContext);
+            value = await valueProvider.GetValueAsync();
+            Assert.Null(value);
+        }
+
+        [Fact]
+        public async Task Create_HandlesNullableString()
+        {
+            // Arrange
+            IBindingProvider product = new DataBindingProvider();
+
+            string parameterName = "p";
+            Type parameterType = typeof(string);
+            BindingProviderContext context = CreateBindingContext(parameterName, parameterType);
+
+            // Act
+            IBinding binding = await product.TryCreateAsync(context);
+
+            // Assert
+            Assert.NotNull(binding);
+
+            var functionBindingContext = new FunctionBindingContext(Guid.NewGuid(), CancellationToken.None, null);
+            var valueBindingContext = new ValueBindingContext(functionBindingContext, CancellationToken.None);
+            var bindingData = new Dictionary<string, object>
+            {
+                { "p", "Testing" }
+            };
+            var bindingContext = new BindingContext(valueBindingContext, bindingData);
+            var valueProvider = await binding.BindAsync(bindingContext);
+            var value = await valueProvider.GetValueAsync();
+            Assert.Equal("Testing", value);
 
             bindingData["p"] = null;
             bindingContext = new BindingContext(valueBindingContext, bindingData);


### PR DESCRIPTION
Fix for https://github.com/Azure/azure-webjobs-sdk-extensions/issues/224. Related to a previous fix I did a while back for nullable types (PR https://github.com/Azure/azure-webjobs-sdk/pull/869). That handled structs, but not cases where non-struct types (e.g. strings) were null.