### PR TITLE
System binding data tweaks

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/Path/BindingParameterResolver.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/Path/BindingParameterResolver.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings.Path
         {
             // create the static set of built in system resolvers
             _resolvers = new Collection<BindingParameterResolver>();
+            _resolvers.Add(new GuidResolver());
             _resolvers.Add(new RandGuidResolver());
             _resolvers.Add(new DateTimeResolver());
         }
@@ -74,8 +75,26 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings.Path
             return null;
         }
 
-        // This is an alias for 'sys.randguid'
-        private class RandGuidResolver : BindingParameterResolver
+        // This is an alias for 'sys.guid'
+        private class GuidResolver : BindingParameterResolver
+        {
+            public override string Name
+            {
+                get
+                {
+                    return "guid";
+                }
+            }
+
+            public override string Resolve(string value)
+            {
+                string format = GetFormatOrNull(value);
+                var val = new SystemBindingData().Guid;
+                return BindingDataPathHelper.ConvertParameterValueToString(val, format);                
+            }
+        }
+
+        private class RandGuidResolver : GuidResolver
         {
             public override string Name
             {
@@ -84,18 +103,8 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings.Path
                     return "rand-guid";
                 }
             }
-
-            public override string Resolve(string value)
-            {
-                string format = GetFormatOrNull(value);
-                var val = new SystemBindingData().RandGuid;
-                return BindingDataPathHelper.ConvertParameterValueToString(val, format);                
-            }
         }
 
-        // This can't be aliases to 'sys.UtcNow' because
-        // 'sys.UtcNow' always resolves to DateTime.UtcNow. 
-        // But 'datetime' may either resolve to user bidning data or to DateTime.UtcNow.        
         private class DateTimeResolver : BindingParameterResolver
         {
             public override string Name
@@ -109,7 +118,7 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings.Path
             public override string Resolve(string value)
             {
                 string format = GetFormatOrNull(value);
-                var val = new SystemBindingData().UtcNow;
+                var val = new SystemBindingData().DateTime;
                 return BindingDataPathHelper.ConvertParameterValueToString(val, format);
             }
         }

--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/SystemBindingData.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/SystemBindingData.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
         // The public name for this binding in the binding expressions. 
         public const string Name = "sys";
 
-        // An internal name for this binding that uses characters that gaurantee it can't be overwritten by a user. 
+        // An internal name for this binding that uses characters that guarantee it can't be overwritten by a user. 
         // This is never seen by the user. 
         // This ensures that we can always unambiguously retrieve this later. 
         private const string InternalKeyName = "$sys";
@@ -36,14 +36,14 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
         public string MethodName { get; set; }
 
         /// <summary>
-        /// Get the current UTC date. 
+        /// Get the current UTC date. This returns the current value each time it is called.
         /// </summary>
-        public DateTime UtcNow => DateTime.UtcNow;
+        public DateTime DateTime => DateTime.UtcNow;
 
         /// <summary>
         /// Return a new random guid. This create a new guid each time it's called.
         /// </summary>
-        public Guid RandGuid => Guid.NewGuid();  
+        public Guid Guid => Guid.NewGuid();  
 
         // Given a full bindingData, create a binding data with just the system object .
         // This can be used when resolving default contracts that shouldn't be using an instance binding data. 

--- a/src/Microsoft.Azure.WebJobs.Host/GlobalSuppressions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/GlobalSuppressions.cs
@@ -81,3 +81,5 @@
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1800:DoNotCastUnnecessarily", Scope = "member", Target = "Microsoft.Azure.WebJobs.Host.Bindings.SystemBindingData.#GetFromData(System.Collections.Generic.IReadOnlyDictionary`2<System.String,System.Object>)")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Scope = "member", Target = "Microsoft.Azure.WebJobs.Host.Bindings.SystemBindingData.#UtcNow")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Scope = "member", Target = "Microsoft.Azure.WebJobs.Host.Bindings.SystemBindingData.#RandGuid")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Scope = "member", Target = "Microsoft.Azure.WebJobs.Host.Bindings.SystemBindingData.#DateTime")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Scope = "member", Target = "Microsoft.Azure.WebJobs.Host.Bindings.SystemBindingData.#Guid")]

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Bindings/Path/BindingParameterResolverTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Bindings/Path/BindingParameterResolverTests.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Bindings.Path
     {
         [Theory]
         [InlineData("rand-guid", true)]
+        [InlineData("guid", true)]
         [InlineData("RAND-GUID", true)]
         [InlineData("datetime", true)]
         [InlineData("foobar", false)]
@@ -43,6 +44,35 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Bindings.Path
             Assert.Equal(0, resolvedValue.Count(p => p == '-'));
 
             resolvedValue = resolver.Resolve("rand-guid:B");
+            Assert.Equal(38, resolvedValue.Length);
+            Assert.Equal(4, resolvedValue.Count(p => p == '-'));
+            Assert.True(resolvedValue.StartsWith("{"));
+            Assert.True(resolvedValue.EndsWith("}"));
+        }
+
+        [Fact]
+        public void GuidResolver_ReturnsExpectedValue()
+        {
+            BindingParameterResolver resolver = null;
+            BindingParameterResolver.TryGetResolver("guid", out resolver);
+
+            string resolvedValue = resolver.Resolve("guid");
+            Assert.Equal(36, resolvedValue.Length);
+            Assert.Equal(4, resolvedValue.Count(p => p == '-'));
+
+            resolvedValue = resolver.Resolve("guid:");  // no format
+            Assert.Equal(36, resolvedValue.Length);
+            Assert.Equal(4, resolvedValue.Count(p => p == '-'));
+
+            resolvedValue = resolver.Resolve("guid:D");
+            Assert.Equal(36, resolvedValue.Length);
+            Assert.Equal(4, resolvedValue.Count(p => p == '-'));
+
+            resolvedValue = resolver.Resolve("guid:N");
+            Assert.Equal(32, resolvedValue.Length);
+            Assert.Equal(0, resolvedValue.Count(p => p == '-'));
+
+            resolvedValue = resolver.Resolve("guid:B");
             Assert.Equal(38, resolvedValue.Length);
             Assert.Equal(4, resolvedValue.Count(p => p == '-'));
             Assert.True(resolvedValue.StartsWith("{"));

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Bindings/Path/BindingTemplateTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Bindings/Path/BindingTemplateTests.cs
@@ -334,7 +334,6 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Bindings.Path
 
             foreach (var format in new string[] { "N", "D", "B", "P", "X", "" })
             {
-
                 BindingTemplate template = BindingTemplate.FromString(@"{g:" + format + "}");       
 
                 string expected = g.ToString(format, CultureInfo.InvariantCulture);
@@ -352,7 +351,6 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Bindings.Path
                 {
                     { "dt",dt }
                 };
-
 
             var format = "YYYYMMdd";
             BindingTemplate template = BindingTemplate.FromString(@"{dt:" + format + "}");


### PR DESCRIPTION
A few proposed SystemBindingData renames. These renames change end user expressions to:

- `{sys.guid}`
- `{sys.datetime}`

This makes things consistent with the existing legacy built-ins supported:

- `{datetime}`
- `{guid}`  ** this one is new ***
- `{rand-guid}`