### PR TITLE
Remove usage of MethodInfo throughout code. 

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/FunctionBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/FunctionBinding.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
             if (singletonAttribute != null)
             {
                 string boundScopeId = _singletonManager.GetBoundScopeId(singletonAttribute.ScopeId);
-                IValueProvider singletonValueProvider = new SingletonValueProvider(_descriptor.Method, boundScopeId, context.FunctionInstanceId.ToString(), singletonAttribute, _singletonManager);
+                IValueProvider singletonValueProvider = new SingletonValueProvider(_descriptor, boundScopeId, context.FunctionInstanceId.ToString(), singletonAttribute, _singletonManager);
                 results.Add(SingletonValueProvider.SingletonParameterName, singletonValueProvider);
             }
 

--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/FunctionBindingContext.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/FunctionBindingContext.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
             _functionCancellationToken = functionCancellationToken;
             _trace = trace;
 
-            this.MethodName = functionDescriptor?.Method?.Name;
+            this.MethodName = functionDescriptor?.LogName;
         }
 
         /// <summary>

--- a/src/Microsoft.Azure.WebJobs.Host/Listeners/HostListenerFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Listeners/HostListenerFactory.cs
@@ -51,9 +51,8 @@ namespace Microsoft.Azure.WebJobs.Host.Listeners
                     continue;
                 }
 
-                // Determine if the function is disabled
-                MethodInfo method = functionDefinition.Descriptor.Method;
-                if (IsDisabled(method, _nameResolver, _activator))
+                // Determine if the function is disabled                
+                if (functionDefinition.Descriptor.IsDisabled)
                 {
                     string msg = string.Format("Function '{0}' is disabled", functionDefinition.Descriptor.ShortName);
                     _trace.Info(msg, TraceSource.Host);
@@ -64,10 +63,10 @@ namespace Microsoft.Azure.WebJobs.Host.Listeners
                 IListener listener = await listenerFactory.CreateAsync(cancellationToken);
 
                 // if the listener is a Singleton, wrap it with our SingletonListener
-                SingletonAttribute singletonAttribute = SingletonManager.GetListenerSingletonOrNull(listener.GetType(), method);
+                SingletonAttribute singletonAttribute = SingletonManager.GetListenerSingletonOrNull(listener.GetType(), functionDefinition.Descriptor);
                 if (singletonAttribute != null)
                 {
-                    listener = new SingletonListener(method, singletonAttribute, _singletonManager, listener, _trace, _loggerFactory);
+                    listener = new SingletonListener(functionDefinition.Descriptor, singletonAttribute, _singletonManager, listener, _trace, _loggerFactory);
                 }
 
                 // wrap the listener with a function listener to handle exceptions

--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/LoggerExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/LoggerExtensions.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Extensions.Logging
                 new Dictionary<string, object>
                 {
                     [ScopeKeys.FunctionInvocationId] = functionInstance?.Id,
-                    [ScopeKeys.FunctionName] = functionInstance?.FunctionDescriptor?.Method?.Name
+                    [ScopeKeys.FunctionName] = functionInstance?.FunctionDescriptor?.LogName
                 });
         }
     }

--- a/src/Microsoft.Azure.WebJobs.Host/Singleton/SingletonListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Singleton/SingletonListener.cs
@@ -3,11 +3,10 @@
 
 using System;
 using System.Globalization;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Timers;
-using Microsoft.Azure.WebJobs.Host.Loggers;
+using Microsoft.Azure.WebJobs.Host.Protocols;
 using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Extensions.Logging;
 
@@ -25,7 +24,7 @@ namespace Microsoft.Azure.WebJobs.Host.Listeners
         private RenewableLockHandle _lockHandle;
         private bool _isListening;
 
-        public SingletonListener(MethodInfo method, SingletonAttribute attribute, SingletonManager singletonManager, IListener innerListener, TraceWriter trace, ILoggerFactory loggerFactory)
+        public SingletonListener(FunctionDescriptor method, SingletonAttribute attribute, SingletonManager singletonManager, IListener innerListener, TraceWriter trace, ILoggerFactory loggerFactory)
         {
             _attribute = attribute;
             _singletonManager = singletonManager;

--- a/src/Microsoft.Azure.WebJobs.Host/Singleton/SingletonManager.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Singleton/SingletonManager.cs
@@ -172,12 +172,12 @@ namespace Microsoft.Azure.WebJobs.Host
             _logger?.LogDebug(msg);
         }
 
-        public string FormatLockId(MethodInfo method, SingletonScope scope, string scopeId)
+        public string FormatLockId(FunctionDescriptor method, SingletonScope scope, string scopeId)
         {
             return FormatLockId(method, scope, HostId, scopeId);
         }
 
-        public static string FormatLockId(MethodInfo method, SingletonScope scope, string hostId, string scopeId)
+        public static string FormatLockId(FunctionDescriptor descr, SingletonScope scope, string hostId, string scopeId)
         {
             if (string.IsNullOrEmpty(hostId))
             {
@@ -187,7 +187,7 @@ namespace Microsoft.Azure.WebJobs.Host
             string lockId = string.Empty;
             if (scope == SingletonScope.Function)
             {
-                lockId += string.Format(CultureInfo.InvariantCulture, "{0}.{1}", method.DeclaringType.FullName, method.Name);
+                lockId += descr.FullName;
             }
 
             if (!string.IsNullOrEmpty(scopeId))
@@ -259,12 +259,12 @@ namespace Microsoft.Azure.WebJobs.Host
             return new SingletonListener(null, singletonAttribute, this, innerListener, _trace, _loggerFactory);
         }
 
-        public static SingletonAttribute GetListenerSingletonOrNull(Type listenerType, MethodInfo method)
+        public static SingletonAttribute GetListenerSingletonOrNull(Type listenerType, FunctionDescriptor method)
         {
             // First check the method, then the listener class. This allows a method to override an implicit
             // listener singleton.
             SingletonAttribute singletonAttribute = null;
-            SingletonAttribute[] singletonAttributes = method.GetCustomAttributes<SingletonAttribute>().Where(p => p.Mode == SingletonMode.Listener).ToArray();
+            SingletonAttribute[] singletonAttributes = method.SingletonAttributes.Where(p => p.Mode == SingletonMode.Listener).ToArray();
             if (singletonAttributes.Length > 1)
             {
                 throw new NotSupportedException("Only one SingletonAttribute using mode 'Listener' is allowed.");

--- a/src/Microsoft.Azure.WebJobs.Host/Singleton/SingletonValueProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Singleton/SingletonValueProvider.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.WebJobs.Host
         private readonly SingletonWatcher _watcher;
         private readonly string _scopeId;
 
-        public SingletonValueProvider(MethodInfo method, string scopeId, string functionInstanceId, SingletonAttribute attribute, SingletonManager singletonManager)
+        public SingletonValueProvider(FunctionDescriptor method, string scopeId, string functionInstanceId, SingletonAttribute attribute, SingletonManager singletonManager)
         {
             _scopeId = string.IsNullOrEmpty(scopeId) ? "(null)" : scopeId;
             string lockId = singletonManager.FormatLockId(method, attribute.Scope, scopeId);

--- a/src/Microsoft.Azure.WebJobs.Host/Triggers/TriggeredFunctionBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Triggers/TriggeredFunctionBinding.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.WebJobs.Host.Triggers
             if (singletonAttribute != null)
             {
                 string boundScopeId = _singletonManager.GetBoundScopeId(singletonAttribute.ScopeId, bindingData);
-                IValueProvider singletonValueProvider = new SingletonValueProvider(_descriptor.Method, boundScopeId, context.FunctionInstanceId.ToString(), singletonAttribute, _singletonManager);
+                IValueProvider singletonValueProvider = new SingletonValueProvider(_descriptor, boundScopeId, context.FunctionInstanceId.ToString(), singletonAttribute, _singletonManager);
                 valueProviders.Add(SingletonValueProvider.SingletonParameterName, singletonValueProvider);
             }
 

--- a/src/Microsoft.Azure.WebJobs.Protocols/FunctionDescriptor.cs
+++ b/src/Microsoft.Azure.WebJobs.Protocols/FunctionDescriptor.cs
@@ -22,23 +22,30 @@ namespace Microsoft.Azure.WebJobs.Host.Protocols
         /// <summary>Gets or sets the ID of the function.</summary>
         public string Id { get; set; }
 
-        /// <summary>Gets or sets the fully qualified name of the function.</summary>
+        /// <summary>Gets or sets the fully qualified name of the function. This is 'Namespace.Class.Method' </summary>
         public string FullName { get; set; }
 
-        /// <summary>Gets or sets the display name of the function.</summary>
+        /// <summary>Gets or sets the display name of the function. This is commonly 'Class.Method' </summary>
         public string ShortName { get; set; }
 
         /// <summary>Gets or sets the function's parameters.</summary>
         public IEnumerable<ParameterDescriptor> Parameters { get; set; }
 
-        /// <summary>
-        /// Gets the <see cref="MethodInfo"/> for this function
-        /// </summary>
-        [JsonIgnore]
-        internal MethodInfo Method { get; set; }
 
 #if PUBLICPROTOCOL
 #else
+        /// <summary>Gets or sets the name used for logging. This is 'Method'. </summary>
+        [JsonIgnore] 
+        internal string LogName { get; set; }
+
+        /// <summary>Gets or sets whether this method is disabled. </summary>
+        [JsonIgnore]
+        internal bool IsDisabled {get;set;}
+
+        /// <summary>Gets or sets whether this signature includes a cancellation token. 
+        /// This indicates whether the method is requesting to be alerted of attempted cancellation. </summary>
+        internal bool HasCancellationToken {get;set;}
+
         /// <summary>
         /// Gets the <see cref="Protocols.TriggerParameterDescriptor"/> for this function
         /// </summary>

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Listeners/HostListenerFactoryTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Listeners/HostListenerFactoryTests.cs
@@ -53,11 +53,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Listeners
 
             // create a bunch of function definitions that are disabled
             List<FunctionDefinition> functions = new List<FunctionDefinition>();
-            FunctionDescriptor descriptor = new FunctionDescriptor
-            {
-                Method = jobType.GetMethod(methodName, BindingFlags.Public | BindingFlags.Static),
-                ShortName = string.Format("{0}.{1}", jobType.Name, methodName)
-            };
+            var method = jobType.GetMethod(methodName, BindingFlags.Public | BindingFlags.Static);
+            FunctionDescriptor descriptor = FunctionIndexer.FromMethod(method, DefaultJobActivator.Instance); 
             FunctionDefinition definition = new FunctionDefinition(descriptor, mockInstanceFactory.Object, mockListenerFactory.Object);
             functions.Add(definition);
 

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsLoggerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsLoggerTests.cs
@@ -14,6 +14,7 @@ using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Azure.WebJobs.Host.Indexers;
 using Microsoft.Azure.WebJobs.Host.Loggers;
 using Microsoft.Azure.WebJobs.Host.Protocols;
 using Microsoft.Azure.WebJobs.Logging;
@@ -515,10 +516,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
 
         private IFunctionInstance CreateFunctionInstance(Guid id)
         {
-            var descriptor = new FunctionDescriptor
-            {
-                Method = GetType().GetMethod(nameof(TestFunction), BindingFlags.NonPublic | BindingFlags.Static)
-            };
+            var method = GetType().GetMethod(nameof(TestFunction), BindingFlags.NonPublic | BindingFlags.Static);
+            var descriptor = FunctionIndexer.FromMethod(method);
 
             return new FunctionInstance(id, null, new ExecutionReason(), null, null, descriptor);
         }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Singleton/SingletonListenerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Singleton/SingletonListenerTests.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Azure.WebJobs.Host.Indexers;
 using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Moq;
@@ -27,6 +28,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Singleton
         public SingletonListenerTests()
         {
             MethodInfo methodInfo = this.GetType().GetMethod("TestJob", BindingFlags.Static | BindingFlags.NonPublic);
+            var descriptor = FunctionIndexer.FromMethod(methodInfo);
             _attribute = new SingletonAttribute();
             _config = new SingletonConfiguration
             {
@@ -36,9 +38,9 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Singleton
             _mockSingletonManager.SetupGet(p => p.Config).Returns(_config);
             _mockInnerListener = new Mock<IListener>(MockBehavior.Strict);
 
-            _listener = new SingletonListener(methodInfo, _attribute, _mockSingletonManager.Object, _mockInnerListener.Object,
+            _listener = new SingletonListener(descriptor, _attribute, _mockSingletonManager.Object, _mockInnerListener.Object,
                 new TestTraceWriter(System.Diagnostics.TraceLevel.Verbose), null);
-            _lockId = SingletonManager.FormatLockId(methodInfo, SingletonScope.Function, testHostId, _attribute.ScopeId) + ".Listener";
+            _lockId = SingletonManager.FormatLockId(descriptor, SingletonScope.Function, testHostId, _attribute.ScopeId) + ".Listener";
         }
 
         [Fact]

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Singleton/SingletonManagerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Singleton/SingletonManagerTests.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Azure.WebJobs.Host.Indexers;
 using Microsoft.Azure.WebJobs.Host.Protocols;
 using Microsoft.Azure.WebJobs.Host.Storage;
 using Microsoft.Azure.WebJobs.Host.Storage.Blob;
@@ -370,7 +371,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Singleton
         public void FormatLockId_ReturnsExpectedValue(SingletonScope scope, string scopeId, string expectedLockId)
         {
             MethodInfo methodInfo = this.GetType().GetMethod("TestJob", BindingFlags.Static | BindingFlags.NonPublic);
-            string actualLockId = SingletonManager.FormatLockId(methodInfo, scope, "TestHostId", scopeId);
+            var descriptor = FunctionIndexer.FromMethod(methodInfo);
+            string actualLockId = SingletonManager.FormatLockId(descriptor, scope, "TestHostId", scopeId);
             Assert.Equal(expectedLockId, actualLockId);
         }
 
@@ -475,10 +477,11 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Singleton
         public void GetListenerSingletonOrNull_ThrowsOnMultiple()
         {
             MethodInfo method = this.GetType().GetMethod("TestJob_MultipleListenerSingletons", BindingFlags.Static | BindingFlags.NonPublic);
+            var descriptor = FunctionIndexer.FromMethod(method);
 
             NotSupportedException exception = Assert.Throws<NotSupportedException>(() =>
             {
-                SingletonManager.GetListenerSingletonOrNull(typeof(TestListener), method);
+                SingletonManager.GetListenerSingletonOrNull(typeof(TestListener), descriptor);
             });
             Assert.Equal("Only one SingletonAttribute using mode 'Listener' is allowed.", exception.Message);
         }
@@ -487,8 +490,9 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Singleton
         public void GetListenerSingletonOrNull_MethodSingletonTakesPrecedence()
         {
             MethodInfo method = this.GetType().GetMethod("TestJob_ListenerSingleton", BindingFlags.Static | BindingFlags.NonPublic);
+            var descriptor = FunctionIndexer.FromMethod(method);
 
-            SingletonAttribute attribute = SingletonManager.GetListenerSingletonOrNull(typeof(TestListener), method);
+            SingletonAttribute attribute = SingletonManager.GetListenerSingletonOrNull(typeof(TestListener), descriptor);
             Assert.Equal("Function", attribute.ScopeId);
         }
 
@@ -496,8 +500,9 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Singleton
         public void GetListenerSingletonOrNull_ReturnsListenerClassSingleton()
         {
             MethodInfo method = this.GetType().GetMethod("TestJob", BindingFlags.Static | BindingFlags.NonPublic);
+            var descriptor = FunctionIndexer.FromMethod(method);
 
-            SingletonAttribute attribute = SingletonManager.GetListenerSingletonOrNull(typeof(TestListener), method);
+            SingletonAttribute attribute = SingletonManager.GetListenerSingletonOrNull(typeof(TestListener), descriptor);
             Assert.Equal("Listener", attribute.ScopeId);
         }
 

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Singleton/SingletonValueProviderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Singleton/SingletonValueProviderTests.cs
@@ -9,6 +9,7 @@ using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Protocols;
 using Moq;
 using Xunit;
+using Microsoft.Azure.WebJobs.Host.Indexers;
 
 namespace Microsoft.Azure.WebJobs.Host.UnitTests.Singleton
 {
@@ -19,13 +20,14 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Singleton
         private readonly string _lockId;
         private readonly SingletonValueProvider _valueProvider;
         private readonly SingletonAttribute _attribute;
-        private readonly MethodInfo _method;
+        private readonly FunctionDescriptor _method;
 
         public SingletonValueProviderTests()
         {
             _attribute = new SingletonAttribute("TestScope");
             SingletonManager singletonManager = new SingletonManager(null, null, null, null, null, new FixedHostIdProvider(TestHostId));
-            _method = GetType().GetMethod("TestJob", BindingFlags.Static | BindingFlags.Public);
+            var method = GetType().GetMethod("TestJob", BindingFlags.Static | BindingFlags.Public);
+            _method = FunctionIndexer.FromMethod(method);
             _lockId = SingletonManager.FormatLockId(_method, SingletonScope.Function, TestHostId, _attribute.ScopeId);
             _valueProvider = new SingletonValueProvider(_method, "TestScope", TestInstanceId, _attribute, singletonManager);
         }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>


### PR DESCRIPTION
Fully rely on FunctionDescriptor.
Remove FunctionDescriptor.MethodInfo. Adding new fields on FunctionDescriptor like LogName, IsDisabled, HasCanncelationtoken.
  methodInfo.DeclaringType.Name + "." +methodInfo.Name --> FunctionDescriptor.ShortName
  methodInfo.Name --> FunctionDescriptor.LogName

Continuation of work started in
https://github.com/Azure/azure-webjobs-sdk/commit/183e3c4f194c7a670dd11465ec0e92014ad8dd46

No functional change here. This is prepping for the [FunctionName] support. (https://github.com/Azure/azure-webjobs-sdk/issues/1170)