### PR TITLE
Changing MessageFactory caching to be per entity/connection

### DIFF
--- a/src/Microsoft.Azure.WebJobs.ServiceBus/MessagingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/MessagingProvider.cs
@@ -66,12 +66,13 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
 
             string connectionString = GetConnectionString(connectionStringName);
 
-            // We cache messaging factories per connection, in accordance with ServiceBus
+            // We cache messaging factories per entity/connection, in accordance with ServiceBus
             // performance guidelines.
             // https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-performance-improvements
-            var messagingFactory = _messagingFactoryCache.GetOrAdd(connectionString, (c) =>
+            string cacheKey = $"{entityPath}-{connectionString}";
+            var messagingFactory = _messagingFactoryCache.GetOrAdd(cacheKey, (p) =>
             {
-                return MessagingFactory.CreateFromConnectionString(c);
+                return MessagingFactory.CreateFromConnectionString(connectionString);
             });
 
             return messagingFactory;

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/MessagingProviderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/MessagingProviderTests.cs
@@ -68,16 +68,27 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests
         {
             var factory = _provider.CreateMessagingFactory("test");
 
+            // same cached factory each time for the same entity/connection
             Assert.Same(factory, _provider.CreateMessagingFactory("test"));
             Assert.Same(factory, _provider.CreateMessagingFactory("test"));
             Assert.Same(factory, _provider.CreateMessagingFactory("test"));
 
-            var factory2 = _provider.CreateMessagingFactory("test", "ServiceBusOverride");
+            // different factory for a different entity
+            var factory2 = _provider.CreateMessagingFactory("test2");
             Assert.NotSame(factory, factory2);
+            Assert.Same(factory2, _provider.CreateMessagingFactory("test2"));
 
-            Assert.Same(factory2, _provider.CreateMessagingFactory("test", "ServiceBusOverride"));
-            Assert.Same(factory2, _provider.CreateMessagingFactory("test", "ServiceBusOverride"));
-            Assert.Same(factory2, _provider.CreateMessagingFactory("test", "ServiceBusOverride"));
+            factory2 = _provider.CreateMessagingFactory("test3", "ServiceBusOverride");
+
+            // same cached factory each time for the same entity/connection
+            Assert.Same(factory2, _provider.CreateMessagingFactory("test3", "ServiceBusOverride"));
+            Assert.Same(factory2, _provider.CreateMessagingFactory("test3", "ServiceBusOverride"));
+            Assert.Same(factory2, _provider.CreateMessagingFactory("test3", "ServiceBusOverride"));
+
+            // different factory for same entity different connection
+            var factory3 = _provider.CreateMessagingFactory("test3", "AzureWebJobsServiceBus");
+            Assert.NotSame(factory2, factory3);
+            Assert.Same(factory3, _provider.CreateMessagingFactory("test3", "AzureWebJobsServiceBus"));
         }
 
         [Fact]


### PR DESCRIPTION
In PR https://github.com/Azure/azure-webjobs-sdk/pull/1150 I added caching per connection string. I'd like to make that more granular, so we're caching per entity/connection. Note that this more in line with the behavior before caching was added. Previously we'd create a new factory at index time per function. This makes the caching more granular, addressing some concerns Brett raised previously about overloading a single TCP connection.