### PR TITLE
temporarily removing LoggerFactory.Dispose()

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostContext.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostContext.cs
@@ -96,7 +96,6 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             if (!_disposed)
             {
                 _listener.Dispose();
-                _loggerFactory?.Dispose();
 
                 _disposed = true;
             }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostContextTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostContextTests.cs
@@ -43,7 +43,10 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             context.Dispose();
 
             mockListener.Verify(p => p.Dispose(), Times.Once);
-            mockLoggerFactory.Verify(p => p.Dispose(), Times.Once);
+
+            // we're temporarily removing the disposal call until this issue is resolved:
+            // https://github.com/Azure/azure-webjobs-sdk-script/issues/1537
+            mockLoggerFactory.Verify(p => p.Dispose(), Times.Never);
         }
     }
 }


### PR DESCRIPTION
Due to https://github.com/Azure/azure-webjobs-sdk-script/issues/1537, I'm temporarily removing the call to `Dispose()` as it can cause functions to error that haven't in the past. The real fix will be larger and take more time.