### PR TITLE
fixing queue visibility renewals

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Queues/QueueProcessor.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Queues/QueueProcessor.cs
@@ -110,11 +110,6 @@ namespace Microsoft.Azure.WebJobs.Host.Queues
         /// <returns></returns>
         public virtual async Task CompleteProcessingMessageAsync(CloudQueueMessage message, FunctionResult result, CancellationToken cancellationToken)
         {
-            // These values may change if the message is inserted into another queue. We'll store them here and make sure
-            // the message always has the original values before we pass it to a customer-facing method.
-            string id = message.Id;
-            string popReceipt = message.PopReceipt;
-
             if (result.Succeeded)
             {
                 await DeleteMessageAsync(message, cancellationToken);
@@ -123,6 +118,11 @@ namespace Microsoft.Azure.WebJobs.Host.Queues
             {
                 if (message.DequeueCount >= MaxDequeueCount)
                 {
+                    // These values may change if the message is inserted into another queue. We'll store them here and make sure
+                    // the message always has the original values before we pass it to a customer-facing method.
+                    string id = message.Id;
+                    string popReceipt = message.PopReceipt;
+
                     await CopyMessageToPoisonQueueAsync(message, _poisonQueue, cancellationToken);
 
                     // TEMP: Re-evaluate these property updates when we update Storage SDK: https://github.com/Azure/azure-webjobs-sdk/issues/1144


### PR DESCRIPTION
Reducing the number of places that we do our property updates to get 8.x working. I missed a scenario where we do a background message update, which changes the pop receipt. That caused future deletes to break.

Instead, taking @mathewc's advice and reducing the number of places we replace -- ensuring that the common scenario of poison-queue-handling works in 8.x as expected. If you are adding existing messages to queues from within your function in 8.x, we'll no longer be able to successfully delete that message, but that is manageable for the end-user.