### PR TITLE
Improve doccomments for "connection" property.

### DIFF
--- a/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubAttribute.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         public string EventHubName { get; private set; }
 
         /// <summary>
-        /// Optional connection name. If missing, tries to use a registered event hub sender.
+        /// Gets or sets the optional app setting name that contains the Event Hub connection string. If missing, tries to use a registered event hub sender.
         /// </summary>
         [AppSetting]
         public string Connection { get; set; }

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubTriggerAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubTriggerAttribute.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         public string ConsumerGroup { get; set; }
 
         /// <summary>
-        /// Optional connection name. If missing, tries to use a registered event hub receiver.
+        /// Gets or sets the optional app setting name that contains the Event Hub connection string. If missing, tries to use a registered event hub receiver.
         /// </summary>
         [AppSetting]
         public string Connection { get; set; }

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/ServiceBusAccountAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/ServiceBusAccountAttribute.cs
@@ -33,11 +33,13 @@ namespace Microsoft.Azure.WebJobs
         }
 
         /// <summary>
-        /// Gets the name of the ServiceBus connection string to use.
+        /// Gets or sets the name of the app setting that contains the Service Bus connection string.
         /// </summary>
         public string Account { get; private set; }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Gets or sets the app setting name that contains the Service Bus connection string.
+        /// </summary>
         string IConnectionProvider.Connection
         {
             get

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/ServiceBusAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/ServiceBusAttribute.cs
@@ -57,7 +57,9 @@ namespace Microsoft.Azure.WebJobs
         /// </summary>
         public string QueueOrTopicName { get; private set; }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Gets or sets the app setting name that contains the Service Bus connection string.
+        /// </summary>
         public string Connection { get; set; }
 
         /// <summary>

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/ServiceBusTriggerAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/ServiceBusTriggerAttribute.cs
@@ -77,7 +77,9 @@ namespace Microsoft.Azure.WebJobs
             Access = access;
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Gets or sets the app setting name that contains the Service Bus connection string.
+        /// </summary>
         public string Connection { get; set; }
 
         /// <summary>

--- a/src/Microsoft.Azure.WebJobs/BlobAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs/BlobAttribute.cs
@@ -90,7 +90,9 @@ namespace Microsoft.Azure.WebJobs
             get { return _access; }
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Gets or sets the app setting name that contains the Azure Storage connection string.
+        /// </summary>
         public string Connection { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs/BlobTriggerAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs/BlobTriggerAttribute.cs
@@ -46,7 +46,9 @@ namespace Microsoft.Azure.WebJobs
             _blobPath = blobPath;
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Gets or sets the app setting name that contains the Azure Storage connection string.
+        /// </summary>
         public string Connection { get; set; }
 
         /// <summary>Gets the path of the blob to which to bind.</summary>

--- a/src/Microsoft.Azure.WebJobs/IConnectionProvider.cs
+++ b/src/Microsoft.Azure.WebJobs/IConnectionProvider.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.WebJobs
     public interface IConnectionProvider
     {
         /// <summary>
-        /// Gets the name of the connection string to use.
+        /// Gets or sets the app setting name that contains the connection string.
         /// </summary>
         string Connection { get; set; }
     }

--- a/src/Microsoft.Azure.WebJobs/QueueAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs/QueueAttribute.cs
@@ -47,7 +47,9 @@ namespace Microsoft.Azure.WebJobs
             get { return _queueName; }
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Gets or sets the app setting name that contains the Azure Storage connection string.
+        /// </summary>
         public string Connection { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs/QueueTriggerAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs/QueueTriggerAttribute.cs
@@ -41,7 +41,9 @@ namespace Microsoft.Azure.WebJobs
             get { return _queueName; }
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Gets or sets the app setting name that contains the Azure Storage connection string.
+        /// </summary>
         public string Connection { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs/StorageAccountAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs/StorageAccountAttribute.cs
@@ -33,11 +33,13 @@ namespace Microsoft.Azure.WebJobs
         }
 
         /// <summary>
-        /// Gets the name of the Azure Storage connection string to use.
+        /// Gets or sets the app setting name that contains the Azure Storage connection string.
         /// </summary>
         public string Account { get; private set; }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Gets or sets the app setting name that contains the Azure Storage connection string.
+        /// </summary>
         string IConnectionProvider.Connection
         {
             get

--- a/src/Microsoft.Azure.WebJobs/TableAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs/TableAttribute.cs
@@ -125,7 +125,9 @@ namespace Microsoft.Azure.WebJobs
             }
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Gets or sets the app setting name that contains the Azure Storage connection string.
+        /// </summary>
         public string Connection { get; set; }
     }
 }


### PR DESCRIPTION
Customers often try to put in a connection string for the "connection" property and then get a poor error message. Maybe a better doccomment will help.

I removed use of "inheritdoc" since Visual Studio does not honor it when generating intellisense files. I found an old UserVoice suggestion from 2013 asking for this feature, so I'm going to assume it's not happening anytime soon: [Add IntelliSense support for the <inheritdoc /> tag in XML documentation comments](https://visualstudio.uservoice.com/forums/121579-visual-studio-ide/suggestions/3745102-add-intellisense-support-for-the-inheritdoc-ta).