### PR TITLE
Add link to GitHub repo releases page to nuspec Release Notes

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Core.NuGet/WebJobs.Core.nuspec
+++ b/src/Microsoft.Azure.WebJobs.Core.NuGet/WebJobs.Core.nuspec
@@ -8,6 +8,7 @@
     <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>
     <summary>Microsoft.Azure.WebJobs is a library for writing WebJobs in Microsoft Azure. This package contains the runtime assemblies for Microsoft.Azure.WebJobs.</summary>
     <description>This library simplifies the task of adding background processing to your Microsoft Azure Web Sites. The SDK uses Microsoft Azure Storage, triggering a function in your program when items are added to Queues and Blobs. A dashboard provides rich monitoring and diagnostics for the programs that you write by using the SDK. For more information, please visit http://go.microsoft.com/fwlink/?LinkID=320971</description>
+    <releaseNotes>Release Notes: https://github.com/Azure/azure-webjobs-sdk/releases</releaseNotes>
     <language>en-US</language>
     <projectUrl>http://go.microsoft.com/fwlink/?LinkID=320972</projectUrl>
     <licenseUrl>$PackageEULA$</licenseUrl>

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights.NuGet/WebJobs.Logging.ApplicationInsights.nuspec
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights.NuGet/WebJobs.Logging.ApplicationInsights.nuspec
@@ -8,6 +8,7 @@
     <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>
     <summary>Microsoft.Azure.WebJobs.Logging.ApplicationInsights is a library for writing WebJobs logs with ILogger and Application Insights.</summary>
     <description>This package contains the runtime assemblies for Microsoft.Azure.WebJobs.Logging.ApplicationInsights. For more information, please visit http://go.microsoft.com/fwlink/?LinkID=320971</description>
+    <releaseNotes>Release Notes: https://github.com/Azure/azure-webjobs-sdk/releases</releaseNotes>
     <language>en-US</language>
     <projectUrl>http://go.microsoft.com/fwlink/?LinkID=320972</projectUrl>
     <licenseUrl>$PackageEULA$</licenseUrl>

--- a/src/Microsoft.Azure.WebJobs.Logging.NuGet/WebJobs.Logging.nuspec
+++ b/src/Microsoft.Azure.WebJobs.Logging.NuGet/WebJobs.Logging.nuspec
@@ -8,6 +8,7 @@
     <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>
     <summary>Microsoft.Azure.WebJobs.Logging is a library for writing Microsoft Azure WebJobs Logs.</summary>
     <description>This package contains the runtime assemblies for Microsoft.Azure.WebJobs.Logging. For more information, please visit http://go.microsoft.com/fwlink/?LinkID=320971</description>
+    <releaseNotes>Release Notes: https://github.com/Azure/azure-webjobs-sdk/releases</releaseNotes>
     <language>en-US</language>
     <projectUrl>http://go.microsoft.com/fwlink/?LinkID=320972</projectUrl>
     <licenseUrl>$PackageEULA$</licenseUrl>

--- a/src/Microsoft.Azure.WebJobs.NuGet/WebJobs.nuspec
+++ b/src/Microsoft.Azure.WebJobs.NuGet/WebJobs.nuspec
@@ -8,6 +8,7 @@
     <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>
     <summary>Microsoft.Azure.WebJobs.Host is a library for writing WebJobs in Microsoft Azure. The host is a container where all the functions in your program can execute. This package contains the runtime assemblies for Microsoft.Azure.WebJobs.Host.</summary>
     <description>This package contains the runtime assemblies for Microsoft.Azure.WebJobs.Host. It also adds rich diagnostics capabilities which makes it easier to monitor the WebJobs in the dashboard. For more information, please visit http://go.microsoft.com/fwlink/?LinkID=320971</description>
+    <releaseNotes>Release Notes: https://github.com/Azure/azure-webjobs-sdk/releases</releaseNotes>
     <language>en-US</language>
     <projectUrl>http://go.microsoft.com/fwlink/?LinkID=320972</projectUrl>
     <licenseUrl>$PackageEULA$</licenseUrl>

--- a/src/Microsoft.Azure.WebJobs.ServiceBus.NuGet/WebJobs.ServiceBus.nuspec
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus.NuGet/WebJobs.ServiceBus.nuspec
@@ -8,6 +8,7 @@
     <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>
     <summary>Microsoft.Azure.WebJobs.ServiceBus is a library for writing Microsoft Azure WebJobs using Service Bus. This package contains the runtime assemblies for Microsoft.Azure.WebJobs.ServiceBus.</summary>
     <description>This package contains the runtime assemblies for Microsoft.Azure.WebJobs.ServiceBus. For more information, please visit http://go.microsoft.com/fwlink/?LinkID=320971</description>
+    <releaseNotes>Release Notes: https://github.com/Azure/azure-webjobs-sdk/releases</releaseNotes>
     <language>en-US</language>
     <projectUrl>http://go.microsoft.com/fwlink/?LinkID=320972</projectUrl>
     <licenseUrl>$PackageEULA$</licenseUrl>

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon.NuGet/WebJobs.Host.TestCommon.nuspec
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon.NuGet/WebJobs.Host.TestCommon.nuspec
@@ -8,6 +8,7 @@
     <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>
     <summary>Microsoft.Azure.WebJobs.Host.TestCommon is a test library for writing WebJobs in Microsoft Azure.</summary>
     <description>Microsoft.Azure.WebJobs.Host.TestCommon is a test library for writing WebJobs in Microsoft Azure.</description>
+    <releaseNotes>Release Notes: https://github.com/Azure/azure-webjobs-sdk/releases</releaseNotes>
     <language>en-US</language>
     <projectUrl>http://go.microsoft.com/fwlink/?LinkID=320972</projectUrl>
     <licenseUrl>$PackageEULA$</licenseUrl>


### PR DESCRIPTION
Added link to this repo's releases page as this is where we're adding release notes and it takes unnecessary searching to find them from the NuGet page