### PR TITLE
[AppInsights] using start/stop on RequestTelemetry to support Profiler

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/FunctionInstanceLogEntry.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/FunctionInstanceLogEntry.cs
@@ -26,8 +26,11 @@ namespace Microsoft.Azure.WebJobs.Host.Loggers
         /// <summary>The parent instance that caused this function instance to run. this is used to establish causality between functions. </summary>
         public Guid? ParentId { get; set; }
 
-        /// <summary>The name of the function. This serves as an identifier.</summary>
+        /// <summary>The name of the function, including the class name. This serves as an identifier.</summary>
         public string FunctionName { get; set; }
+
+        /// <summary>The name of the function method, excluding the class name.</summary>
+        public string LogName { get; set; }
 
         /// <summary>
         /// An optional hint about why this function was invoked. It may have been triggered, replayed, manually invoked, etc. 
@@ -51,8 +54,15 @@ namespace Microsoft.Azure.WebJobs.Host.Loggers
         /// </summary>
         public string ErrorDetails { get; set; }
 
-        /// <summary>Gets or sets the function's argument values and help strings.
-        /// If this is null, then the event is before binding. </summary>        
+        /// <summary>
+        /// Null on success. Else, set to the Exception thrown by the function invocation.
+        /// </summary>
+        public Exception Exception { get; set; }
+
+        /// <summary>
+        /// Gets or sets the function's argument values and help strings.
+        /// If this is null, then the event is before binding. 
+        /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
         public IDictionary<string, string> Arguments { get; set; }
 

--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/Aggregator/FunctionResultAggregate.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/Aggregator/FunctionResultAggregate.cs
@@ -23,15 +23,15 @@ namespace Microsoft.Azure.WebJobs.Logging
         {
             return new ReadOnlyDictionary<string, object>(new Dictionary<string, object>
             {
-                [LoggingKeys.Name] = Name,
-                [LoggingKeys.Count] = Count,
-                [LoggingKeys.Timestamp] = Timestamp,
-                [LoggingKeys.AverageDuration] = AverageDuration,
-                [LoggingKeys.MaxDuration] = MaxDuration,
-                [LoggingKeys.MinDuration] = MinDuration,
-                [LoggingKeys.Successes] = Successes,
-                [LoggingKeys.Failures] = Failures,
-                [LoggingKeys.SuccessRate] = SuccessRate
+                [LogConstants.NameKey] = Name,
+                [LogConstants.CountKey] = Count,
+                [LogConstants.TimestampKey] = Timestamp,
+                [LogConstants.AverageDurationKey] = AverageDuration,
+                [LogConstants.MaxDurationKey] = MaxDuration,
+                [LogConstants.MinDurationKey] = MinDuration,
+                [LogConstants.SuccessesKey] = Successes,
+                [LogConstants.FailuresKey] = Failures,
+                [LogConstants.SuccessRateKey] = SuccessRate
             });
         }
     }

--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/Constants/LogConstants.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/Constants/LogConstants.cs
@@ -8,102 +8,102 @@ namespace Microsoft.Azure.WebJobs.Logging
     /// <summary>
     /// Keys used by the <see cref="ILogger"/> infrastructure.
     /// </summary>
-    public static class LoggingKeys
+    public static class LogConstants
     {
         /// <summary>
         /// Gets the name of the key used to store the full name of the function.
         /// </summary>
-        public const string FullName = "FullName";
+        public const string FullNameKey = "FullName";
 
         /// <summary>
         /// Gets the name of the key used to store the name of the function.
         /// </summary>
-        public const string Name = "Name";
+        public const string NameKey = "Name";
 
         /// <summary>
         /// Gets the name of the key used to store the number of invocations.
         /// </summary>
-        public const string Count = "Count";
+        public const string CountKey = "Count";
 
         /// <summary>
         /// Gets the name of the key used to store the success count.
         /// </summary>
-        public const string Successes = "Successes";
+        public const string SuccessesKey = "Successes";
 
         /// <summary>
         /// Gets the name of the key used to store the failure count.
         /// </summary>
-        public const string Failures = "Failures";
+        public const string FailuresKey = "Failures";
 
         /// <summary>
         /// Gets the name of the key used to store the success rate.
         /// </summary>
-        public const string SuccessRate = "SuccessRate";
+        public const string SuccessRateKey = "SuccessRate";
 
         /// <summary>
         /// Gets the name of the key used to store the average duration in milliseconds.
         /// </summary>
-        public const string AverageDuration = "AvgDurationMs";
+        public const string AverageDurationKey = "AvgDurationMs";
 
         /// <summary>
         /// Gets the name of the key used to store the maximum duration in milliseconds.
         /// </summary>
-        public const string MaxDuration = "MaxDurationMs";
+        public const string MaxDurationKey = "MaxDurationMs";
 
         /// <summary>
         /// Gets the name of the key used to store the minimum duration in milliseconds.
         /// </summary>
-        public const string MinDuration = "MinDurationMs";
+        public const string MinDurationKey = "MinDurationMs";
 
         /// <summary>
         /// Gets the name of the key used to store the timestamp.
         /// </summary>
-        public const string Timestamp = "Timestamp";
+        public const string TimestampKey = "Timestamp";
 
         /// <summary>
         /// Gets the name of the key used to store the function invocation id.
         /// </summary>
-        public const string InvocationId = "InvocationId";
+        public const string InvocationIdKey = "InvocationId";
 
         /// <summary>
         /// Gets the name of the key used to store the trigger reason.
         /// </summary>
-        public const string TriggerReason = "TriggerReason";
+        public const string TriggerReasonKey = "TriggerReason";
 
         /// <summary>
         /// Gets the name of the key used to store the start time.
         /// </summary>
-        public const string StartTime = "StartTime";
+        public const string StartTimeKey = "StartTime";
 
         /// <summary>
         /// Gets the name of the key used to store the end time.
         /// </summary>
-        public const string EndTime = "EndTime";
+        public const string EndTimeKey = "EndTime";
 
         /// <summary>
         /// Gets the name of the key used to store the duration of the function invocation.
         /// </summary>
-        public const string Duration = "Duration";
+        public const string DurationKey = "Duration";
 
         /// <summary>
         /// Gets the name of the key used to store whether the function succeeded.
         /// </summary>
-        public const string Succeeded = "Succeeded";
+        public const string SucceededKey = "Succeeded";
 
         /// <summary>
         /// Gets the name of the key used to store the formatted message.
         /// </summary>
-        public const string FormattedMessage = "FormattedMessage";
+        public const string FormattedMessageKey = "FormattedMessage";
 
         /// <summary>
         /// Gets the name of the key used to store the category of the log message.
         /// </summary>
-        public const string CategoryName = "Category";
+        public const string CategoryNameKey = "Category";
 
         /// <summary>
         /// Gets the name of the key used to store the HTTP method.
         /// </summary>
-        public const string HttpMethod = "HttpMethod";
+        public const string HttpMethodKey = "HttpMethod";
 
         /// <summary>
         /// Gets the prefix for custom properties.
@@ -118,11 +118,16 @@ namespace Microsoft.Azure.WebJobs.Logging
         /// <summary>
         /// Gets the name of the key used to store the original format of the log message.
         /// </summary>
-        public const string OriginalFormat = "{OriginalFormat}";
+        public const string OriginalFormatKey = "{OriginalFormat}";
 
         /// <summary>
         /// Gets the name of the key used to store the <see cref="LogLevel"/> of the log message.
         /// </summary>
-        public const string LogLevel = "LogLevel";
+        public const string LogLevelKey = "LogLevel";
+
+        /// <summary>
+        /// Gets the function start event name.
+        /// </summary>
+        public const string FunctionStartEvent = "FunctionStart";
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/Constants/ScopeKeys.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/Constants/ScopeKeys.cs
@@ -17,5 +17,10 @@ namespace Microsoft.Azure.WebJobs.Logging
         /// A key identifying the function name.
         /// </summary>
         public const string FunctionName = "MS_FunctionName";
+
+        /// <summary>
+        /// A key identifying the event starting with the current scope
+        /// </summary>
+        public const string Event = "MS_Event";
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
+++ b/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
@@ -510,7 +510,7 @@
     <Compile Include="Loggers\Logger\Aggregator\FunctionResultAggregatorFactory.cs" />
     <Compile Include="Loggers\Logger\Aggregator\IFunctionResultAggregatorFactory.cs" />
     <Compile Include="Loggers\Logger\Constants\LogCategories.cs" />
-    <Compile Include="Loggers\Logger\Constants\LoggingKeys.cs" />
+    <Compile Include="Loggers\Logger\Constants\LogConstants.cs" />
     <Compile Include="Loggers\Logger\Constants\ScopeKeys.cs" />
     <Compile Include="Loggers\Logger\LoggerExtensions.cs" />
     <Compile Include="Loggers\Logger\LogCategoryFilter.cs" />

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/FilteringTelemetryProcessor.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/FilteringTelemetryProcessor.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
             if (telemetry != null && _filter != null)
             {
                 string categoryName = null;
-                if (!telemetry.Properties.TryGetValue(LoggingKeys.CategoryName, out categoryName))
+                if (!telemetry.Properties.TryGetValue(LogConstants.CategoryNameKey, out categoryName))
                 {
                     // If no category is specified, it will be filtered by the default filter
                     categoryName = string.Empty;
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                 // Extract the log level and apply the filter
                 string logLevelString = null;
                 LogLevel logLevel;
-                if (telemetry.Properties.TryGetValue(LoggingKeys.LogLevel, out logLevelString) &&
+                if (telemetry.Properties.TryGetValue(LogConstants.LogLevelKey, out logLevelString) &&
                     Enum.TryParse(logLevelString, out logLevel))
                 {
                     enabled = _filter(categoryName, logLevel);

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobsTelemetryInitializer.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobsTelemetryInitializer.cs
@@ -35,27 +35,23 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
             // Apply our special scope properties
             IDictionary<string, object> scopeProps = DictionaryLoggerScope.GetMergedStateDictionary() ?? new Dictionary<string, object>();
 
-            Guid invocationId = scopeProps.GetValueOrDefault<Guid>(ScopeKeys.FunctionInvocationId);
-            if (invocationId != default(Guid))
-            {
-                telemetry.Context.Operation.Id = invocationId.ToString();
-            }
+            telemetry.Context.Operation.Id = scopeProps.GetValueOrDefault<string>(ScopeKeys.FunctionInvocationId);
             telemetry.Context.Operation.Name = scopeProps.GetValueOrDefault<string>(ScopeKeys.FunctionName);
 
             // Apply Category and LogLevel to all telemetry
             ISupportProperties telemetryProps = telemetry as ISupportProperties;
             if (telemetryProps != null)
             {
-                string category = scopeProps.GetValueOrDefault<string>(LoggingKeys.CategoryName);
+                string category = scopeProps.GetValueOrDefault<string>(LogConstants.CategoryNameKey);
                 if (category != null)
                 {
-                    telemetryProps.Properties[LoggingKeys.CategoryName] = category;
+                    telemetryProps.Properties[LogConstants.CategoryNameKey] = category;
                 }
 
-                LogLevel? logLevel = scopeProps.GetValueOrDefault<LogLevel?>(LoggingKeys.LogLevel);
+                LogLevel? logLevel = scopeProps.GetValueOrDefault<LogLevel?>(LogConstants.LogLevelKey);
                 if (logLevel != null)
                 {
-                    telemetryProps.Properties[LoggingKeys.LogLevel] = logLevel.Value.ToString();
+                    telemetryProps.Properties[LogConstants.LogLevelKey] = logLevel.Value.ToString();
                 }
             }
         }

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsightsEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsightsEndToEndTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
@@ -9,10 +10,12 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse;
 using Microsoft.ApplicationInsights.WindowsServer.Channel.Implementation;
 using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Microsoft.Azure.WebJobs.Host.Timers;
 using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Azure.WebJobs.Logging.ApplicationInsights;
 using Microsoft.Extensions.Logging;
@@ -25,6 +28,8 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
     {
         private const string _mockApplicationInsightsUrl = "http://localhost:4005/v2/track/";
         private const string _mockQuickPulseUrl = "http://localhost:4005/QuickPulseService.svc/";
+
+        private readonly TestTelemetryChannel _channel = new TestTelemetryChannel();
         private const string _mockApplicationInsightsKey = "some_key";
 
         [Fact]
@@ -36,7 +41,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
             var loggerFactory = new LoggerFactory()
                 .AddApplicationInsights(
-                    new TestTelemetryClientFactory(_mockApplicationInsightsKey, new SamplingPercentageEstimatorSettings(), filter.Filter));
+                    new TestTelemetryClientFactory(filter.Filter, _channel));
 
             JobHostConfiguration config = new JobHostConfiguration
             {
@@ -45,42 +50,34 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             };
             config.Aggregator.IsEnabled = false;
 
-            using (var listener = new ApplicationInsightsTestListener())
+            using (JobHost host = new JobHost(config))
             {
-                listener.StartListening();
-
-                using (JobHost host = new JobHost(config))
-                {
-                    await host.StartAsync();
-                    var methodInfo = GetType().GetMethod(testName, BindingFlags.Public | BindingFlags.Static);
-                    await host.CallAsync(methodInfo, new { input = "function input" });
-                    await host.StopAsync();
-                }
-
-                // wait for everything to flush
-                await Task.Delay(2000);
-
-                Assert.Equal(6, listener.TelemetryItems.Count);
-
-                // Validate the traces. Order by message string as the requests may come in
-                // slightly out-of-order or on different threads
-                TelemetryPayload[] telemetries = listener.TelemetryItems
-                    .Where(t => t.Data.BaseType == "MessageData")
-                    .OrderBy(t => t.Data.BaseData.Message)
-                    .ToArray();
-
-                ValidateTrace(telemetries[0], "Found the following functions:\r\n", LogCategories.Startup);
-                ValidateTrace(telemetries[1], "Job host started", LogCategories.Startup);
-                ValidateTrace(telemetries[2], "Job host stopped", LogCategories.Startup);
-                ValidateTrace(telemetries[3], "Logger", LogCategories.Function, testName);
-                ValidateTrace(telemetries[4], "Trace", LogCategories.Function, testName);
-
-                // Finally, validate the request
-                TelemetryPayload request = listener.TelemetryItems
-                    .Where(t => t.Data.BaseType == "RequestData")
-                    .Single();
-                ValidateRequest(request, testName, true);
+                await host.StartAsync();
+                var methodInfo = GetType().GetMethod(testName, BindingFlags.Public | BindingFlags.Static);
+                await host.CallAsync(methodInfo, new { input = "function input" });
+                await host.StopAsync();
             }
+
+            Assert.Equal(6, _channel.Telemetries.Count);
+
+            // Validate the traces. Order by message string as the requests may come in
+            // slightly out-of-order or on different threads
+            TraceTelemetry[] telemetries = _channel.Telemetries
+                .OfType<TraceTelemetry>()
+                .OrderBy(t => t.Message)
+                .ToArray();
+
+            ValidateTrace(telemetries[0], "Found the following functions:\r\n", LogCategories.Startup);
+            ValidateTrace(telemetries[1], "Job host started", LogCategories.Startup);
+            ValidateTrace(telemetries[2], "Job host stopped", LogCategories.Startup);
+            ValidateTrace(telemetries[3], "Logger", LogCategories.Function, testName);
+            ValidateTrace(telemetries[4], "Trace", LogCategories.Function, testName);
+
+            // Finally, validate the request
+            RequestTelemetry request = _channel.Telemetries
+                .OfType<RequestTelemetry>()
+                .Single();
+            ValidateRequest(request, testName, true);
         }
 
         [Fact]
@@ -92,7 +89,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
             var loggerFactory = new LoggerFactory()
                 .AddApplicationInsights(
-                    new TestTelemetryClientFactory(_mockApplicationInsightsKey, new SamplingPercentageEstimatorSettings(), filter.Filter));
+                    new TestTelemetryClientFactory(filter.Filter, _channel));
 
             JobHostConfiguration config = new JobHostConfiguration
             {
@@ -101,48 +98,40 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             };
             config.Aggregator.IsEnabled = false;
 
-            using (var listener = new ApplicationInsightsTestListener())
+            using (JobHost host = new JobHost(config))
             {
-                listener.StartListening();
-
-                using (JobHost host = new JobHost(config))
-                {
-                    await host.StartAsync();
-                    var methodInfo = GetType().GetMethod(testName, BindingFlags.Public | BindingFlags.Static);
-                    await Assert.ThrowsAsync<FunctionInvocationException>(() => host.CallAsync(methodInfo, new { input = "function input" }));
-                    await host.StopAsync();
-                }
-
-                // wait for everything to flush
-                await Task.Delay(2000);
-
-                Assert.Equal(7, listener.TelemetryItems.Count);
-
-                // Validate the traces. Order by message string as the requests may come in
-                // slightly out-of-order or on different threads
-                TelemetryPayload[] telemetries = listener.TelemetryItems
-                    .Where(t => t.Data.BaseType == "MessageData")
-                    .OrderBy(t => t.Data.BaseData.Message)
-                    .ToArray();
-
-                ValidateTrace(telemetries[0], "Found the following functions:\r\n", LogCategories.Startup);
-                ValidateTrace(telemetries[1], "Job host started", LogCategories.Startup);
-                ValidateTrace(telemetries[2], "Job host stopped", LogCategories.Startup);
-                ValidateTrace(telemetries[3], "Logger", LogCategories.Function, testName);
-                ValidateTrace(telemetries[4], "Trace", LogCategories.Function, testName);
-
-                // Validate the exception
-                TelemetryPayload exception = listener.TelemetryItems
-                    .Where(t => t.Data.BaseType == "ExceptionData")
-                    .Single();
-                ValidateException(exception, testName);
-
-                // Finally, validate the request
-                TelemetryPayload request = listener.TelemetryItems
-                    .Where(t => t.Data.BaseType == "RequestData")
-                    .Single();
-                ValidateRequest(request, testName, false);
+                await host.StartAsync();
+                var methodInfo = GetType().GetMethod(testName, BindingFlags.Public | BindingFlags.Static);
+                await Assert.ThrowsAsync<FunctionInvocationException>(() => host.CallAsync(methodInfo, new { input = "function input" }));
+                await host.StopAsync();
             }
+
+            Assert.Equal(7, _channel.Telemetries.Count);
+
+            // Validate the traces. Order by message string as the requests may come in
+            // slightly out-of-order or on different threads
+            TraceTelemetry[] telemetries = _channel.Telemetries
+             .OfType<TraceTelemetry>()
+             .OrderBy(t => t.Message)
+             .ToArray();
+
+            ValidateTrace(telemetries[0], "Found the following functions:\r\n", LogCategories.Startup);
+            ValidateTrace(telemetries[1], "Job host started", LogCategories.Startup);
+            ValidateTrace(telemetries[2], "Job host stopped", LogCategories.Startup);
+            ValidateTrace(telemetries[3], "Logger", LogCategories.Function, testName);
+            ValidateTrace(telemetries[4], "Trace", LogCategories.Function, testName);
+
+            // Validate the exception
+            ExceptionTelemetry exception = _channel.Telemetries
+                .OfType<ExceptionTelemetry>()
+                .Single();
+            ValidateException(exception, testName);
+
+            // Finally, validate the request
+            RequestTelemetry request = _channel.Telemetries
+                .OfType<RequestTelemetry>()
+                .Single();
+            ValidateRequest(request, testName, false);
         }
 
         [Theory]
@@ -156,7 +145,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
             var loggerFactory = new LoggerFactory()
                 .AddApplicationInsights(
-                    new TestTelemetryClientFactory(_mockApplicationInsightsKey, new SamplingPercentageEstimatorSettings(), filter.Filter));
+                    new TestTelemetryClientFactory(filter.Filter, _channel));
 
             JobHostConfiguration config = new JobHostConfiguration
             {
@@ -200,7 +189,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 Assert.True(sum > min && sum < max, $"Expected sum to be greater than {min} and less than {max}. DefaultLevel: {defaultLevel}. Actual: {sum}");
 
                 // These will be filtered based on the default filter.
-                Assert.Equal(expectedTelemetryItems, listener.TelemetryItems.Count());
+                Assert.Equal(expectedTelemetryItems, _channel.Telemetries.Count());
             }
         }
 
@@ -233,8 +222,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
             private readonly HttpListener _applicationInsightsListener = new HttpListener();
             private Thread _listenerThread;
-
-            public List<TelemetryPayload> TelemetryItems { get; } = new List<TelemetryPayload>();
 
             public List<QuickPulsePayload> QuickPulseItems { get; } = new List<QuickPulsePayload>();
 
@@ -281,7 +268,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     }
                     else
                     {
-                        HandleTelemetryRequest(request);
+                        throw new NotSupportedException();
                     }
                 }
                 finally
@@ -300,21 +287,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     QuickPulsePayload[] quickPulse = JsonConvert.DeserializeObject<QuickPulsePayload[]>(result);
                     QuickPulseItems.AddRange(quickPulse);
                 }
-            }
-
-            private void HandleTelemetryRequest(HttpListenerRequest request)
-            {
-                string result = GetRequestContent(request);
-
-                if (!string.IsNullOrWhiteSpace(request.Headers["Content-Encoding"]) &&
-                       string.Equals("gzip", request.Headers["Content-Encoding"],
-                           StringComparison.InvariantCultureIgnoreCase))
-                {
-                    result = Decompress(result);
-                }
-
-                TelemetryPayload telemetry = JsonConvert.DeserializeObject<TelemetryPayload>(result);
-                TelemetryItems.Add(telemetry);
             }
 
             private static string GetRequestContent(HttpListenerRequest request)
@@ -366,164 +338,69 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             }
         }
 
-        private class TestTelemetryClientFactory : DefaultTelemetryClientFactory
-        {
-            public TestTelemetryClientFactory(string instrumentationKey, SamplingPercentageEstimatorSettings samplingSettings, Func<string, LogLevel, bool> filter)
-                : base(instrumentationKey, samplingSettings, filter)
-            {
-            }
-
-            protected override QuickPulseTelemetryModule CreateQuickPulseTelemetryModule()
-            {
-                QuickPulseTelemetryModule module = base.CreateQuickPulseTelemetryModule();
-                module.QuickPulseServiceEndpoint = _mockQuickPulseUrl;
-                return module;
-            }
-
-            protected override ITelemetryChannel CreateTelemetryChannel()
-            {
-                ITelemetryChannel channel = base.CreateTelemetryChannel();
-                channel.EndpointAddress = _mockApplicationInsightsUrl;
-
-                // DeveloperMode prevents buffering so items are sent immediately.
-                channel.DeveloperMode = true;
-                ((ServerTelemetryChannel)channel).MaxTelemetryBufferDelay = TimeSpan.FromSeconds(1);
-
-                return channel;
-            }
-        }
-
-        private static void ValidateTrace(TelemetryPayload telemetryItem, string expectedMessageStartsWith,
+        private static void ValidateTrace(TraceTelemetry telemetry, string expectedMessageStartsWith,
             string expectedCategory, string expectedOperationName = null)
         {
-            Assert.Equal("MessageData", telemetryItem.Data.BaseType);
+            Assert.StartsWith(expectedMessageStartsWith, telemetry.Message);
+            Assert.Equal(SeverityLevel.Information, telemetry.SeverityLevel);
 
-            Assert.StartsWith(expectedMessageStartsWith, telemetryItem.Data.BaseData.Message);
-            Assert.Equal("Information", telemetryItem.Data.BaseData.SeverityLevel);
-
-            Assert.Equal(expectedCategory, telemetryItem.Data.BaseData.Properties["Category"]);
+            Assert.Equal(expectedCategory, telemetry.Properties["Category"]);
 
             if (expectedCategory == LogCategories.Function || expectedCategory == LogCategories.Executor)
             {
                 // These should have associated operation information
-                Assert.Equal(expectedOperationName, telemetryItem.Tags["ai.operation.name"]);
-                Assert.NotNull(telemetryItem.Tags["ai.operation.id"]);
+                Assert.Equal(expectedOperationName, telemetry.Context.Operation.Name);
+                Assert.NotNull(telemetry.Context.Operation.Id);
             }
             else
             {
-                Assert.DoesNotContain("ai.operation.name", telemetryItem.Tags.Keys);
-                Assert.DoesNotContain("ai.operation.id", telemetryItem.Tags.Keys);
+                Assert.Null(telemetry.Context.Operation.Name);
+                Assert.Null(telemetry.Context.Operation.Id);
             }
 
-            ValidateSdkVersion(telemetryItem);
+            ValidateSdkVersion(telemetry);
         }
 
-        private static void ValidateException(TelemetryPayload telemetryItem, string expectedOperationName)
+        private static void ValidateException(ExceptionTelemetry telemetryItem, string expectedOperationName)
         {
-            Assert.Equal("ExceptionData", telemetryItem.Data.BaseType);
-
-            Assert.Null(telemetryItem.Data.BaseData.Name);
-            Assert.Equal("Host.Results", telemetryItem.Data.BaseData.Properties["Category"]);
-            Assert.Equal(expectedOperationName, telemetryItem.Tags["ai.operation.name"]);
-            Assert.NotNull(telemetryItem.Tags["ai.operation.id"]);
+            Assert.Equal("Host.Results", telemetryItem.Properties["Category"]);
+            Assert.Equal(expectedOperationName, telemetryItem.Context.Operation.Name);
+            Assert.NotNull(telemetryItem.Context.Operation.Id);
 
             // Check that the Function details show up as 'prop__'. We may change this in the future as
             // it may not be exceptionally useful.
-            Assert.Equal(expectedOperationName, telemetryItem.Data.BaseData.Properties[$"{LoggingKeys.CustomPropertyPrefix}{LoggingKeys.Name}"]);
-            Assert.Equal("This function was programmatically called via the host APIs.", telemetryItem.Data.BaseData.Properties[$"{LoggingKeys.CustomPropertyPrefix}{LoggingKeys.TriggerReason}"]);
+            Assert.Equal(expectedOperationName, telemetryItem.Properties[$"{LogConstants.CustomPropertyPrefix}{LogConstants.NameKey}"]);
+            Assert.Equal("This function was programmatically called via the host APIs.", telemetryItem.Properties[$"{LogConstants.CustomPropertyPrefix}{LogConstants.TriggerReasonKey}"]);
 
             // TODO: Parameter logging shouldn't have prop__ prefixes. Need to revisit.
-            Assert.Equal("function input", telemetryItem.Data.BaseData.Properties[$"{LoggingKeys.CustomPropertyPrefix}{LoggingKeys.ParameterPrefix}input"]);
+            Assert.Equal("function input", telemetryItem.Properties[$"{LogConstants.CustomPropertyPrefix}{LogConstants.ParameterPrefix}input"]);
 
-            Assert.Equal(2, telemetryItem.Data.BaseData.Exceptions.Length);
-
-            TelemetryException first = telemetryItem.Data.BaseData.Exceptions[0];
-            Assert.Equal("Microsoft.Azure.WebJobs.Host.FunctionInvocationException", first.TypeName);
-            Assert.Equal("n/a", first.Message);
-            Assert.True(first.HasFullStack);
-
-            TelemetryException second = telemetryItem.Data.BaseData.Exceptions[1];
-            Assert.Equal("System.Exception", second.TypeName);
-            Assert.Equal("Boom!", second.Message);
-            Assert.True(second.HasFullStack);
+            Assert.IsType<FunctionInvocationException>(telemetryItem.Exception);
+            Assert.IsType<Exception>(telemetryItem.Exception.InnerException);
 
             ValidateSdkVersion(telemetryItem);
         }
 
-        private static void ValidateRequest(TelemetryPayload telemetryItem, string operationName, bool success)
+        private static void ValidateRequest(RequestTelemetry telemetry, string operationName, bool success)
         {
-            Assert.Equal("RequestData", telemetryItem.Data.BaseType);
+            Assert.NotNull(telemetry.Context.Operation.Id);
+            Assert.Equal(operationName, telemetry.Context.Operation.Name);
+            Assert.NotNull(telemetry.Duration);
+            Assert.Equal(success, telemetry.Success);
 
-            Assert.NotNull(telemetryItem.Data.BaseData.Id);
-            Assert.Equal(operationName, telemetryItem.Data.BaseData.Name);
-            Assert.NotNull(telemetryItem.Data.BaseData.Duration);
-            Assert.Equal(success, telemetryItem.Data.BaseData.Success);
+            Assert.NotNull(telemetry.Properties[$"{LogConstants.ParameterPrefix}input"]);
+            Assert.Equal($"ApplicationInsightsEndToEndTests.{operationName}", telemetry.Properties[LogConstants.FullNameKey].ToString());
+            Assert.Equal("This function was programmatically called via the host APIs.", telemetry.Properties[LogConstants.TriggerReasonKey].ToString());
 
-            Assert.NotNull(telemetryItem.Data.BaseData.Properties[$"{LoggingKeys.ParameterPrefix}input"]);
-            Assert.Equal($"ApplicationInsightsEndToEndTests.{operationName}", telemetryItem.Data.BaseData.Properties[LoggingKeys.FullName].ToString());
-            Assert.Equal("This function was programmatically called via the host APIs.", telemetryItem.Data.BaseData.Properties[LoggingKeys.TriggerReason].ToString());
-
-            ValidateSdkVersion(telemetryItem);
+            ValidateSdkVersion(telemetry);
         }
 
-        private static void ValidateSdkVersion(TelemetryPayload telemetryItem)
+        private static void ValidateSdkVersion(ITelemetry telemetry)
         {
-            Assert.StartsWith("webjobs: ", telemetryItem.Tags["ai.internal.sdkVersion"]);
-        }
+            PropertyInfo propInfo = typeof(TelemetryContext).GetProperty("Tags", BindingFlags.NonPublic | BindingFlags.Instance);
+            IDictionary<string, string> tags = propInfo.GetValue(telemetry.Context) as IDictionary<string, string>;
 
-        private class TelemetryPayload
-        {
-            public string Name { get; set; }
-
-            public DateTime Time { get; set; }
-
-            public string IKey { get; set; }
-
-            public IDictionary<string, string> Tags { get; } = new Dictionary<string, string>();
-
-            public TelemetryData Data { get; } = new TelemetryData();
-
-            public override string ToString()
-            {
-                return Data.BaseData.Message;
-            }
-        }
-
-        private class TelemetryData
-        {
-            public string BaseType { get; set; }
-
-            public TelemetryBaseData BaseData { get; } = new TelemetryBaseData();
-        }
-
-        private class TelemetryException
-        {
-            public string TypeName { get; set; }
-
-            public string Message { get; set; }
-
-            public bool HasFullStack { get; set; }
-        }
-
-        private class TelemetryBaseData
-        {
-            public string Id { get; set; }
-
-            public string Name { get; set; }
-
-            public TimeSpan Duration { get; set; }
-
-            public bool? Success { get; set; }
-
-            public string Ver { get; set; }
-
-            public string Message { get; set; }
-
-            public string SeverityLevel { get; set; }
-
-            public TelemetryException[] Exceptions { get; set; }
-
-            public IDictionary<string, string> Properties { get; } = new Dictionary<string, string>();
+            Assert.StartsWith("webjobs: ", tags["ai.internal.sdkVersion"]);
         }
 
         private class QuickPulsePayload
@@ -544,6 +421,51 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             public double Value { get; set; }
 
             public int Weight { get; set; }
+        }        
+
+        private class TestTelemetryClientFactory : DefaultTelemetryClientFactory
+        {
+            private TestTelemetryChannel _channel;
+
+            public TestTelemetryClientFactory(Func<string, LogLevel, bool> filter, TestTelemetryChannel channel)
+                : base(_mockApplicationInsightsKey, new SamplingPercentageEstimatorSettings(), filter)
+            {
+                _channel = channel;
+            }
+
+            protected override QuickPulseTelemetryModule CreateQuickPulseTelemetryModule()
+            {
+                QuickPulseTelemetryModule module = base.CreateQuickPulseTelemetryModule();
+                module.QuickPulseServiceEndpoint = _mockQuickPulseUrl;
+                return module;
+            }
+
+            protected override ITelemetryChannel CreateTelemetryChannel()
+            {
+                return _channel;
+            }
+        }
+
+        private class TestTelemetryChannel : ITelemetryChannel
+        {
+            public ConcurrentBag<ITelemetry> Telemetries = new ConcurrentBag<ITelemetry>();
+
+            public bool? DeveloperMode { get; set; }
+
+            public string EndpointAddress { get; set; }
+
+            public void Dispose()
+            {
+            }
+
+            public void Flush()
+            {
+            }
+
+            public void Send(ITelemetry item)
+            {
+                Telemetries.Add(item);
+            }
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/FilteringTelemetryProcessorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/FilteringTelemetryProcessorTests.cs
@@ -41,8 +41,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             var processor = new FilteringTelemetryProcessor(filter.Filter, _nextTelemetryProcessorMock.Object);
 
             var telemetry = new TestTelemetry();
-            telemetry.Properties[LoggingKeys.CategoryName] = LogCategories.Results;
-            telemetry.Properties[LoggingKeys.LogLevel] = telemetryLevel.ToString();
+            telemetry.Properties[LogConstants.CategoryNameKey] = LogCategories.Results;
+            telemetry.Properties[LogConstants.LogLevelKey] = telemetryLevel.ToString();
 
             processor.Process(telemetry);
 
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             var processor = new FilteringTelemetryProcessor(filter.Filter, _nextTelemetryProcessorMock.Object);
 
             var telemetry = new TestTelemetry();
-            telemetry.Properties[LoggingKeys.LogLevel] = telemetryLevel.ToString();
+            telemetry.Properties[LogConstants.LogLevelKey] = telemetryLevel.ToString();
             // no category specified
 
             processor.Process(telemetry);
@@ -110,7 +110,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             var processor = new FilteringTelemetryProcessor(filter.Filter, _nextTelemetryProcessorMock.Object);
 
             var telemetry = new TestTelemetry();
-            telemetry.Properties[LoggingKeys.CategoryName] = LogCategories.Results;
+            telemetry.Properties[LogConstants.CategoryNameKey] = LogCategories.Results;
             // no log level specified
 
             processor.Process(telemetry);
@@ -129,8 +129,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             var processor = new FilteringTelemetryProcessor(filter.Filter, _nextTelemetryProcessorMock.Object);
 
             var telemetry = new TestTelemetry();
-            telemetry.Properties[LoggingKeys.CategoryName] = LogCategories.Results;
-            telemetry.Properties[LoggingKeys.LogLevel] = "InvalidLevel";
+            telemetry.Properties[LogConstants.CategoryNameKey] = LogCategories.Results;
+            telemetry.Properties[LogConstants.LogLevelKey] = "InvalidLevel";
 
             processor.Process(telemetry);
             _nextTelemetryProcessorMock.Verify(m => m.Process(telemetry), Times.Once);

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/FunctionResultAggregatorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/FunctionResultAggregatorTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             ILoggerFactory factory = CreateMockLoggerFactory((props) =>
             {
                 publishCalls++;
-                Assert.Equal(batchSize, props[LoggingKeys.Successes]);
+                Assert.Equal(batchSize, props[LogConstants.SuccessesKey]);
             });
 
             var aggregator = new FunctionResultAggregator(batchSize, TimeSpan.FromMinutes(1), factory);
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             ILoggerFactory factory = CreateMockLoggerFactory((props) =>
             {
                 publishCalls++;
-                Assert.Equal(numberToInsert, props[LoggingKeys.Successes]);
+                Assert.Equal(numberToInsert, props[LogConstants.SuccessesKey]);
             });
 
             var aggregator = new FunctionResultAggregator(batchSize, TimeSpan.FromSeconds(1), factory);
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             ILoggerFactory factory = CreateMockLoggerFactory((props) =>
             {
                 publishCalls++;
-                totalSuccesses += Convert.ToInt32(props[LoggingKeys.Successes]);
+                totalSuccesses += Convert.ToInt32(props[LogConstants.SuccessesKey]);
             });
 
             var aggregator = new FunctionResultAggregator(batchSize, TimeSpan.FromSeconds(1), factory);
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             ILoggerFactory factory = CreateMockLoggerFactory((props) =>
             {
                 publishCalls++;
-                Assert.Equal(10, props[LoggingKeys.Successes]);
+                Assert.Equal(10, props[LogConstants.SuccessesKey]);
             });
 
             var aggregator = new FunctionResultAggregator(batchSize, TimeSpan.FromSeconds(1), factory);
@@ -116,8 +116,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             ILoggerFactory factory = CreateMockLoggerFactory((props) =>
             {
                 publishCalls++;
-                Assert.Equal(10, props[LoggingKeys.Successes]);
-                Assert.Equal("SomeTest", props[LoggingKeys.Name]);
+                Assert.Equal(10, props[LogConstants.SuccessesKey]);
+                Assert.Equal("SomeTest", props[LogConstants.NameKey]);
             });
 
             var aggregator = new FunctionResultAggregator(batchSize, TimeSpan.FromSeconds(1), factory);
@@ -134,8 +134,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             ILoggerFactory factory = CreateMockLoggerFactory((props) =>
             {
                 publishCalls++;
-                Assert.Equal(10, props[LoggingKeys.Successes]);
-                Assert.Equal("AnotherClass.SomeTest", props[LoggingKeys.Name]);
+                Assert.Equal(10, props[LogConstants.SuccessesKey]);
+                Assert.Equal("AnotherClass.SomeTest", props[LogConstants.NameKey]);
             });
 
             var aggregator = new FunctionResultAggregator(batchSize, TimeSpan.FromSeconds(1), factory);

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
@@ -232,7 +232,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 "FunctionResultAggregatorConfiguration",
                 "LogCategoryFilter",
                 "LogCategories",
-                "LoggingKeys",
+                "LogConstants",
                 "ScopeKeys",
                 "IDistributedLockManager",
                 "IDistributedLock",


### PR DESCRIPTION
Fixes #1147 

In order to support the App Insights Profiler, we need to emit Start/StopOperation(). This change now starts the operation just before the function begins, stores the operation in the current scope, and then stops the operation when we log the final result. The end result should be the same as before this change, but now the App Insights Profiler can work as expected.