### PR TITLE
workaround for TaskCanceledExceptions wrapped in StorageException

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Queues/Listeners/QueueListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Queues/Listeners/QueueListener.cs
@@ -266,6 +266,10 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Listeners
 
                 await _queueProcessor.CompleteProcessingMessageAsync(message.SdkObject, result, cancellationToken);
             }
+            catch (StorageException ex) when (ex.IsTaskCanceled())
+            {
+                // TaskCanceledExceptions may be wrapped in StorageException.
+            }
             catch (OperationCanceledException)
             {
                 // Don't fail the top-level task when an inner task cancels.

--- a/src/Microsoft.Azure.WebJobs.Host/Timers/TaskSeriesTimer.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Timers/TaskSeriesTimer.cs
@@ -5,6 +5,8 @@ using System;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.Storage;
+using Microsoft.WindowsAzure.Storage;
 
 namespace Microsoft.Azure.WebJobs.Host.Timers
 {
@@ -146,6 +148,11 @@ namespace Microsoft.Azure.WebJobs.Host.Timers
                     {
                         TaskSeriesCommandResult result = await _command.ExecuteAsync(cancellationToken);
                         wait = result.Wait;
+                    }
+                    catch (StorageException ex) when (ex.IsTaskCanceled())
+                    {
+                        // TaskCanceledExceptions coming from storage are wrapped in a StorageException.
+                        // We'll handle them all here so they don't have to be managed for every call.
                     }
                     catch (OperationCanceledException)
                     {

--- a/src/Microsoft.Azure.WebJobs.Storage/StorageExceptionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Storage/StorageExceptionExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.WindowsAzure.Storage;
 
 #if PUBLICSTORAGE
@@ -743,6 +744,21 @@ namespace Microsoft.Azure.WebJobs.Host.Storage
             }
 
             return extendedInformation.ErrorCode == "LeaseLost";
+        }
+
+        /// <summary>
+        /// Determines whether the exception is due to a task cancellation.
+        /// </summary>
+        /// <param name="exception">The storage exception.</param>
+        /// <returns><see langword="true"/> if the inner exception is a <see cref="TaskCanceledException"/>. Otherwise, <see langword="false"/>.</returns>
+        public static bool IsTaskCanceled(this StorageException exception)
+        {
+            if (exception == null)
+            {
+                throw new ArgumentNullException("exception");
+            }
+
+            return exception.InnerException is TaskCanceledException;
         }
 
         /// <summary>

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsightsEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsightsEndToEndTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Microsoft.Azure.WebJobs.Host.Timers;
 using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Azure.WebJobs.Logging.ApplicationInsights;
 using Microsoft.Extensions.Logging;
@@ -36,9 +37,10 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             JobHostConfiguration config = new JobHostConfiguration
             {
                 LoggerFactory = loggerFactory,
-                TypeLocator = new FakeTypeLocator(GetType()),
+                TypeLocator = new FakeTypeLocator(GetType()),                
             };
             config.Aggregator.IsEnabled = false;
+            config.AddService<IWebJobsExceptionHandler>(new TestExceptionHandler());
 
             using (JobHost host = new JobHost(config))
             {
@@ -87,6 +89,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 TypeLocator = new FakeTypeLocator(GetType()),
             };
             config.Aggregator.IsEnabled = false;
+            config.AddService<IWebJobsExceptionHandler>(new TestExceptionHandler());
 
             using (JobHost host = new JobHost(config))
             {

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/TestExceptionHandler.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/TestExceptionHandler.cs
@@ -5,6 +5,7 @@ using System;
 using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Timers;
+using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Host.TestCommon
 {
@@ -16,15 +17,13 @@ namespace Microsoft.Azure.WebJobs.Host.TestCommon
 
         public Task OnTimeoutExceptionAsync(ExceptionDispatchInfo exceptionInfo, TimeSpan timeoutGracePeriod)
         {
-            Console.WriteLine("Timeout exception in test exception handler: {0}", exceptionInfo);
-
+            Assert.True(false, $"Timeout exception in test exception handler: {exceptionInfo.SourceException}");
             return Task.CompletedTask;
         }
 
         public Task OnUnhandledExceptionAsync(ExceptionDispatchInfo exceptionInfo)
         {
-            Console.WriteLine("Error in test exception handler: {0}", exceptionInfo);
-
+            Assert.True(false, $"Error in test exception handler: {exceptionInfo.SourceException}");
             return Task.CompletedTask;
         }
     }


### PR DESCRIPTION
We had a series of E2E tests failing due to unhandled `StorageException`s. It looks like the Core version of the Storage SDK is inconsistent with what exception it handles during task cancellation. This affects us during shutdown, which is where these exceptions were coming from. I've filed https://github.com/Azure/azure-storage-net/issues/512 to track in the storage SDK.

For now, we'll handle both wherever we need to.

I also changed the TestExceptionHandler to fail a test if it gets an unexpected exception. This will let us know if there are other unhandled issues that we're missing.