### PR TITLE
Fix batchCheckpointFrequency setter

### DIFF
--- a/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubConfiguration.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubConfiguration.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
                 {
                     throw new InvalidOperationException("Batch checkpoint frequency must be larger than 0.");
                 }
-                BatchCheckpointFrequency = value;
+                _batchCheckpointFrequency = value;
             }
         }
 

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/EventHubTests.cs
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/EventHubTests.cs
@@ -180,5 +180,25 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests
             string actual = EventHubConfiguration.GetBlobPrefix(eventHubName, serviceBusNamespace);
             Assert.Equal(expected, actual);
         }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(5)]
+        [InlineData(200)]
+        public void EventHubBatchCheckpointFrequency(int num)
+        {
+            var config = new EventHubConfiguration();
+            config.BatchCheckpointFrequency = num;
+            Assert.Equal(num, config.BatchCheckpointFrequency);
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        public void EventHubBatchCheckpointFrequency_Throws(int num)
+        {
+            var config = new EventHubConfiguration();
+            Assert.Throws<InvalidOperationException>(() => config.BatchCheckpointFrequency = num);
+        }
     }
 }


### PR DESCRIPTION
This typo causes a stack overflow due to setter recursion.

I don't think we need to prioritize a release with the fix, only those using this setting & webjobs nightly builds could be impacted.