### PR TITLE
removing LoggerFactory disposal again

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostContext.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostContext.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
         private readonly TraceWriter _trace;
         private readonly IAsyncCollector<FunctionInstanceLogEntry> _functionEventCollector; // optional        
         private readonly ILoggerFactory _loggerFactory;
-        
+
         private bool _disposed;
 
         public JobHostContext(IFunctionIndexLookup functionLookup,
@@ -96,7 +96,6 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             if (!_disposed)
             {
                 _listener.Dispose();
-                _loggerFactory?.Dispose();
 
                 _disposed = true;
             }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostContextTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostContextTests.cs
@@ -43,7 +43,10 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             context.Dispose();
 
             mockListener.Verify(p => p.Dispose(), Times.Once);
-            mockLoggerFactory.Verify(p => p.Dispose(), Times.Once);
+
+            // we're temporarily removing the disposal call until this issue is resolved:
+            // https://github.com/Azure/azure-webjobs-sdk-script/issues/1690
+            mockLoggerFactory.Verify(p => p.Dispose(), Times.Never);
         }
     }
 }


### PR DESCRIPTION
Temporarily addresses https://github.com/Azure/azure-webjobs-sdk-script/issues/1690