### PR TITLE
Fix 1296

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging/FunctionInstanceLogItem.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging/FunctionInstanceLogItem.cs
@@ -156,7 +156,8 @@ namespace Microsoft.Azure.WebJobs.Logging
             {
                 if (this.StartTime > this.EndTime)
                 {
-                    throw new InvalidOperationException("End Time must be greater than start time");
+                    // This can happen in rare cases if the clock adjusts while the function is running. 
+                    this.EndTime = this.StartTime.AddMilliseconds(1);                    
                 }
             }
         }


### PR DESCRIPTION
Fix https://github.com/Azure/azure-webjobs-sdk-script/issues/1296
Need to be resilient to clock adjustment in the middle of a running function. 
Tactical fix - eventually this all gets removed and replaced with AI