### PR TITLE
re-adding LoggerFactory disposal

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostContext.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostContext.cs
@@ -96,6 +96,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             if (!_disposed)
             {
                 _listener.Dispose();
+                _loggerFactory?.Dispose();
 
                 _disposed = true;
             }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostContextTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostContextTests.cs
@@ -43,10 +43,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             context.Dispose();
 
             mockListener.Verify(p => p.Dispose(), Times.Once);
-
-            // we're temporarily removing the disposal call until this issue is resolved:
-            // https://github.com/Azure/azure-webjobs-sdk-script/issues/1537
-            mockLoggerFactory.Verify(p => p.Dispose(), Times.Never);
+            mockLoggerFactory.Verify(p => p.Dispose(), Times.Once);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-webjobs-sdk-script/issues/1606
Note -- we can re-enable this b/c https://github.com/Azure/azure-webjobs-sdk-script/issues/1537 has been fixed.