### PR TITLE
SDK honors [FunctionName] attribute

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndex.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndex.cs
@@ -46,6 +46,20 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
             return _functionsById[functionId];
         }
 
+        public IFunctionDefinition LookupByName(string name)
+        {
+            foreach (var items in _functionDescriptors)
+            {
+                if (string.Equals(items.ShortName, name, StringComparison.OrdinalIgnoreCase))
+                {
+                    var id = items.Id;
+                    return Lookup(id);
+                }
+            }
+            // Not found.
+            return null;
+        }        
+
         public IFunctionDefinition Lookup(MethodInfo method)
         {
             if (!_functionsByMethod.ContainsKey(method))

--- a/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexer.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexer.cs
@@ -365,13 +365,26 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
             TraceLevelAttribute traceAttribute = TypeUtility.GetHierarchicalAttributeOrNull<TraceLevelAttribute>(method);
 
             bool hasCancellationToken = method.GetParameters().Any(p => p.ParameterType == typeof(CancellationToken));
-        
+
+            string logName = method.Name;
+            string shortName = method.GetShortName();
+            FunctionNameAttribute nameAttribute = method.GetCustomAttribute<FunctionNameAttribute>();
+            if (nameAttribute != null)
+            {
+                logName = nameAttribute.Name;
+                shortName = logName;
+                if (!FunctionNameAttribute.FunctionNameValidationRegex.IsMatch(logName))
+                {
+                    throw new InvalidOperationException(string.Format("'{0}' is not a valid function name.", logName));
+                }
+            }
+
             return new FunctionDescriptor
             {
                 Id = method.GetFullName(),
-                LogName = method.Name,
+                LogName = logName,
                 FullName = method.GetFullName(),
-                ShortName = method.GetShortName(),
+                ShortName = shortName,
                 IsDisabled = disabled,
                 HasCancellationToken = hasCancellationToken,
                 TraceLevel = traceAttribute?.Level ?? TraceLevel.Verbose,

--- a/src/Microsoft.Azure.WebJobs.Host/Indexers/IFunctionIndexLookup.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Indexers/IFunctionIndexLookup.cs
@@ -10,5 +10,9 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
         IFunctionDefinition Lookup(string functionId);
 
         IFunctionDefinition Lookup(MethodInfo method);
+
+        // This uses the function's short name ("Class.Method"), which can also be overriden
+        // by the FunctionName attribute. 
+        IFunctionDefinition LookupByName(string name);
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Protocols/FunctionDescriptor.cs
+++ b/src/Microsoft.Azure.WebJobs.Protocols/FunctionDescriptor.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.WebJobs.Host.Protocols
 
 #if PUBLICPROTOCOL
 #else
-        /// <summary>Gets or sets the name used for logging. This is 'Method'. </summary>
+        /// <summary>Gets or sets the name used for logging. This is 'Method' or the value overwritten by [FunctionName] </summary>
         [JsonIgnore] 
         internal string LogName { get; set; }
 

--- a/src/Microsoft.Azure.WebJobs/FunctionNameAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs/FunctionNameAttribute.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Text.RegularExpressions;
 
 namespace Microsoft.Azure.WebJobs
 {
@@ -26,5 +27,10 @@ namespace Microsoft.Azure.WebJobs
         /// Gets the function name.
         /// </summary>
         public string Name => _name;
+
+        /// <summary>
+        /// Validation for name. 
+        /// </summary>
+        public static readonly Regex FunctionNameValidationRegex = new Regex(@"^[a-z][a-z0-9_\-]{0,127}$(?<!^host$)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Common/BindToGenericItemTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Common/BindToGenericItemTests.cs
@@ -83,6 +83,9 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Common
 
                 host.Call("Func2", new { k = 1 });
                 Assert.Equal("Func2", _log);
+
+                host.Call("FuncRename", new { k = 1 });
+                Assert.Equal("newname", _log);
             }
 
             string _log;
@@ -110,6 +113,13 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Common
 
             // Missing path, will default to method name 
             public void Func2([Test2] string w)
+            {
+                _log = w;
+            }
+
+            // Missing path, will default to method name 
+            [FunctionName("newname")]
+            public void FuncRename([Test2] string w)
             {
                 _log = w;
             }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/EmptyFunctionIndexProvider.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/EmptyFunctionIndexProvider.cs
@@ -31,6 +31,11 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 return null;
             }
 
+            public IFunctionDefinition LookupByName(string name)
+            {
+                return null;
+            }
+
             public IEnumerable<IFunctionDefinition> ReadAll()
             {
                 return Enumerable.Empty<IFunctionDefinition>();

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Indexers/FunctionNameTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Indexers/FunctionNameTests.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.Loggers;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Xunit;
+using System;
+
+namespace Microsoft.Azure.WebJobs.Host.UnitTests.Indexers
+{
+    public class FunctionNameTests
+    {
+        [Fact]
+        public async Task Test()
+        {
+            var prog = new MyProg();
+            var activator = new FakeActivator();
+            activator.Add(prog);
+            var logger = new MyLogger();
+            var host = TestHelpers.NewJobHost<MyProg>(activator, logger);
+
+            // Invoke with method Info
+            var method = prog.GetType().GetMethod("Test");
+            host.Call(method);
+            prog.AssertValid();
+            logger.AssertValid();
+
+            // Invoke with new name. 
+            await host.CallAsync(MyProg.NewName);
+            prog.AssertValid();
+            logger.AssertValid();
+
+            // Invoke with original name fails 
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await host.CallAsync("Test"));
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await host.CallAsync("MyProg.Test"));
+        }    
+
+        [Fact]
+        public void TestInvalidName()
+        {
+            var host = TestHelpers.NewJobHost<ProgInvalidName>();
+            TestHelpers.AssertIndexingError(() => host.Call("Test"), "ProgInvalidName.Test", "'x y' is not a valid function name.");
+        }
+
+        public class ProgInvalidName
+        {
+            [NoAutomaticTrigger]
+            [FunctionName("x y")] // illegal charecters
+            public void Test()
+            {
+            }
+        }
+
+        public class MyLogger : IAsyncCollector<FunctionInstanceLogEntry>
+        {
+            public List<string> _items = new List<string>();
+
+            public void AssertValid()
+            {
+                Assert.Equal(MyProg.NewName, _items[0]);
+                _items.Clear();
+            }
+
+            public Task AddAsync(FunctionInstanceLogEntry item, CancellationToken cancellationToken = default(CancellationToken))
+            {
+                _items.Add(item.FunctionName);
+                return Task.CompletedTask;
+            }
+
+            public Task FlushAsync(CancellationToken cancellationToken = default(CancellationToken))
+            {
+                return Task.CompletedTask;
+            }
+        }
+
+        public class MyProg
+        {
+            public const string NewName = "otherName";
+            public int _called;
+
+            public void AssertValid()
+            {
+                Assert.Equal(1, _called);
+                _called = 0;
+            }
+
+            [NoAutomaticTrigger]
+            [FunctionName(NewName)]
+            public void Test()
+            {
+                _called++;
+            }
+        }
+    }
+}


### PR DESCRIPTION
SDK honors [FunctionName] attribute
Resolve https://github.com/Azure/azure-webjobs-sdk/issues/1170
ADd new JobHost.CallAsync(string) endpoint which can honor the method name.