### PR TITLE
Return value support for BYOB (InvokeHandler) - breaking change

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Executors/TriggeredFunctionData.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/TriggeredFunctionData.cs
@@ -24,6 +24,6 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
         /// <summary>
         /// Optional handler function for processing the invocation.
         /// </summary>
-        public Func<Func<Task>, Task> InvokeHandler { get; set; }
+        public Func<Func<Task<object>>, Task<object>> InvokeHandler { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/TriggeredFunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/TriggeredFunctionExecutor.cs
@@ -35,20 +35,9 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             var context = new FunctionInstanceFactoryContext<TTriggerValue>()
             {
                 TriggerValue = (TTriggerValue)input.TriggerValue,
-                ParentId = input.ParentId
+                ParentId = input.ParentId,
+                InvokeHandler = input.InvokeHandler,
             };
-
-            if (input.InvokeHandler != null)
-            {
-                context.InvokeHandler = async next =>
-                {
-                    await input.InvokeHandler(next);
-
-                    // NOTE: The InvokeHandler code path currently does not support flowing the return 
-                    // value back to the trigger.
-                    return null;
-                };
-            }
 
             IFunctionInstance instance = _instanceFactory.Create(context);
             IDelayedException exception = await _executor.TryExecuteAsync(instance, cancellationToken);

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/TriggeredFunctionExecutorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/TriggeredFunctionExecutorTests.cs
@@ -34,10 +34,11 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             });
 
             bool customInvokerInvoked = false;
-            Func<Func<Task>, Task> invokeHandler = async (inner) =>
+            Func<Func<Task<object>>, Task<object>> invokeHandler = async (inner) =>
             {
                 customInvokerInvoked = true;
                 await inner();
+                return null;
             };
 
             var mockTriggerBinding = new Mock<ITriggeredFunctionBinding<int>>();


### PR DESCRIPTION
This PR enables InvokeHandler implementations to get the return values of a function execution. Previously this required some lambda/Task gymnastics to get working.  This change removes the need for such gymnastics.

This is a breaking change that is only intended for 3.x. Durable Functions is the only known consumer of this API today and will absorb this breaking change once it moves to run the 3.x base platform.