### PR TITLE
Return value support for BYOB

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionExecutor.cs
@@ -13,6 +13,7 @@ using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Azure.WebJobs.Host.Indexers;
 using Microsoft.Azure.WebJobs.Host.Loggers;
 using Microsoft.Azure.WebJobs.Host.Protocols;
 using Microsoft.Azure.WebJobs.Host.Timers;
@@ -537,7 +538,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             //      b. If !throwOnTimeout, wait for the task to complete.
 
             // Start the invokeTask.
-            Task invokeTask = invoker.InvokeAsync(invokeParameters);
+            Task<object> invokeTask = invoker.InvokeAsync(invokeParameters);
 
             // Combine #1 and #2 with a timeout task (handled by this method).
             // functionCancellationTokenSource.Token is passed to each function that requests it, so we need to call Cancel() on it
@@ -551,7 +552,9 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
                 await TryHandleTimeoutAsync(invokeTask, CancellationToken.None, throwOnTimeout, timeoutTokenSource.Token, timerInterval, instance, null);
             }
 
-            await invokeTask;
+            object returnValue = await invokeTask;
+
+            parameterHelper.SetReturnValue(returnValue);
         }
 
         /// <summary>
@@ -724,10 +727,15 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             private IReadOnlyDictionary<string, IWatcher> _parameterWatchers;
 
             // ValueProviders for the parameters. These are produced from binding. 
+            // This includes a possible $return for the return value. 
             private IReadOnlyDictionary<string, IValueProvider> _parameters;
 
             // ordered parameter names of the underlying physical MethodInfo that will be invoked. 
-            private IReadOnlyList<string> _parameterNames;             
+            // This litererally matches the ParameterInfo[] and does not include return value. 
+            private IReadOnlyList<string> _parameterNames;
+
+            // the return value of the function
+            private object _returnValue;
 
             public ParameterHelper(IReadOnlyList<string> parameterNames)
             {
@@ -739,7 +747,9 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             public object[] InvokeParameters { get; internal set; }
 
             public IDictionary<string, ParameterLog> ParameterLogCollector => _parameterLogCollector;
-                        
+
+            public object ReturnValue => _returnValue;
+
             public IReadOnlyDictionary<string, IWatcher> CreateParameterWatchers()
             {
                 if (_parameterWatchers != null)
@@ -872,7 +882,8 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
 
                     if (binder != null)
                     {
-                        object argument = this.InvokeParameters[this.GetParameterIndex(name)];
+                        bool isReturn = name == FunctionIndexer.ReturnParamName;                        
+                        object argument = isReturn ? this._returnValue : this.InvokeParameters[this.GetParameterIndex(name)];
 
                         try
                         {
@@ -928,6 +939,11 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
 
                 Array.Sort(parameterValues, parameterNames, ValueBinderStepOrderComparer.Instance);
                 return parameterNames;
+            }
+
+            internal void SetReturnValue(object returnValue)
+            {
+                _returnValue = returnValue;
             }
 
             // IDisposable on any of the IValueProviders in our parameter list.             

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionInstanceFactoryContext.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionInstanceFactoryContext.cs
@@ -14,6 +14,6 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
         public Guid? ParentId { get; set; }
         public ExecutionReason ExecutionReason { get; set; }
         public IDictionary<string, object> Parameters { get; set; }
-        public Func<Func<Task>, Task> InvokeHandler { get; set; }
+        public Func<Func<Task<object>>, Task<object>> InvokeHandler { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionInvoker.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionInvoker.cs
@@ -7,14 +7,16 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Azure.WebJobs.Host.Executors
 {
-    internal class FunctionInvoker<TReflected> : IFunctionInvoker
+    internal class FunctionInvoker<TReflected, TReturnValue> : IFunctionInvoker
     {
         private readonly IReadOnlyList<string> _parameterNames;
         private readonly IFactory<TReflected> _instanceFactory;
-        private readonly IMethodInvoker<TReflected> _methodInvoker;
+        private readonly IMethodInvoker<TReflected, TReturnValue> _methodInvoker;
 
-        public FunctionInvoker(IReadOnlyList<string> parameterNames, IFactory<TReflected> instanceFactory,
-            IMethodInvoker<TReflected> methodInvoker)
+        public FunctionInvoker(
+            IReadOnlyList<string> parameterNames,
+            IFactory<TReflected> instanceFactory,
+            IMethodInvoker<TReflected, TReturnValue> methodInvoker)
         {
             if (parameterNames == null)
             {
@@ -46,7 +48,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             get { return _parameterNames; }
         }
 
-        public async Task InvokeAsync(object[] arguments)
+        public async Task<object> InvokeAsync(object[] arguments)
         {
             // Return a task immediately in case the method is not async.
             await Task.Yield();
@@ -55,7 +57,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
 
             using (instance as IDisposable)
             {
-                await _methodInvoker.InvokeAsync(instance, arguments);
+                return await _methodInvoker.InvokeAsync(instance, arguments);
             }
         }
     }

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/IFunctionInvoker.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/IFunctionInvoker.cs
@@ -11,6 +11,6 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
         IReadOnlyList<string> ParameterNames { get; }
 
         // The cancellation token, if any, is provided along with the other arguments.
-        Task InvokeAsync(object[] arguments);
+        Task<object> InvokeAsync(object[] arguments);
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/IMethodInvoker.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/IMethodInvoker.cs
@@ -5,9 +5,9 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Azure.WebJobs.Host.Executors
 {
-    internal interface IMethodInvoker<TReflected>
+    internal interface IMethodInvoker<TReflected, TReturnValue>
     {
         // The cancellation token, if any, is provided along with the other arguments.
-        Task InvokeAsync(TReflected instance, object[] arguments);
+        Task<TReturnValue> InvokeAsync(TReflected instance, object[] arguments);
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostConfigurationExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostConfigurationExtensions.cs
@@ -257,7 +257,16 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
 
                 if (functionIndexProvider == null)
                 {
-                    functionIndexProvider = new FunctionIndexProvider(services.GetService<ITypeLocator>(), triggerBindingProvider, bindingProvider, activator, functionExecutor, extensions, singletonManager, trace, loggerFactory);
+                    functionIndexProvider = new FunctionIndexProvider(
+                        services.GetService<ITypeLocator>(),
+                        triggerBindingProvider,
+                        bindingProvider,
+                        activator,
+                        functionExecutor,
+                        extensions,
+                        singletonManager,
+                        trace,
+                        loggerFactory);
 
                     // Important to set this so that the func we passed to DynamicHostIdProvider can pick it up. 
                     services.AddService<IFunctionIndexProvider>(functionIndexProvider);

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/MethodInvokerWithReturnValue.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/MethodInvokerWithReturnValue.cs
@@ -6,19 +6,19 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Azure.WebJobs.Host.Executors
 {
-    internal class VoidMethodInvoker<TReflected, TReturnValue> : IMethodInvoker<TReflected, TReturnValue>
+    internal class MethodInvokerWithReturnValue<TReflected, TReturnValue> : IMethodInvoker<TReflected, TReturnValue>
     {
-        private readonly Action<TReflected, object[]> _lambda;
+        private readonly Func<TReflected, object[], TReturnValue> _lambda;
 
-        public VoidMethodInvoker(Action<TReflected, object[]> lambda)
+        public MethodInvokerWithReturnValue(Func<TReflected, object[], TReturnValue> lambda)
         {
             _lambda = lambda;
         }
 
         public Task<TReturnValue> InvokeAsync(TReflected instance, object[] arguments)
         {
-            _lambda.Invoke(instance, arguments);
-            return Task.FromResult(default(TReturnValue));
+            TReturnValue result = _lambda.Invoke(instance, arguments);
+            return Task.FromResult(result);
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/TaskMethodInvoker.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/TaskMethodInvoker.cs
@@ -7,18 +7,18 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Azure.WebJobs.Host.Executors
 {
-    internal class TaskMethodInvoker<TReflected> : IMethodInvoker<TReflected>
+    internal class TaskMethodInvoker<TReflected, TReturnType> : IMethodInvoker<TReflected, TReturnType>
     {
-        private readonly Func<TReflected, object[], Task> _lambda;
+        private readonly Func<TReflected, object[], Task<TReturnType>> _lambda;
 
-        public TaskMethodInvoker(Func<TReflected, object[], Task> lambda)
+        public TaskMethodInvoker(Func<TReflected, object[], Task<TReturnType>> lambda)
         {
             _lambda = lambda;
         }
 
-        public Task InvokeAsync(TReflected instance, object[] arguments)
+        public Task<TReturnType> InvokeAsync(TReflected instance, object[] arguments)
         {
-            Task task = _lambda.Invoke(instance, arguments);
+            Task<TReturnType> task = _lambda.Invoke(instance, arguments);
             ThrowIfWrappedTaskInstance(task);
             return task;
         }

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/TriggeredFunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/TriggeredFunctionExecutor.cs
@@ -35,9 +35,21 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             var context = new FunctionInstanceFactoryContext<TTriggerValue>()
             {
                 TriggerValue = (TTriggerValue)input.TriggerValue,
-                ParentId = input.ParentId,
-                InvokeHandler = input.InvokeHandler
+                ParentId = input.ParentId
             };
+
+            if (input.InvokeHandler != null)
+            {
+                context.InvokeHandler = async next =>
+                {
+                    await input.InvokeHandler(next);
+
+                    // NOTE: The InvokeHandler code path currently does not support flowing the return 
+                    // value back to the trigger.
+                    return null;
+                };
+            }
+
             IFunctionInstance instance = _instanceFactory.Create(context);
             IDelayedException exception = await _executor.TryExecuteAsync(instance, cancellationToken);
 

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/VoidTaskMethodInvoker.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/VoidTaskMethodInvoker.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.WebJobs.Host.Executors
+{
+    internal class VoidTaskMethodInvoker<TReflected, TReturnType> : IMethodInvoker<TReflected, TReturnType>
+    {
+        private readonly Func<TReflected, object[], Task> _lambda;
+
+        public VoidTaskMethodInvoker(Func<TReflected, object[], Task> lambda)
+        {
+            _lambda = lambda;
+        }
+
+        public async Task<TReturnType> InvokeAsync(TReflected instance, object[] arguments)
+        {
+            await _lambda.Invoke(instance, arguments);
+            return default(TReturnType);
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexer.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexer.cs
@@ -21,6 +21,8 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
 {
     internal class FunctionIndexer
     {
+        public const string ReturnParamName = "$return";
+
         private static readonly BindingFlags PublicMethodFlags = BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance | BindingFlags.DeclaredOnly;
 
         private readonly ITriggerBindingProvider _triggerBindingProvider;
@@ -113,9 +115,14 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
             if (method.ContainsGenericParameters)
             {
                 return false;
-            }
+            }            
 
             if (method.GetCustomAttributesData().Any(HasJobAttribute))
+            {
+                return true;
+            }
+
+            if (method.ReturnParameter.GetCustomAttributesData().Any(HasJobAttribute))
             {
                 return true;
             }
@@ -173,7 +180,7 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
 
             ITriggerBinding triggerBinding = null;
             ParameterInfo triggerParameter = null;
-            ParameterInfo[] parameters = method.GetParameters();
+            IEnumerable<ParameterInfo> parameters = method.GetParameters();
 
             foreach (ParameterInfo parameter in parameters)
             {
@@ -208,6 +215,23 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
             bool hasParameterBindingAttribute = false;
             Exception invalidInvokeBindingException = null;
 
+            ReturnParameterInfo returnParameter = null;
+            bool triggerHasReturnBinding = false;
+
+            if (TypeUtility.TryGetReturnType(method, out Type methodReturnType))
+            {
+                if (bindingDataContract != null && bindingDataContract.TryGetValue(ReturnParamName, out Type triggerReturnType))
+                {
+                    // The trigger will handle the return value.
+                    triggerHasReturnBinding = true;
+                }
+                
+                // We treat binding to the return type the same as binding to an 'out T' parameter. 
+                // An explicit return binding takes precedence over an implicit trigger binding. 
+                returnParameter = new ReturnParameterInfo(method);
+                parameters = parameters.Concat(new ParameterInfo[] { returnParameter });                
+            }
+
             foreach (ParameterInfo parameter in parameters)
             {
                 if (parameter == triggerParameter)
@@ -218,6 +242,21 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
                 IBinding binding = await _bindingProvider.TryCreateAsync(new BindingProviderContext(parameter, bindingDataContract, cancellationToken));
                 if (binding == null)
                 {
+                    if (parameter == returnParameter)
+                    {
+                        if (triggerHasReturnBinding)
+                        {
+                            // Ok. Skip and let trigger own the return binding. 
+                            continue;
+                        }
+                        else
+                        {
+                            // If the method has a return value, then we must have a binding to it. 
+                            // This is similar to the error we used to throw. 
+                            invalidInvokeBindingException = new InvalidOperationException("Functions must return Task or void, have a binding attribute for the return value, or be triggered by a binding that natively supports return values.");
+                        }
+                    }
+
                     if (triggerBinding != null && !hasNoAutomaticTriggerAttribute)
                     {
                         throw new InvalidOperationException(
@@ -264,13 +303,6 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
                 string msg = $"Function '{method.Name}' is async but does not return a Task. Your function may not run correctly.";
                 _trace.Warning(msg);
                 _logger?.LogWarning(msg);
-            }
-
-            Type returnType = method.ReturnType;
-
-            if (returnType != typeof(void) && returnType != typeof(Task))
-            {
-                throw new InvalidOperationException("Functions must return Task or void.");
             }
 
             if (invalidInvokeBindingException != null)
@@ -392,6 +424,29 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
             {
                 ListenerFactoryContext context = new ListenerFactoryContext(_descriptor, _executor, cancellationToken);
                 return _binding.CreateListenerAsync(context);
+            }
+        }
+
+        // Get a ParameterInfo that represents the return type as a parameter. 
+        private class ReturnParameterInfo : ParameterInfo
+        {
+            private readonly IEnumerable<Attribute> _attributes;
+
+            public ReturnParameterInfo(MethodInfo method)
+            {
+                var retType = method.ReturnType.MakeByRefType(); // 'return T' is 'out T'
+                ClassImpl = retType;
+                AttrsImpl = ParameterAttributes.Out;
+                NameImpl = ReturnParamName;
+                MemberImpl = method;
+
+                // union all the parameter attributes
+                _attributes = method.ReturnParameter.GetCustomAttributes();
+            }
+
+            public override object[] GetCustomAttributes(Type attributeType, bool inherit)
+            {
+                return _attributes.Where(p => p.GetType() == attributeType).ToArray();
             }
         }
     }

--- a/src/Microsoft.Azure.WebJobs.Host/Triggers/TriggerData.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Triggers/TriggerData.cs
@@ -37,5 +37,11 @@ namespace Microsoft.Azure.WebJobs.Host.Triggers
         {
             get { return _bindingData; }
         }
+
+        /// <summary>
+        /// If non-null, then this trigger handles a return value. 
+        /// The binding data contract should have a "$return" entry of byref type too. 
+        /// </summary>
+        public IValueBinder ReturnValueProvider { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Triggers/TriggeredFunctionBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Triggers/TriggeredFunctionBinding.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Azure.WebJobs.Host.Indexers;
 using Microsoft.Azure.WebJobs.Host.Protocols;
 
 namespace Microsoft.Azure.WebJobs.Host.Triggers
@@ -50,11 +51,13 @@ namespace Microsoft.Azure.WebJobs.Host.Triggers
             IValueProvider triggerProvider;
             IReadOnlyDictionary<string, object> bindingData;
 
+            IValueBinder triggerReturnValueProvider= null;
             try
             {
                 ITriggerData triggerData = await _triggerBinding.BindAsync(value, context);
                 triggerProvider = triggerData.ValueProvider;
                 bindingData = triggerData.BindingData;
+                triggerReturnValueProvider = (triggerData as TriggerData)?.ReturnValueProvider;
             }
             catch (OperationCanceledException)
             {
@@ -65,8 +68,8 @@ namespace Microsoft.Azure.WebJobs.Host.Triggers
                 triggerProvider = new BindingExceptionValueProvider(_triggerParameterName, exception);
                 bindingData = null;
             }
+
             valueProviders.Add(_triggerParameterName, triggerProvider);
-            BindingContext bindingContext = FunctionBinding.NewBindingContext(context, bindingData, parameters);
 
             // Bind Singleton if specified
             SingletonAttribute singletonAttribute = SingletonManager.GetFunctionSingletonOrNull(_descriptor, isTriggered: true);
@@ -77,6 +80,7 @@ namespace Microsoft.Azure.WebJobs.Host.Triggers
                 valueProviders.Add(SingletonValueProvider.SingletonParameterName, singletonValueProvider);
             }
 
+            BindingContext bindingContext = FunctionBinding.NewBindingContext(context, bindingData, parameters);
             foreach (KeyValuePair<string, IBinding> item in _nonTriggerBindings)
             {
                 string name = item.Key;
@@ -104,6 +108,17 @@ namespace Microsoft.Azure.WebJobs.Host.Triggers
                 }
 
                 valueProviders.Add(name, valueProvider);
+            }
+
+            // Triggers can optionally process the return values of functions. They do so by declaring
+            // a "$return" key in their binding data dictionary and mapping it to an IValueBinder.
+            // An explicit return binding takes precedence over an implicit trigger binding. 
+            if (!valueProviders.ContainsKey(FunctionIndexer.ReturnParamName))
+            {
+                if (triggerReturnValueProvider != null)
+                {
+                    valueProviders.Add(FunctionIndexer.ReturnParamName, triggerReturnValueProvider);
+                }
             }
 
             return valueProviders;

--- a/src/Microsoft.Azure.WebJobs.Host/Triggers/TriggeredFunctionInstanceFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Triggers/TriggeredFunctionInstanceFactory.cs
@@ -59,18 +59,18 @@ namespace Microsoft.Azure.WebJobs.Host.Triggers
         private class InvokeWrapper : IFunctionInvoker
         {
             private readonly IFunctionInvoker _inner;
-            private readonly Func<Func<Task>, Task> _handler;
+            private readonly Func<Func<Task<object>>, Task<object>> _handler;
 
-            public InvokeWrapper(IFunctionInvoker inner, Func<Func<Task>, Task> handler)
+            public InvokeWrapper(IFunctionInvoker inner, Func<Func<Task<object>>, Task<object>> handler)
             {
                 _inner = inner;
                 _handler = handler;
             }
             public IReadOnlyList<string> ParameterNames => _inner.ParameterNames;
 
-            public Task InvokeAsync(object[] arguments)
+            public Task<object> InvokeAsync(object[] arguments)
             {
-                Func<Task> inner = () => _inner.InvokeAsync(arguments);
+                Func<Task<object>> inner = () => _inner.InvokeAsync(arguments);
                 return _handler(inner);
             }
         }

--- a/src/Microsoft.Azure.WebJobs.Host/TypeUtility.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/TypeUtility.cs
@@ -167,5 +167,24 @@ namespace Microsoft.Azure.WebJobs.Host
         {
             return IsAsync(methodInfo) && (methodInfo.ReturnType == typeof(void));
         }
+
+        public static bool TryGetReturnType(MethodInfo methodInfo, out Type type)
+        {
+            Type returnType = methodInfo.ReturnType;
+            if (returnType == typeof(void) || returnType == typeof(Task))
+            {
+                type = null;
+            }
+            else if (typeof(Task).IsAssignableFrom(methodInfo.ReturnType))
+            {
+                type = returnType.GetGenericArguments()[0];
+            }
+            else
+            {
+                type = returnType;
+            }
+
+            return type != null;
+        }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/FunctionExecutorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/FunctionExecutorTests.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
                 .Returns(() =>
                 {
                     called = true;
-                    return Task.FromResult(0);
+                    return Task.FromResult<object>(null);
                 });
 
             var timeoutSource = new CancellationTokenSource();
@@ -155,6 +155,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
                         await Task.Delay(1000);
                     }
                     called = true;
+                    return null;
                 });
 
             var timeoutSource = new CancellationTokenSource();
@@ -182,6 +183,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
                     {
                         await Task.Delay(500);
                     }
+                    return null;
                 });
 
             // setup the instance details for the exception message
@@ -217,6 +219,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
                         await Task.Delay(1000);
                     }
                     called = true;
+                    return null;
                 });
 
             var timeoutSource = new CancellationTokenSource();
@@ -245,6 +248,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
                         await Task.Delay(1500);
                     }
                     called = true;
+                    return null;
                 });
 
             var timeoutSource = new CancellationTokenSource();
@@ -273,6 +277,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
                     {
                         await Task.Delay(500);
                     }
+                    return null;
                 });
 
             // setup the instance details for the exception message

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/FunctionInvokerFactoryTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/FunctionInvokerFactoryTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             IFunctionInvoker invoker = FunctionInvokerFactory.Create(method, activator);
 
             // Assert
-            Assert.IsType<FunctionInvoker<FunctionInvokerFactoryTests>>(invoker);
+            Assert.IsType<FunctionInvoker<FunctionInvokerFactoryTests, object>>(invoker);
         }
 
         [Fact]
@@ -91,9 +91,9 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             IFunctionInvoker invoker = FunctionInvokerFactory.Create(method, activator);
 
             // Assert
-            Assert.IsType<FunctionInvoker<FunctionInvokerFactoryTests>>(invoker);
-            FunctionInvoker<FunctionInvokerFactoryTests> typedInvoker =
-                (FunctionInvoker<FunctionInvokerFactoryTests>)invoker;
+            Assert.IsType<FunctionInvoker<FunctionInvokerFactoryTests, object>>(invoker);
+            FunctionInvoker<FunctionInvokerFactoryTests, object> typedInvoker =
+                (FunctionInvoker<FunctionInvokerFactoryTests, object>)invoker;
             Assert.IsType<NullInstanceFactory<FunctionInvokerFactoryTests>>(typedInvoker.InstanceFactory);
         }
 
@@ -108,9 +108,9 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             IFunctionInvoker invoker = FunctionInvokerFactory.Create(method, activator);
 
             // Assert
-            Assert.IsType<FunctionInvoker<FunctionInvokerFactoryTests>>(invoker);
-            FunctionInvoker<FunctionInvokerFactoryTests> typedInvoker =
-                (FunctionInvoker<FunctionInvokerFactoryTests>)invoker;
+            Assert.IsType<FunctionInvoker<FunctionInvokerFactoryTests, object>>(invoker);
+            FunctionInvoker<FunctionInvokerFactoryTests, object> typedInvoker =
+                (FunctionInvoker<FunctionInvokerFactoryTests, object>)invoker;
             Assert.IsType<ActivatorInstanceFactory<FunctionInvokerFactoryTests>>(typedInvoker.InstanceFactory);
         }
 
@@ -125,8 +125,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             IFunctionInvoker invoker = FunctionInvokerFactory.Create(method, activator);
 
             // Assert
-            Assert.IsType<FunctionInvoker<Subclass>>(invoker);
-            FunctionInvoker<Subclass> typedInvoker = (FunctionInvoker<Subclass>)invoker;
+            Assert.IsType<FunctionInvoker<Subclass, object>>(invoker);
+            FunctionInvoker<Subclass, object> typedInvoker = (FunctionInvoker<Subclass, object>)invoker;
             Assert.IsType<ActivatorInstanceFactory<Subclass>>(typedInvoker.InstanceFactory);
         }
 

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/MethodInvokerFactoryTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/MethodInvokerFactoryTests.cs
@@ -2,14 +2,11 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
 {
@@ -24,7 +21,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             MethodInfo method = null;
 
             // Act & Assert
-            ExceptionAssert.ThrowsArgumentNull(() => MethodInvokerFactory.Create<MethodInvokerFactoryTests>(method),
+            ExceptionAssert.ThrowsArgumentNull(() => MethodInvokerFactory.Create<MethodInvokerFactoryTests, object>(method),
                 "method");
         }
 
@@ -37,38 +34,27 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             MethodInfo method = GetMethodInfo(isInstance, "ReturnVoid");
 
             // Act
-            IMethodInvoker<MethodInvokerFactoryTests> invoker =
-                MethodInvokerFactory.Create<MethodInvokerFactoryTests>(method);
+            IMethodInvoker<MethodInvokerFactoryTests, object> invoker =
+                MethodInvokerFactory.Create<MethodInvokerFactoryTests, object>(method);
 
             // Assert
-            Assert.IsType<VoidMethodInvoker<MethodInvokerFactoryTests>>(invoker);
+            Assert.IsType<VoidMethodInvoker<MethodInvokerFactoryTests, object>>(invoker);
         }
 
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public void Create_IfStaticMethodReturnsTask_ReturnsTaskInvoker(bool isInstance)
+        public void Create_IfStaticMethodReturnsTask_ReturnsVoidTaskInvoker(bool isInstance)
         {
             // Arrange
             MethodInfo method = GetMethodInfo(isInstance, "ReturnTask");
 
             // Act
-            IMethodInvoker<MethodInvokerFactoryTests> invoker =
-                MethodInvokerFactory.Create<MethodInvokerFactoryTests>(method);
+            IMethodInvoker<MethodInvokerFactoryTests, object> invoker =
+                MethodInvokerFactory.Create<MethodInvokerFactoryTests, object>(method);
 
             // Assert
-            Assert.IsType<TaskMethodInvoker<MethodInvokerFactoryTests>>(invoker);
-        }
-
-        [Fact]
-        public void Create_IfMethodReturnsNonTask_Throws()
-        {
-            // Arrange
-            MethodInfo method = GetMethodInfo("ReturnInt");
-
-            // Act & Assert
-            ExceptionAssert.ThrowsNotSupported(() => MethodInvokerFactory.Create<MethodInvokerFactoryTests>(method),
-                "Methods may only return void or Task.");
+            Assert.IsType<VoidTaskMethodInvoker<MethodInvokerFactoryTests, object>>(invoker);
         }
 
         [Theory]
@@ -80,7 +66,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             MethodInfo method = GetMethodInfo(isInstance, "ReturnVoid");
 
             // Act & Assert
-            ExceptionAssert.ThrowsInvalidOperation(() => MethodInvokerFactory.Create<object>(method),
+            ExceptionAssert.ThrowsInvalidOperation(() => MethodInvokerFactory.Create<object, object>(method),
                 "The Type must match the method's ReflectedType.");
         }
 
@@ -96,8 +82,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             object[] expectedC = new object[] { new object() };
 
             // Act
-            IMethodInvoker<MethodInvokerFactoryTests> invoker =
-                MethodInvokerFactory.Create<MethodInvokerFactoryTests>(method);
+            IMethodInvoker<MethodInvokerFactoryTests, object> invoker =
+                MethodInvokerFactory.Create<MethodInvokerFactoryTests, object>(method);
 
             // Assert
             Assert.NotNull(invoker);
@@ -127,8 +113,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             object[] expectedC = new object[] { new object() };
 
             // Act
-            IMethodInvoker<MethodInvokerFactoryTests> invoker =
-                MethodInvokerFactory.Create<MethodInvokerFactoryTests>(method);
+            IMethodInvoker<MethodInvokerFactoryTests, object> invoker =
+                MethodInvokerFactory.Create<MethodInvokerFactoryTests, object>(method);
 
             // Assert
             Assert.NotNull(invoker);
@@ -164,8 +150,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             object[] expectedFinalC = new object[] { new object(), default(int), String.Empty };
 
             // Act
-            IMethodInvoker<MethodInvokerFactoryTests> invoker =
-                MethodInvokerFactory.Create<MethodInvokerFactoryTests>(method);
+            IMethodInvoker<MethodInvokerFactoryTests, object> invoker =
+                MethodInvokerFactory.Create<MethodInvokerFactoryTests, object>(method);
 
             // Assert
             Assert.NotNull(invoker);
@@ -202,8 +188,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             object[] expectedC = new object[] { new object(), default(int), String.Empty };
 
             // Act
-            IMethodInvoker<MethodInvokerFactoryTests> invoker =
-                MethodInvokerFactory.Create<MethodInvokerFactoryTests>(method);
+            IMethodInvoker<MethodInvokerFactoryTests, object> invoker =
+                MethodInvokerFactory.Create<MethodInvokerFactoryTests, object>(method);
 
             // Assert
             Assert.NotNull(invoker);
@@ -234,8 +220,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             MethodInfo method = GetMethodInfo(isInstance, "ReturnCanceledTask");
 
             // Act
-            IMethodInvoker<MethodInvokerFactoryTests> invoker =
-                MethodInvokerFactory.Create<MethodInvokerFactoryTests>(method);
+            IMethodInvoker<MethodInvokerFactoryTests, object> invoker =
+                MethodInvokerFactory.Create<MethodInvokerFactoryTests, object>(method);
 
             // Assert
             MethodInvokerFactoryTests instance = GetInstance(isInstance);
@@ -254,8 +240,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             MethodInfo method = GetMethodInfo(isInstance, "ParameterlessMethod");
 
             // Act
-            IMethodInvoker<MethodInvokerFactoryTests> invoker =
-                MethodInvokerFactory.Create<MethodInvokerFactoryTests>(method);
+            IMethodInvoker<MethodInvokerFactoryTests, object> invoker =
+                MethodInvokerFactory.Create<MethodInvokerFactoryTests, object>(method);
 
             try
             {

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/TriggeredFunctionExecutorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/TriggeredFunctionExecutorTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             mockInvoker.Setup(m => m.InvokeAsync(null)).Returns(() =>
             {
                 innerInvokerInvoked = true;
-                return Task.CompletedTask;
+                return Task.FromResult<object>(null);
             });
 
             bool customInvokerInvoked = false;

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/VoidMethodInvokerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/VoidMethodInvokerTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
                 arguments = a;
             };
 
-            IMethodInvoker<object> invoker = CreateProductUnderTest(lambda);
+            IMethodInvoker<object, object> invoker = CreateProductUnderTest(lambda);
 
             // Act
             Task task = invoker.InvokeAsync(expectedInstance, expectedArguments);
@@ -39,9 +39,9 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             Assert.Same(expectedArguments, arguments);
         }
 
-        private static VoidMethodInvoker<object> CreateProductUnderTest(Action<object, object[]> lambda)
+        private static VoidMethodInvoker<object, object> CreateProductUnderTest(Action<object, object[]> lambda)
         {
-            return new VoidMethodInvoker<object>(lambda);
+            return new VoidMethodInvoker<object, object>(lambda);
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Indexers/FunctionIndexerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Indexers/FunctionIndexerTests.cs
@@ -93,38 +93,6 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Indexers
         }
 
         [Fact]
-        public void IndexMethod_IfMethodReturnsNonTask_Throws()
-        {
-            // Arrange
-            IFunctionIndexCollector index = CreateDummyFunctionIndex();
-            FunctionIndexer product = CreateProductUnderTest();
-
-            // Act & Assert
-            FunctionIndexingException exception = Assert.Throws<FunctionIndexingException>(
-                () => product.IndexMethodAsync(typeof(FunctionIndexerTests).GetMethod("ReturnNonTask"), index,
-                    CancellationToken.None).GetAwaiter().GetResult());
-            InvalidOperationException innerException = exception.InnerException as InvalidOperationException;
-            Assert.NotNull(innerException);
-            Assert.Equal("Functions must return Task or void.", innerException.Message);
-        }
-
-        [Fact]
-        public void IndexMethod_IfMethodReturnsTaskOfTResult_Throws()
-        {
-            // Arrange
-            IFunctionIndexCollector index = CreateDummyFunctionIndex();
-            FunctionIndexer product = CreateProductUnderTest();
-
-            // Act & Assert
-            FunctionIndexingException exception = Assert.Throws<FunctionIndexingException>(
-                () => product.IndexMethodAsync(typeof(FunctionIndexerTests).GetMethod("ReturnGenericTask"), index,
-                    CancellationToken.None).GetAwaiter().GetResult());
-            InvalidOperationException innerException = exception.InnerException as InvalidOperationException;
-            Assert.NotNull(innerException);
-            Assert.Equal("Functions must return Task or void.", innerException.Message);
-        }
-
-        [Fact]
         public void IndexMethod_IfMethodReturnsVoid_DoesNotThrow()
         {
             // Arrange

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Indexers/ReturnValueTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Indexers/ReturnValueTests.cs
@@ -1,0 +1,229 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.WebJobs.Host.Config;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using System.Threading;
+using Microsoft.Azure.WebJobs.Host.Triggers;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Azure.WebJobs.Host.Listeners;
+using Microsoft.Azure.WebJobs.Host.Protocols;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Microsoft.Azure.WebJobs.Description;
+
+namespace Microsoft.Azure.WebJobs.Host.UnitTests.Indexers
+{
+    public class ReturnValueTests
+    {
+        [Fact]
+        public void ImplicitReturn()
+        {
+            var ext = new MyExtension();
+            var prog = TestHelpers.NewJobHost<TestProg>(ext);
+
+            prog.Call("ImplicitReturn", new { trigger = "trigger" } );
+            ext.AssertFromBeta("triggerbeta");        
+        }
+
+        [Fact]
+        public void ExplicitReturn()
+        {
+            var ext = new MyExtension();
+            var prog = TestHelpers.NewJobHost<TestProg>(ext);
+
+            prog.Call("ExplicitReturn");
+            ext.AssertFromAlpha("alpha");
+        }
+
+        [Fact]
+        public void ExplicitReturnWins()
+        {
+            var ext = new MyExtension();
+            var prog = TestHelpers.NewJobHost<TestProg>(ext);        
+
+            prog.Call("ExplicitReturnWins", new { trigger = "trigger" });
+            ext.AssertFromAlpha("triggeralpha");
+        }
+
+        [Fact]
+        public void TestIndexError()
+        {
+            var ext = new MyExtension();
+            var prog = TestHelpers.NewJobHost<TestProgErrors>(ext);
+
+            TestHelpers.AssertIndexingError(() => prog.Call("Error"), "TestProgErrors.Error",
+                "Functions must return Task or void, have a binding attribute for the return value, or be triggered by a binding that natively supports return values.");
+        }
+
+        public class TestProgErrors
+        {
+            // Error to have a return without any binding 
+            // Put an attribute on it to ensure it still gets indexed. 
+            [NoAutomaticTrigger]
+            public string Error()
+            {
+                return "error";
+            }
+        }
+
+        // Bind to a regular async collector (output) binding,
+        [Binding]
+        public class AlphaAttribute : Attribute
+        {
+        }
+
+        // Bind to a trigger that accepts a return value. 
+        [Binding]
+        public class BetaAttribute : Attribute
+        {
+        }
+
+        class MyExtension : IExtensionConfigProvider, IAsyncCollector<string>, ITriggerBindingProvider
+        {
+            public List<string> _itemsFromAlpha = new List<string>();
+            public List<string> _itemsFromBeta = new List<string>();
+
+            public void AssertFromAlpha(string expected)
+            {
+                Assert.Equal(1, _itemsFromAlpha.Count);
+                Assert.Equal(0, _itemsFromBeta.Count);
+                Assert.Equal(expected, _itemsFromAlpha[0]);
+                _itemsFromAlpha.Clear();
+                _itemsFromBeta.Clear();
+            }
+            public void AssertFromBeta(string expected)
+            {
+                Assert.Equal(0, _itemsFromAlpha.Count);
+                Assert.Equal(1, _itemsFromBeta.Count);
+                Assert.Equal(expected, _itemsFromBeta[0]);
+                _itemsFromAlpha.Clear();
+                _itemsFromBeta.Clear();
+            }
+
+            public Task AddAsync(string item, CancellationToken cancellationToken = default(CancellationToken))
+            {
+                _itemsFromAlpha.Add(item);
+                return Task.CompletedTask;
+            }
+
+            public Task FlushAsync(CancellationToken cancellationToken = default(CancellationToken))
+            {
+                return Task.CompletedTask;
+            }
+
+            public void Initialize(ExtensionConfigContext context)
+            {
+                context.AddBindingRule<AlphaAttribute>().
+                    BindToCollector(attr => this);
+
+                context.AddBindingRule<BetaAttribute>().
+                    BindToTrigger(this);
+            }
+        
+            Task<ITriggerBinding> ITriggerBindingProvider.TryCreateAsync(TriggerBindingProviderContext context)
+            {
+                return Task.FromResult<ITriggerBinding>(new BetaTrigger(this));
+            }
+
+            class BetaTrigger : ITriggerBinding
+            {
+                MyExtension _parent;
+                public BetaTrigger(MyExtension parent)
+                {
+                    _parent = parent;
+                }
+                public Type TriggerValueType => typeof(string);
+
+                public IReadOnlyDictionary<string, Type> BindingDataContract => new Dictionary<string, Type>
+                {
+                    { "$return", typeof(string).MakeByRefType() } // Return is same as 'out T'. 
+                };
+
+                public Task<ITriggerData> BindAsync(object value, ValueBindingContext context)
+                {
+                    var inputValueProvider = new BetaValueProvider(_parent) { Value = value };
+                    var returnValueProvider = new BetaReturnValueProvider(_parent) { Value = "return" };
+                    var bindingData = new Dictionary<string, object>();
+                    var triggerData = new TriggerData(inputValueProvider, bindingData)
+                    {
+                        ReturnValueProvider = returnValueProvider
+                    };
+                    return Task.FromResult<ITriggerData>(triggerData);
+                }
+
+                public Task<IListener> CreateListenerAsync(ListenerFactoryContext context)
+                {
+                    return Task.FromResult<IListener>(new NullListener());
+                }
+
+                public ParameterDescriptor ToParameterDescriptor()
+                {
+                    return new ParameterDescriptor();
+                }
+            }
+
+            class BetaValueProvider : IValueProvider
+            {
+                protected MyExtension _parent;
+
+                public BetaValueProvider(MyExtension parent)
+                {
+                    _parent = parent;
+                }
+
+                public Type Type => typeof(string);
+
+                public object Value;
+
+                public Task<object> GetValueAsync()
+                {
+                    return Task.FromResult(Value);                    
+                }
+                public string ToInvokeString()
+                {
+                    return Value.ToString();
+                }
+            }
+
+            class BetaReturnValueProvider : BetaValueProvider, IValueBinder
+            {
+                public BetaReturnValueProvider(MyExtension parent) : base(parent)
+                {
+                }
+
+                public Task SetValueAsync(object value, CancellationToken cancellationToken)
+                {
+                    _parent._itemsFromBeta.Add((string) value);
+                    return Task.CompletedTask;
+                }
+            }
+        }
+
+        public class TestProg
+        {
+            // Return is explict
+            [return: Alpha]
+            public string ExplicitReturn()
+            {
+                return "alpha";
+            }
+                        
+            // Return is from Trigger 
+            public string ImplicitReturn([Beta] string trigger)
+            {
+                return trigger + "beta";
+            }
+
+            [return: Alpha] // 
+            public string ExplicitReturnWins([Beta] string trigger)
+            {
+                return trigger + "alpha";
+            }            
+        }
+    }
+}


### PR DESCRIPTION
This is to resolve https://github.com/Azure/azure-webjobs-sdk/issues/1104.

Phase 1 simply allows functions in WebJobs to have a return value. Previously we supported `void` and `Task`. With this change, we also support `TReturnValue` and `Task<TReturnValue>`.

Example functions I'm using for testing:

```csharp
public static int QueueTriggerWithReturnValue(
    [QueueTrigger("test")] string message)
{
    Console.WriteLine("Processed message: " + message);
    return 5;
}

public static Task<int> QueueTriggerWithReturnValueAsync(
    [QueueTrigger("test")] string message)
{
    Console.WriteLine("Processed message: " + message);
    return Task.FromResult(5);
}
```



Phase 2 (TBD) is to connect the return value back to the trigger binding.