### PR TITLE
Caching assembly name resolution

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/AssemblyNameCache.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/AssemblyNameCache.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.WebJobs.Host
+{
+    /// <summary>
+    /// Caches a mapping of Assembly objects to their corresponding AssemblyNames.
+    /// </summary>
+    public static class AssemblyNameCache
+    {
+        private static readonly ConcurrentDictionary<Assembly, AssemblyName> AssemblyToNameCache = new ConcurrentDictionary<Assembly, AssemblyName>();
+
+        /// <summary>
+        /// Returns a cached copy of the given Assembly's AssemblyName if available, otherwise, retrieves the AssemblyName, caches it and returns it.
+        /// </summary>
+        /// <param name="assembly">The Assembly</param>
+        /// <returns>The AssemblyName</returns>
+        public static AssemblyName GetName(Assembly assembly)
+        {
+            return AssemblyToNameCache.GetOrAdd(assembly, asm => asm.GetName());
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostConfigurationExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostConfigurationExtensions.cs
@@ -328,7 +328,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
 
                     IEnumerable<MethodInfo> indexedMethods = functions.ReadAllMethods();
                     Assembly hostAssembly = GetHostAssembly(indexedMethods);
-                    string displayName = hostAssembly != null ? hostAssembly.GetName().Name : "Unknown";
+                    string displayName = hostAssembly != null ? AssemblyNameCache.GetName(hostAssembly).Name : "Unknown";
 
                     hostOutputMessage = new DataOnlyHostOutputMessage
                     {

--- a/src/Microsoft.Azure.WebJobs.Host/Extensions/JobHostMetadataProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Extensions/JobHostMetadataProvider.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.WebJobs.Host
 
         private void AddAssembly(Assembly assembly)
         {
-            AssemblyName name = assembly.GetName();
+            AssemblyName name = AssemblyNameCache.GetName(assembly);
             _resolvedAssemblies[name.FullName] = assembly;
             _resolvedAssemblies[name.Name] = assembly;
         }

--- a/src/Microsoft.Azure.WebJobs.Host/Indexers/DefaultTypeLocator.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Indexers/DefaultTypeLocator.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
     // Default policy for locating types. 
     internal class DefaultTypeLocator : ITypeLocator
     {
-        private static readonly string WebJobsAssemblyName = typeof(TableAttribute).Assembly.GetName().Name;
+        private static readonly string WebJobsAssemblyName = AssemblyNameCache.GetName(typeof(TableAttribute).Assembly).Name;
 
         private readonly TextWriter _log;
         private readonly IExtensionRegistry _extensions;
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
                     return true;
                 }
 
-                if (extensionAssemblies.Any(p => string.Equals(referencedAssemblyName.Name, p.GetName().Name, StringComparison.OrdinalIgnoreCase)))
+                if (extensionAssemblies.Any(p => string.Equals(referencedAssemblyName.Name, AssemblyNameCache.GetName(p).Name, StringComparison.OrdinalIgnoreCase)))
                 {
                     // the assembly references an extension assembly that may
                     // contain extension attributes

--- a/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
+++ b/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
@@ -452,6 +452,7 @@
     <Compile Include="..\Microsoft.Azure.WebJobs.Storage\Table\TypeEntityResolver.cs">
       <Link>Storage\Table\TypeEntityResolver.cs</Link>
     </Compile>
+    <Compile Include="AssemblyNameCache.cs" />
     <Compile Include="AzureStorageDeploymentValidator.cs" />
     <Compile Include="Bindings\AmbientBindingContext.cs" />
     <Compile Include="Bindings\AttributeCloner.cs" />

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
@@ -235,7 +235,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 "LoggingKeys",
                 "ScopeKeys",
                 "IDistributedLockManager",
-                "IDistributedLock"
+                "IDistributedLock",
+                "AssemblyNameCache"
             };
 
             AssertPublicTypes(expected, assembly);


### PR DESCRIPTION
These are changes proposed by Kranthi based on results from his performance tests.

The `Assembly.GetName()` calls throughout the code are fairly expensive, and caching the result has a measurable impact.