### PR TITLE
Add a pre-bind logging instrumentation end point.

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/FunctionInstanceLogEntry.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/FunctionInstanceLogEntry.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using Newtonsoft.Json;
 
 namespace Microsoft.Azure.WebJobs.Host.Loggers
 {
@@ -49,12 +51,41 @@ namespace Microsoft.Azure.WebJobs.Host.Loggers
         /// </summary>
         public string ErrorDetails { get; set; }
 
-        /// <summary>Gets or sets the function's argument values and help strings.</summary>        
+        /// <summary>Gets or sets the function's argument values and help strings.
+        /// If this is null, then the event is before binding. </summary>        
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
         public IDictionary<string, string> Arguments { get; set; }
 
         /// <summary>Direct inline capture for output written to the per-function instance TextWriter log. 
         /// For large log outputs, this is truncated</summary>
         public string LogOutput { get; set; }
+
+        /// <summary>
+        /// in-memory Property bag that lives for the lifetime of the item. 
+        /// This can be used to help the caller correlate data at various phases. 
+        /// </summary>
+        [JsonIgnore]
+        public IDictionary<string, object> Properties { get; set; }
+
+        /// <summary>
+        /// An in-memory timer to measure the duration during execution. Use <see cref="Duration"/> for persisted cases.
+        /// </summary>
+        [JsonIgnore]
+        public Stopwatch LiveTimer { get; set; }
+
+        /// <summary>
+        /// Function has just started. This is before arguments are bound. 
+        /// </summary>
+        public bool IsStart => this.Arguments == null;
+
+        /// <summary>
+        /// Function has bound the arguments but the the body is not yet invoked. 
+        /// </summary>
+        public bool IsPostBind => !this.EndTime.HasValue && this.Arguments != null;
+
+        /// <summary>
+        /// Function has completed and run body. See <see cref="ErrorDetails"/> to determine if this was success of failure. 
+        /// </summary>
+        public bool IsCompleted => this.EndTime.HasValue;
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/FunctionInstanceLogEntry.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/FunctionInstanceLogEntry.cs
@@ -76,12 +76,12 @@ namespace Microsoft.Azure.WebJobs.Host.Loggers
         /// <summary>
         /// Function has just started. This is before arguments are bound. 
         /// </summary>
-        public bool IsStart => this.Arguments == null;
+        public bool IsStart => !IsCompleted && this.Arguments == null;
 
         /// <summary>
         /// Function has bound the arguments but the the body is not yet invoked. 
         /// </summary>
-        public bool IsPostBind => !this.EndTime.HasValue && this.Arguments != null;
+        public bool IsPostBind => !IsCompleted && this.Arguments != null;
 
         /// <summary>
         /// Function has completed and run body. See <see cref="ErrorDetails"/> to determine if this was success of failure. 

--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/Aggregator/FunctionResultAggregator.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/Aggregator/FunctionResultAggregator.cs
@@ -91,8 +91,8 @@ namespace Microsoft.Azure.WebJobs.Logging
 
         public async Task AddAsync(FunctionInstanceLogEntry result, CancellationToken cancellationToken = default(CancellationToken))
         {
-            // We'll get 'Function started' events here, which we don't care about.
-            if (result.EndTime != null)
+            // We only care about completed events.
+            if (result.IsCompleted)
             {
                 await _buffer.SendAsync(result, cancellationToken);
             }

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/ILoggerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/ILoggerTests.cs
@@ -90,7 +90,13 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
             var mockAggregator = new Mock<IAsyncCollector<FunctionInstanceLogEntry>>(MockBehavior.Strict);
             mockAggregator
                 .Setup(a => a.AddAsync(It.IsAny<FunctionInstanceLogEntry>(), It.IsAny<CancellationToken>()))
-                .Callback<FunctionInstanceLogEntry, CancellationToken>((l, t) => addCalls++)
+                .Callback<FunctionInstanceLogEntry, CancellationToken>((l, t) =>
+                {
+                    if (l.IsCompleted)
+                    {
+                        addCalls++; // The default aggregator will ingore the 'Function started' calls.
+                    }
+                })
                 .Returns(Task.CompletedTask);
             mockAggregator
                 .Setup(a => a.FlushAsync(It.IsAny<CancellationToken>()))
@@ -124,7 +130,7 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
 
             // Add will be called 5 times. The default aggregator will ingore the 
             // 'Function started' calls.
-            Assert.Equal(10, addCalls);
+            Assert.Equal(5, addCalls);
 
             // Flush is called on host stop
             Assert.Equal(1, flushCalls);

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/ILoggerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/ILoggerTests.cs
@@ -110,8 +110,9 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
 
             config.AddService<IFunctionResultAggregatorFactory>(mockFactory.Object);
 
+            const int N = 5;
             config.Aggregator.IsEnabled = true;
-            config.Aggregator.BatchSize = 5;
+            config.Aggregator.BatchSize = N;
             config.Aggregator.FlushTimeout = TimeSpan.FromSeconds(1);
 
             using (JobHost host = new JobHost(config))
@@ -120,7 +121,7 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
 
                 var method = typeof(ILoggerFunctions).GetMethod(nameof(ILoggerFunctions.TraceWriterWithILoggerFactory));
 
-                for (int i = 0; i < 5; i++)
+                for (int i = 0; i < N; i++)
                 {
                     host.Call(method);
                 }
@@ -128,9 +129,7 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
                 host.Stop();
             }
 
-            // Add will be called 5 times. The default aggregator will ingore the 
-            // 'Function started' calls.
-            Assert.Equal(5, addCalls);
+            Assert.Equal(N, addCalls);
 
             // Flush is called on host stop
             Assert.Equal(1, flushCalls);

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/TestHelpers.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/TestHelpers.cs
@@ -129,6 +129,7 @@ namespace Microsoft.Azure.WebJobs.Host.TestCommon
             IExtensionRegistry extensions = config.GetService<IExtensionRegistry>();
 
             var types = new Type[] {
+                typeof(IAsyncCollector<FunctionInstanceLogEntry>),
                 typeof(IHostInstanceLoggerProvider),
                 typeof(IFunctionInstanceLoggerProvider),
                 typeof(IFunctionOutputLoggerProvider),

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostConfigurationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostConfigurationTests.cs
@@ -343,15 +343,19 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
 
             public Task AddAsync(FunctionInstanceLogEntry item, CancellationToken cancellationToken = default(CancellationToken))
             {
+                if (item.Arguments == null)
+                {
+                    return Task.CompletedTask;
+                }
                 var clone = JsonConvert.DeserializeObject<FunctionInstanceLogEntry>(JsonConvert.SerializeObject(item));
                 List.Add(clone);
-                return Task.FromResult(0);
+                return Task.CompletedTask;
             }
 
             public Task FlushAsync(CancellationToken cancellationToken = default(CancellationToken))
             {
                 List.Add(FlushEntry);
-                return Task.FromResult(0);
+                return Task.CompletedTask;
             }
         }
 

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/FunctionExecutorLogOrdering.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/FunctionExecutorLogOrdering.cs
@@ -1,0 +1,161 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Description;
+using Microsoft.Azure.WebJobs.Host.Config;
+using Microsoft.Azure.WebJobs.Host.Loggers;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
+{
+    // Test that FunctionExecutor emits logs in the right order
+    public class FunctionExecutorLogOrdering
+    {
+        public const string PreBindLog = "[Start]";
+        public const string ParamLog = "[Param]";
+        public const string ParamFailLog = "[ParamFail]"; // parameter binding failed
+        public const string PostBindLog = "[PostBind]";
+        public const string BodyLog = "Body";
+        public const string BodyFailLog = "[BodyFail]";
+        public const string CompletedLog = "[Done]";
+        public const string CompletedFailLog = "[DoneFail]";
+
+        // Test that instrumentation points are emitted in the right order.
+        [Fact]
+        public void TestSuccess()
+        {
+            var logger = new MyLogger();
+            var host = TestHelpers.NewJobHost<MyProg>(logger, new TestExt());
+            host.Call("test");
+
+            Assert.Equal(PreBindLog + ParamLog + PostBindLog + BodyLog + CompletedLog, logger._log.ToString());
+        }
+
+        [Fact]
+        public void TestWithFailParam()
+        {
+            var logger = new MyLogger();
+            var host = TestHelpers.NewJobHost<MyProg>(logger, new TestExt());
+
+            Assert.Throws<FunctionInvocationException>(() => host.Call("testFailParam"));
+
+            Assert.Equal(PreBindLog + ParamFailLog + PostBindLog + CompletedFailLog, logger._log.ToString());
+        }
+
+        [Fact]
+        public void TestWithFailBody()
+        {
+            var logger = new MyLogger();
+            var host = TestHelpers.NewJobHost<MyProg>(logger, new TestExt());
+            Assert.Throws<FunctionInvocationException>(() => host.Call("testFailBody"));
+
+            Assert.Equal(PreBindLog + ParamLog + PostBindLog + BodyFailLog + CompletedFailLog, logger._log.ToString());
+        }
+
+        public class MyLogger : IAsyncCollector<FunctionInstanceLogEntry>
+        {
+            public StringBuilder _log = new StringBuilder();
+
+            string key = "k1";
+
+            public Task AddAsync(FunctionInstanceLogEntry item, CancellationToken cancellationToken = default(CancellationToken))
+            {
+                if (item.IsStart)
+                {
+                    Assert.Null(item.EndTime);
+                    _log.Append(PreBindLog);
+
+                    Assert.False(item.Properties.ContainsKey(key));
+                    item.Properties[key] = 1;
+                }
+                else
+                {
+                    if (item.IsPostBind)
+                    {
+                        var x = (int) item.Properties[key];
+                        Assert.Equal(1, x); // Verify state is carried over
+
+                        // this is still called in failure case; but hte Error message may not be set yet until the complete event. 
+                        Assert.Null(item.ErrorDetails); 
+
+                        _log.Append(PostBindLog);
+                    }
+                    else
+                    {
+                        Assert.True(item.IsCompleted);
+
+                        var x = (int)item.Properties[key];
+                        Assert.Equal(1, x); // Verify state is carried over
+
+                        if (item.ErrorDetails == null)
+                        {
+                            _log.Append(CompletedLog);
+                        }
+                        else
+                        {
+                            _log.Append(CompletedFailLog);
+                        }
+                    }
+                }
+
+                return Task.CompletedTask;
+            }
+
+            public Task FlushAsync(CancellationToken cancellationToken = default(CancellationToken))
+            {
+                return Task.CompletedTask;
+            }
+        }
+
+        [Binding]
+        public class LoggerTestAttribute : Attribute {
+            public bool Fail { get; set; }
+        }
+
+        public class TestExt : IExtensionConfigProvider
+        {
+            public void Initialize(ExtensionConfigContext context)
+            {
+                var logger = (MyLogger)context.Config.GetService<IAsyncCollector<FunctionInstanceLogEntry>>();
+                context.AddBindingRule<LoggerTestAttribute>().BindToInput(attr =>
+                {
+                    if (attr.Fail)
+                    {
+                        logger._log.Append(ParamFailLog);
+                        throw new InvalidOperationException("Paramter binding fored failure");
+                    }
+                    logger._log.Append(ParamLog);
+                    return logger;
+                });
+            }
+        }
+
+
+        public class MyProg
+        {
+            [NoAutomaticTrigger]
+            public void test([LoggerTest] MyLogger logger )
+            {
+                logger._log.Append(BodyLog);
+            }
+
+            [NoAutomaticTrigger]
+            public void testFailParam([LoggerTest(Fail = true)] MyLogger logger)
+            {
+                logger._log.Append(BodyLog); // Should never get called. 
+            }
+
+            [NoAutomaticTrigger]
+            public void testFailBody([LoggerTest] MyLogger logger)
+            {
+                logger._log.Append(BodyFailLog);
+                throw new InvalidOperationException(BodyFailLog);
+            }
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
@@ -260,6 +260,7 @@
     <Compile Include="Executors\TriggeredFunctionExecutorTests.cs" />
     <Compile Include="ExtensionConfigContextTests.cs" />
     <Compile Include="Loggers\ApplicationInsightsLoggerProviderTests.cs" />
+    <Compile Include="Loggers\FunctionExecutorLogOrdering.cs" />
     <Compile Include="Loggers\DefaultTelemetryClientFactoryTests.cs" />
     <Compile Include="Loggers\FilteringTelemetryProcessorTests.cs" />
     <Compile Include="Loggers\FunctionResultAggregatorConfigurationTests.cs" />


### PR DESCRIPTION
Add an aggressive unit test to verify ordering, including in failure situations.
This is SDK support for Script bug (https://github.com/Azure/azure-webjobs-sdk-script/issues/578 , PR  https://github.com/Azure/azure-webjobs-sdk-script/pull/1660 ) , which will consume the event. 