### PR TITLE
Storage account caching and validation fix

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Queues/Bindings/QueueBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Queues/Bindings/QueueBindingProvider.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Bindings
 
             internal IStorageQueue GetQueue(QueueAttribute attrResolved)
             {
-                var account = Task.Run(() => this._accountProvider.GetStorageAccountAsync(attrResolved, CancellationToken.None)).GetAwaiter().GetResult();
+                var account = Task.Run(() => _accountProvider.GetStorageAccountAsync(attrResolved, CancellationToken.None)).GetAwaiter().GetResult();
                 var client = account.CreateQueueClient();
 
                 string queueName = attrResolved.QueueName.ToLowerInvariant();


### PR DESCRIPTION
Improvement for connection exhaustion.

For non storage/dashboard accounts, we were running the validation calls (blob endpoint & queue endpoint http calls) every time we called `TryGetAccountAsync`