### PR TITLE
[AppInsights] using start/stop on RequestTelemetry to support Profiler

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionExecutor.cs
@@ -83,12 +83,13 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             string functionStartedMessageId = null;
             TraceLevel functionTraceLevel = functionInstance.FunctionDescriptor.TraceLevel;
 
-            FunctionInstanceLogEntry fastItem = await this.NotifyPreBindAsync(functionStartedMessage);
+            FunctionInstanceLogEntry fastItem = null;
                         
             try
             {
                 using (_logger?.BeginFunctionScope(functionInstance))
                 {
+                    fastItem = await this.NotifyPreBindAsync(functionStartedMessage);
                     functionStartedMessageId = await ExecuteWithLoggingAsync(functionInstance, functionStartedMessage, fastItem, parameterHelper, functionTraceLevel, cancellationToken);
                 }
                 functionCompletedMessage = CreateCompletedMessage(functionStartedMessage);
@@ -127,11 +128,10 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             {
                 logCompletedCancellationToken = cancellationToken;
             }
-
-            await NotifyCompleteAsync(fastItem, functionCompletedMessage.Arguments, exceptionInfo);
-          
+            
             using (_resultsLogger?.BeginFunctionScope(functionInstance))
             {
+                await NotifyCompleteAsync(fastItem, functionCompletedMessage.Arguments, exceptionInfo);
                 _resultsLogger?.LogFunctionResult(functionInstance.FunctionDescriptor.LogName, fastItem, fastItem.LiveTimer.Elapsed, exceptionInfo?.SourceException);
             }
 

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionExecutor.cs
@@ -8,7 +8,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -84,66 +83,63 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             TraceLevel functionTraceLevel = functionInstance.FunctionDescriptor.TraceLevel;
 
             FunctionInstanceLogEntry fastItem = null;
-                        
-            try
-            {
-                using (_logger?.BeginFunctionScope(functionInstance))
-                {
-                    fastItem = await this.NotifyPreBindAsync(functionStartedMessage);
-                    functionStartedMessageId = await ExecuteWithLoggingAsync(functionInstance, functionStartedMessage, fastItem, parameterHelper, functionTraceLevel, cancellationToken);
-                }
-                functionCompletedMessage = CreateCompletedMessage(functionStartedMessage);
-            }
-            catch (Exception exception)
-            {
-                if (functionCompletedMessage == null)
-                {
-                    functionCompletedMessage = CreateCompletedMessage(functionStartedMessage);
-                }
 
-                functionCompletedMessage.Failure = new FunctionFailure
-                {
-                    Exception = exception,
-                    ExceptionType = exception.GetType().FullName,
-                    ExceptionDetails = exception.ToDetails(),
-                };
-
-                exceptionInfo = ExceptionDispatchInfo.Capture(exception);
-            }
-
-            if (functionCompletedMessage != null)
-            {
-                functionCompletedMessage.ParameterLogs = parameterHelper.ParameterLogCollector;
-                functionCompletedMessage.EndTime = DateTimeOffset.UtcNow;
-            }
-
-            bool loggedStartedEvent = functionStartedMessageId != null;
-            CancellationToken logCompletedCancellationToken;
-            if (loggedStartedEvent)
-            {
-                // If function started was logged, don't cancel calls to log function completed.
-                logCompletedCancellationToken = CancellationToken.None;
-            }
-            else
-            {
-                logCompletedCancellationToken = cancellationToken;
-            }
-            
             using (_resultsLogger?.BeginFunctionScope(functionInstance))
             {
+                try
+                {
+                    fastItem = await NotifyPreBindAsync(functionStartedMessage);
+                    functionStartedMessageId = await ExecuteWithLoggingAsync(functionInstance, functionStartedMessage, fastItem, parameterHelper, functionTraceLevel, cancellationToken);
+                    functionCompletedMessage = CreateCompletedMessage(functionStartedMessage);
+                }
+                catch (Exception exception)
+                {
+                    if (functionCompletedMessage == null)
+                    {
+                        functionCompletedMessage = CreateCompletedMessage(functionStartedMessage);
+                    }
+
+                    functionCompletedMessage.Failure = new FunctionFailure
+                    {
+                        Exception = exception,
+                        ExceptionType = exception.GetType().FullName,
+                        ExceptionDetails = exception.ToDetails(),
+                    };
+
+                    exceptionInfo = ExceptionDispatchInfo.Capture(exception);
+                }
+
+                if (functionCompletedMessage != null)
+                {
+                    functionCompletedMessage.ParameterLogs = parameterHelper.ParameterLogCollector;
+                    functionCompletedMessage.EndTime = DateTimeOffset.UtcNow;
+                }
+
+                bool loggedStartedEvent = functionStartedMessageId != null;
+                CancellationToken logCompletedCancellationToken;
+                if (loggedStartedEvent)
+                {
+                    // If function started was logged, don't cancel calls to log function completed.
+                    logCompletedCancellationToken = CancellationToken.None;
+                }
+                else
+                {
+                    logCompletedCancellationToken = cancellationToken;
+                }
+
                 await NotifyCompleteAsync(fastItem, functionCompletedMessage.Arguments, exceptionInfo);
-                _resultsLogger?.LogFunctionResult(functionInstance.FunctionDescriptor.LogName, fastItem, fastItem.LiveTimer.Elapsed, exceptionInfo?.SourceException);
-            }
+                _resultsLogger?.LogFunctionResult(fastItem);
 
-            if (functionCompletedMessage != null &&
-                ((functionTraceLevel >= TraceLevel.Info) || (functionCompletedMessage.Failure != null && functionTraceLevel >= TraceLevel.Error)))
-            {
-                await _functionInstanceLogger.LogFunctionCompletedAsync(functionCompletedMessage, logCompletedCancellationToken);
-            }
+                if (functionCompletedMessage != null &&
+                    ((functionTraceLevel >= TraceLevel.Info) || (functionCompletedMessage.Failure != null && functionTraceLevel >= TraceLevel.Error)))
+                {
+                    await _functionInstanceLogger.LogFunctionCompletedAsync(functionCompletedMessage, logCompletedCancellationToken);
+                }
 
-            if (loggedStartedEvent)
-            {
-                await _functionInstanceLogger.DeleteLogFunctionStartedAsync(functionStartedMessageId, cancellationToken);
+                if (loggedStartedEvent)
+                {
+                    await _functionInstanceLogger.DeleteLogFunctionStartedAsync(functionStartedMessageId, cancellationToken);
+                }
             }
 
             if (exceptionInfo != null)
@@ -209,13 +205,13 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
 
                     // Must bind before logging (bound invoke string is included in log message).
                     FunctionBindingContext functionContext = new FunctionBindingContext(
-                        instance.Id, 
-                        functionCancellationTokenSource.Token, 
+                        instance.Id,
+                        functionCancellationTokenSource.Token,
                         traceWriter,
                         instance.FunctionDescriptor);
                     var valueBindingContext = new ValueBindingContext(functionContext, cancellationToken);
                     await parameterHelper.BindAsync(instance.BindingSource, valueBindingContext);
-                    
+
                     Exception invocationException = null;
                     ExceptionDispatchInfo exceptionInfo = null;
                     string startedMessageId = null;
@@ -432,7 +428,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             ParameterHelper parameterHelper,
             TraceWriter trace,
             ILogger logger,
-            IFunctionOutputDefinition outputDefinition,            
+            IFunctionOutputDefinition outputDefinition,
             TraceLevel functionTraceLevel,
             CancellationTokenSource functionCancellationTokenSource)
         {
@@ -658,6 +654,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
                 FunctionInstanceId = functionStartedMessage.FunctionInstanceId,
                 ParentId = functionStartedMessage.ParentId,
                 FunctionName = functionStartedMessage.Function.ShortName,
+                LogName = functionStartedMessage.Function.LogName,
                 TriggerReason = functionStartedMessage.ReasonDetails,
                 StartTime = functionStartedMessage.StartTime.DateTime,
                 Properties = new Dictionary<string, object>(),
@@ -704,6 +701,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             if (exceptionInfo != null)
             {
                 var ex = exceptionInfo.SourceException;
+                fastItem.Exception = ex;
                 if (ex.InnerException != null)
                 {
                     ex = ex.InnerException;
@@ -887,7 +885,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
 
                     if (binder != null)
                     {
-                        bool isReturn = name == FunctionIndexer.ReturnParamName;                        
+                        bool isReturn = name == FunctionIndexer.ReturnParamName;
                         object argument = isReturn ? this._returnValue : this.InvokeParameters[this.GetParameterIndex(name)];
 
                         try

--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/FunctionInstanceLogEntry.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/FunctionInstanceLogEntry.cs
@@ -26,8 +26,11 @@ namespace Microsoft.Azure.WebJobs.Host.Loggers
         /// <summary>The parent instance that caused this function instance to run. this is used to establish causality between functions. </summary>
         public Guid? ParentId { get; set; }
 
-        /// <summary>The name of the function. This serves as an identifier.</summary>
+        /// <summary>The name of the function, including the class name. This serves as an identifier.</summary>
         public string FunctionName { get; set; }
+
+        /// <summary>The name of the function method, excluding the class name.</summary>
+        public string LogName { get; set; }
 
         /// <summary>
         /// An optional hint about why this function was invoked. It may have been triggered, replayed, manually invoked, etc. 
@@ -51,8 +54,15 @@ namespace Microsoft.Azure.WebJobs.Host.Loggers
         /// </summary>
         public string ErrorDetails { get; set; }
 
-        /// <summary>Gets or sets the function's argument values and help strings.
-        /// If this is null, then the event is before binding. </summary>        
+        /// <summary>
+        /// Null on success. Else, set to the Exception thrown by the function invocation.
+        /// </summary>
+        public Exception Exception { get; set; }
+
+        /// <summary>
+        /// Gets or sets the function's argument values and help strings.
+        /// If this is null, then the event is before binding. 
+        /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
         public IDictionary<string, string> Arguments { get; set; }
 

--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/Aggregator/FunctionResultAggregate.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/Aggregator/FunctionResultAggregate.cs
@@ -23,15 +23,15 @@ namespace Microsoft.Azure.WebJobs.Logging
         {
             return new ReadOnlyDictionary<string, object>(new Dictionary<string, object>
             {
-                [LoggingKeys.Name] = Name,
-                [LoggingKeys.Count] = Count,
-                [LoggingKeys.Timestamp] = Timestamp,
-                [LoggingKeys.AverageDuration] = AverageDuration,
-                [LoggingKeys.MaxDuration] = MaxDuration,
-                [LoggingKeys.MinDuration] = MinDuration,
-                [LoggingKeys.Successes] = Successes,
-                [LoggingKeys.Failures] = Failures,
-                [LoggingKeys.SuccessRate] = SuccessRate
+                [LogConstants.NameKey] = Name,
+                [LogConstants.CountKey] = Count,
+                [LogConstants.TimestampKey] = Timestamp,
+                [LogConstants.AverageDurationKey] = AverageDuration,
+                [LogConstants.MaxDurationKey] = MaxDuration,
+                [LogConstants.MinDurationKey] = MinDuration,
+                [LogConstants.SuccessesKey] = Successes,
+                [LogConstants.FailuresKey] = Failures,
+                [LogConstants.SuccessRateKey] = SuccessRate
             });
         }
     }

--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/Constants/LogConstants.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/Constants/LogConstants.cs
@@ -8,102 +8,102 @@ namespace Microsoft.Azure.WebJobs.Logging
     /// <summary>
     /// Keys used by the <see cref="ILogger"/> infrastructure.
     /// </summary>
-    public static class LoggingKeys
+    public static class LogConstants
     {
         /// <summary>
         /// Gets the name of the key used to store the full name of the function.
         /// </summary>
-        public const string FullName = "FullName";
+        public const string FullNameKey = "FullName";
 
         /// <summary>
         /// Gets the name of the key used to store the name of the function.
         /// </summary>
-        public const string Name = "Name";
+        public const string NameKey = "Name";
 
         /// <summary>
         /// Gets the name of the key used to store the number of invocations.
         /// </summary>
-        public const string Count = "Count";
+        public const string CountKey = "Count";
 
         /// <summary>
         /// Gets the name of the key used to store the success count.
         /// </summary>
-        public const string Successes = "Successes";
+        public const string SuccessesKey = "Successes";
 
         /// <summary>
         /// Gets the name of the key used to store the failure count.
         /// </summary>
-        public const string Failures = "Failures";
+        public const string FailuresKey = "Failures";
 
         /// <summary>
         /// Gets the name of the key used to store the success rate.
         /// </summary>
-        public const string SuccessRate = "SuccessRate";
+        public const string SuccessRateKey = "SuccessRate";
 
         /// <summary>
         /// Gets the name of the key used to store the average duration in milliseconds.
         /// </summary>
-        public const string AverageDuration = "AvgDurationMs";
+        public const string AverageDurationKey = "AvgDurationMs";
 
         /// <summary>
         /// Gets the name of the key used to store the maximum duration in milliseconds.
         /// </summary>
-        public const string MaxDuration = "MaxDurationMs";
+        public const string MaxDurationKey = "MaxDurationMs";
 
         /// <summary>
         /// Gets the name of the key used to store the minimum duration in milliseconds.
         /// </summary>
-        public const string MinDuration = "MinDurationMs";
+        public const string MinDurationKey = "MinDurationMs";
 
         /// <summary>
         /// Gets the name of the key used to store the timestamp.
         /// </summary>
-        public const string Timestamp = "Timestamp";
+        public const string TimestampKey = "Timestamp";
 
         /// <summary>
         /// Gets the name of the key used to store the function invocation id.
         /// </summary>
-        public const string InvocationId = "InvocationId";
+        public const string InvocationIdKey = "InvocationId";
 
         /// <summary>
         /// Gets the name of the key used to store the trigger reason.
         /// </summary>
-        public const string TriggerReason = "TriggerReason";
+        public const string TriggerReasonKey = "TriggerReason";
 
         /// <summary>
         /// Gets the name of the key used to store the start time.
         /// </summary>
-        public const string StartTime = "StartTime";
+        public const string StartTimeKey = "StartTime";
 
         /// <summary>
         /// Gets the name of the key used to store the end time.
         /// </summary>
-        public const string EndTime = "EndTime";
+        public const string EndTimeKey = "EndTime";
 
         /// <summary>
         /// Gets the name of the key used to store the duration of the function invocation.
         /// </summary>
-        public const string Duration = "Duration";
+        public const string DurationKey = "Duration";
 
         /// <summary>
         /// Gets the name of the key used to store whether the function succeeded.
         /// </summary>
-        public const string Succeeded = "Succeeded";
+        public const string SucceededKey = "Succeeded";
 
         /// <summary>
         /// Gets the name of the key used to store the formatted message.
         /// </summary>
-        public const string FormattedMessage = "FormattedMessage";
+        public const string FormattedMessageKey = "FormattedMessage";
 
         /// <summary>
         /// Gets the name of the key used to store the category of the log message.
         /// </summary>
-        public const string CategoryName = "Category";
+        public const string CategoryNameKey = "Category";
 
         /// <summary>
         /// Gets the name of the key used to store the HTTP method.
         /// </summary>
-        public const string HttpMethod = "HttpMethod";
+        public const string HttpMethodKey = "HttpMethod";
 
         /// <summary>
         /// Gets the prefix for custom properties.
@@ -118,11 +118,16 @@ namespace Microsoft.Azure.WebJobs.Logging
         /// <summary>
         /// Gets the name of the key used to store the original format of the log message.
         /// </summary>
-        public const string OriginalFormat = "{OriginalFormat}";
+        public const string OriginalFormatKey = "{OriginalFormat}";
 
         /// <summary>
         /// Gets the name of the key used to store the <see cref="LogLevel"/> of the log message.
         /// </summary>
-        public const string LogLevel = "LogLevel";
+        public const string LogLevelKey = "LogLevel";
+
+        /// <summary>
+        /// Gets the function start event name.
+        /// </summary>
+        public const string FunctionStartEvent = "FunctionStart";
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/Constants/ScopeKeys.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/Constants/ScopeKeys.cs
@@ -17,5 +17,10 @@ namespace Microsoft.Azure.WebJobs.Logging
         /// A key identifying the function name.
         /// </summary>
         public const string FunctionName = "MS_FunctionName";
+
+        /// <summary>
+        /// A key identifying the event starting with the current scope
+        /// </summary>
+        public const string Event = "MS_Event";
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/FilteringTelemetryProcessor.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/FilteringTelemetryProcessor.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
             if (telemetry != null && _filter != null)
             {
                 string categoryName = null;
-                if (!telemetry.Properties.TryGetValue(LoggingKeys.CategoryName, out categoryName))
+                if (!telemetry.Properties.TryGetValue(LogConstants.CategoryNameKey, out categoryName))
                 {
                     // If no category is specified, it will be filtered by the default filter
                     categoryName = string.Empty;
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                 // Extract the log level and apply the filter
                 string logLevelString = null;
                 LogLevel logLevel;
-                if (telemetry.Properties.TryGetValue(LoggingKeys.LogLevel, out logLevelString) &&
+                if (telemetry.Properties.TryGetValue(LogConstants.LogLevelKey, out logLevelString) &&
                     Enum.TryParse(logLevelString, out logLevel))
                 {
                     enabled = _filter(categoryName, logLevel);

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobsTelemetryInitializer.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobsTelemetryInitializer.cs
@@ -35,27 +35,23 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
             // Apply our special scope properties
             IDictionary<string, object> scopeProps = DictionaryLoggerScope.GetMergedStateDictionary() ?? new Dictionary<string, object>();
 
-            Guid invocationId = scopeProps.GetValueOrDefault<Guid>(ScopeKeys.FunctionInvocationId);
-            if (invocationId != default(Guid))
-            {
-                telemetry.Context.Operation.Id = invocationId.ToString();
-            }
+            telemetry.Context.Operation.Id = scopeProps.GetValueOrDefault<string>(ScopeKeys.FunctionInvocationId);
             telemetry.Context.Operation.Name = scopeProps.GetValueOrDefault<string>(ScopeKeys.FunctionName);
 
             // Apply Category and LogLevel to all telemetry
             ISupportProperties telemetryProps = telemetry as ISupportProperties;
             if (telemetryProps != null)
             {
-                string category = scopeProps.GetValueOrDefault<string>(LoggingKeys.CategoryName);
+                string category = scopeProps.GetValueOrDefault<string>(LogConstants.CategoryNameKey);
                 if (category != null)
                 {
-                    telemetryProps.Properties[LoggingKeys.CategoryName] = category;
+                    telemetryProps.Properties[LogConstants.CategoryNameKey] = category;
                 }
 
-                LogLevel? logLevel = scopeProps.GetValueOrDefault<LogLevel?>(LoggingKeys.LogLevel);
+                LogLevel? logLevel = scopeProps.GetValueOrDefault<LogLevel?>(LogConstants.LogLevelKey);
                 if (logLevel != null)
                 {
-                    telemetryProps.Properties[LoggingKeys.LogLevel] = logLevel.Value.ToString();
+                    telemetryProps.Properties[LogConstants.LogLevelKey] = logLevel.Value.ToString();
                 }
             }
         }

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsightsEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsightsEndToEndTests.cs
@@ -176,11 +176,11 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
             // Check that the Function details show up as 'prop__'. We may change this in the future as
             // it may not be exceptionally useful.
-            Assert.Equal(expectedOperationName, telemetryItem.Properties[$"{LoggingKeys.CustomPropertyPrefix}{LoggingKeys.Name}"]);
-            Assert.Equal("This function was programmatically called via the host APIs.", telemetryItem.Properties[$"{LoggingKeys.CustomPropertyPrefix}{LoggingKeys.TriggerReason}"]);
+            Assert.Equal(expectedOperationName, telemetryItem.Properties[$"{LogConstants.CustomPropertyPrefix}{LogConstants.NameKey}"]);
+            Assert.Equal("This function was programmatically called via the host APIs.", telemetryItem.Properties[$"{LogConstants.CustomPropertyPrefix}{LogConstants.TriggerReasonKey}"]);
 
             // TODO: Parameter logging shouldn't have prop__ prefixes. Need to revisit.
-            Assert.Equal("function input", telemetryItem.Properties[$"{LoggingKeys.CustomPropertyPrefix}{LoggingKeys.ParameterPrefix}input"]);
+            Assert.Equal("function input", telemetryItem.Properties[$"{LogConstants.CustomPropertyPrefix}{LogConstants.ParameterPrefix}input"]);
                         
             Assert.IsType<FunctionInvocationException>(telemetryItem.Exception);
             Assert.IsType<Exception>(telemetryItem.Exception.InnerException);
@@ -195,9 +195,9 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             Assert.NotNull(telemetry.Duration);
             Assert.Equal(success, telemetry.Success);
 
-            Assert.NotNull(telemetry.Properties[$"{LoggingKeys.ParameterPrefix}input"]);
-            Assert.Equal($"ApplicationInsightsEndToEndTests.{operationName}", telemetry.Properties[LoggingKeys.FullName].ToString());
-            Assert.Equal("This function was programmatically called via the host APIs.", telemetry.Properties[LoggingKeys.TriggerReason].ToString());
+            Assert.NotNull(telemetry.Properties[$"{LogConstants.ParameterPrefix}input"]);
+            Assert.Equal($"ApplicationInsightsEndToEndTests.{operationName}", telemetry.Properties[LogConstants.FullNameKey].ToString());
+            Assert.Equal("This function was programmatically called via the host APIs.", telemetry.Properties[LogConstants.TriggerReasonKey].ToString());
 
             ValidateSdkVersion(telemetry);
         }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsLoggerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsLoggerTests.cs
@@ -37,11 +37,12 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
         private readonly TestTelemetryChannel _channel = new TestTelemetryChannel();
         private readonly string defaultIp = "0.0.0.0";
         private readonly TelemetryClient _client;
-        private readonly int durationMs = 450;
+        private readonly int _durationMs = 450;
+        private readonly IFunctionInstance _functionInstance;
 
         public ApplicationInsightsLoggerTests()
         {
-            _endTime = _startTime.AddMilliseconds(durationMs);
+            _endTime = _startTime.AddMilliseconds(_durationMs);
             _arguments = new Dictionary<string, string>
             {
                 ["queueMessage"] = "my message",
@@ -58,6 +59,14 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             DefaultTelemetryClientFactory.AddInitializers(config);
 
             _client = new TelemetryClient(config);
+
+            var descriptor = new FunctionDescriptor
+            {
+                FullName = _functionFullName,
+                ShortName = _functionShortName
+            };
+
+            _functionInstance = new FunctionInstance(_invocationId, null, ExecutionReason.AutomaticTrigger, null, null, descriptor);
         }
 
         [Fact]
@@ -68,53 +77,59 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
 
             using (logger.BeginFunctionScope(CreateFunctionInstance(_invocationId)))
             {
-                logger.LogFunctionResult(_functionShortName, result, TimeSpan.FromMilliseconds(durationMs));
+                logger.LogFunctionResult(result);
             }
 
             RequestTelemetry telemetry = _channel.Telemetries.Single() as RequestTelemetry;
 
-            Assert.Equal(_invocationId.ToString(), telemetry.Id);
             Assert.Equal(_invocationId.ToString(), telemetry.Context.Operation.Id);
             Assert.Equal(_functionShortName, telemetry.Name);
             Assert.Equal(_functionShortName, telemetry.Context.Operation.Name);
             Assert.Equal(defaultIp, telemetry.Context.Location.Ip);
-            Assert.Equal(LogCategories.Results, telemetry.Properties[LoggingKeys.CategoryName]);
-            Assert.Equal(LogLevel.Information.ToString(), telemetry.Properties[LoggingKeys.LogLevel]);
+            Assert.Equal(LogCategories.Results, telemetry.Properties[LogConstants.CategoryNameKey]);
+            Assert.Equal(LogLevel.Information.ToString(), telemetry.Properties[LogConstants.LogLevelKey]);
+            Assert.Equal("my message", telemetry.Properties[$"{LogConstants.ParameterPrefix}queueMessage"]);
+            Assert.Equal(_triggerReason, telemetry.Properties[LogConstants.TriggerReasonKey]);
             // TODO: Beef up validation to include properties
+
+            // Starting the telemetry prefixes/postfixes values to the request id, but the original guid is there
+            Assert.Contains(_invocationId.ToString(), telemetry.Id);
         }
 
         [Fact]
         public void LogFunctionResult_Failed_SendsCorrectTelemetry()
         {
-            var result = CreateDefaultInstanceLogEntry();
             FunctionInvocationException fex = new FunctionInvocationException("Failed");
+            var result = CreateDefaultInstanceLogEntry(fex);
             ILogger logger = CreateLogger(LogCategories.Results);
 
             using (logger.BeginFunctionScope(CreateFunctionInstance(_invocationId)))
             {
-                logger.LogFunctionResult(_functionShortName, result, TimeSpan.FromMilliseconds(durationMs), fex);
+                logger.LogFunctionResult(result);
             }
 
             // Errors log an associated Exception
             RequestTelemetry requestTelemetry = _channel.Telemetries.OfType<RequestTelemetry>().Single();
             ExceptionTelemetry exceptionTelemetry = _channel.Telemetries.OfType<ExceptionTelemetry>().Single();
-
+            
             Assert.Equal(2, _channel.Telemetries.Count);
-            Assert.Equal(_invocationId.ToString(), requestTelemetry.Id);
             Assert.Equal(_invocationId.ToString(), requestTelemetry.Context.Operation.Id);
             Assert.Equal(_functionShortName, requestTelemetry.Name);
             Assert.Equal(_functionShortName, requestTelemetry.Context.Operation.Name);
             Assert.Equal(defaultIp, requestTelemetry.Context.Location.Ip);
-            Assert.Equal(LogCategories.Results, requestTelemetry.Properties[LoggingKeys.CategoryName]);
-            Assert.Equal(LogLevel.Error.ToString(), requestTelemetry.Properties[LoggingKeys.LogLevel]);
+            Assert.Equal(LogCategories.Results, requestTelemetry.Properties[LogConstants.CategoryNameKey]);
+            Assert.Equal(LogLevel.Error.ToString(), requestTelemetry.Properties[LogConstants.LogLevelKey]);
             // TODO: Beef up validation to include properties
+
+            // Starting the telemetry prefixes/postfixes values to the request id, but the original guid is there
+            Assert.Contains(_invocationId.ToString(), requestTelemetry.Id);
 
             // Exception needs to have associated id
             Assert.Equal(_invocationId.ToString(), exceptionTelemetry.Context.Operation.Id);
             Assert.Equal(_functionShortName, exceptionTelemetry.Context.Operation.Name);
             Assert.Same(fex, exceptionTelemetry.Exception);
-            Assert.Equal(LogCategories.Results, exceptionTelemetry.Properties[LoggingKeys.CategoryName]);
-            Assert.Equal(LogLevel.Error.ToString(), exceptionTelemetry.Properties[LoggingKeys.LogLevel]);
+            Assert.Equal(LogCategories.Results, exceptionTelemetry.Properties[LogConstants.CategoryNameKey]);
+            Assert.Equal(LogLevel.Error.ToString(), exceptionTelemetry.Properties[LogConstants.LogLevelKey]);
             // TODO: Beef up validation to include properties
         }
 
@@ -142,21 +157,21 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
 
             Assert.Equal(7, metricDict.Count);
 
-            ValidateMetric(metricDict[$"{_functionFullName} {LoggingKeys.Failures}"], 4, LogLevel.Information);
-            ValidateMetric(metricDict[$"{_functionFullName} {LoggingKeys.Successes}"], 116, LogLevel.Information);
-            ValidateMetric(metricDict[$"{_functionFullName} {LoggingKeys.MinDuration}"], 200, LogLevel.Information);
-            ValidateMetric(metricDict[$"{_functionFullName} {LoggingKeys.MaxDuration}"], 2180, LogLevel.Information);
-            ValidateMetric(metricDict[$"{_functionFullName} {LoggingKeys.AverageDuration}"], 340, LogLevel.Information);
-            ValidateMetric(metricDict[$"{_functionFullName} {LoggingKeys.SuccessRate}"], 96.67, LogLevel.Information);
-            ValidateMetric(metricDict[$"{_functionFullName} {LoggingKeys.Count}"], 120, LogLevel.Information);
+            ValidateMetric(metricDict[$"{_functionFullName} {LogConstants.FailuresKey}"], 4, LogLevel.Information);
+            ValidateMetric(metricDict[$"{_functionFullName} {LogConstants.SuccessesKey}"], 116, LogLevel.Information);
+            ValidateMetric(metricDict[$"{_functionFullName} {LogConstants.MinDurationKey}"], 200, LogLevel.Information);
+            ValidateMetric(metricDict[$"{_functionFullName} {LogConstants.MaxDurationKey}"], 2180, LogLevel.Information);
+            ValidateMetric(metricDict[$"{_functionFullName} {LogConstants.AverageDurationKey}"], 340, LogLevel.Information);
+            ValidateMetric(metricDict[$"{_functionFullName} {LogConstants.SuccessRateKey}"], 96.67, LogLevel.Information);
+            ValidateMetric(metricDict[$"{_functionFullName} {LogConstants.CountKey}"], 120, LogLevel.Information);
         }
 
         private static void ValidateMetric(MetricTelemetry metric, double expectedValue, LogLevel expectedLevel, string expectedCategory = LogCategories.Aggregator)
         {
             Assert.Equal(expectedValue, metric.Value);
             Assert.Equal(2, metric.Properties.Count);
-            Assert.Equal(expectedCategory, metric.Properties[LoggingKeys.CategoryName]);
-            Assert.Equal(expectedLevel.ToString(), metric.Properties[LoggingKeys.LogLevel]);
+            Assert.Equal(expectedCategory, metric.Properties[LogConstants.CategoryNameKey]);
+            Assert.Equal(expectedLevel.ToString(), metric.Properties[LogConstants.LogLevelKey]);
         }
 
         [Fact]
@@ -184,28 +199,33 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             MockHttpRequest(request, "1.2.3.4", items);
 
             ILogger logger = CreateLogger(LogCategories.Results);
-            var scopeProps = CreateScopeDictionary(_invocationId, _functionShortName);
+            var scopeProps = CreateScopeDictionary(_invocationId.ToString(), _functionShortName);
             scopeProps[ApplicationInsightsScopeKeys.HttpRequest] = request.Object;
 
             using (logger.BeginScope(scopeProps))
             {
-                logger.LogFunctionResult(_functionShortName, result, TimeSpan.FromMilliseconds(durationMs));
+                using (logger.BeginFunctionScope(CreateFunctionInstance(_invocationId)))
+                {
+                    logger.LogFunctionResult(result);
+                }
             }
 
             RequestTelemetry telemetry = _channel.Telemetries.Single() as RequestTelemetry;
-
-            Assert.Equal(_invocationId.ToString(), telemetry.Id);
+            
             Assert.Equal(_invocationId.ToString(), telemetry.Context.Operation.Id);
             Assert.Equal(_functionShortName, telemetry.Name);
             Assert.Equal(_functionShortName, telemetry.Context.Operation.Name);
             Assert.Equal("1.2.3.4", telemetry.Context.Location.Ip);
-            Assert.Equal("POST", telemetry.Properties[LoggingKeys.HttpMethod]);
+            Assert.Equal("POST", telemetry.Properties[LogConstants.HttpMethodKey]);
             Assert.Equal(new Uri("http://someuri/api/path"), telemetry.Url);
             Assert.Equal("my custom user agent", telemetry.Context.User.UserAgent);
             Assert.Equal("200", telemetry.ResponseCode);
-            Assert.Equal(LogCategories.Results, telemetry.Properties[LoggingKeys.CategoryName]);
-            Assert.Equal(LogLevel.Information.ToString(), telemetry.Properties[LoggingKeys.LogLevel]);
-            // TODO: Beef up validation to include properties      
+            Assert.Equal(LogCategories.Results, telemetry.Properties[LogConstants.CategoryNameKey]);
+            Assert.Equal(LogLevel.Information.ToString(), telemetry.Properties[LogConstants.LogLevelKey]);
+            // TODO: Beef up validation to include properties
+
+            // Starting the telemetry prefixes/postfixes values to the request id, but the original guid is there
+            Assert.Contains(_invocationId.ToString(), telemetry.Id);
         }
 
         [Fact]
@@ -213,8 +233,9 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
         {
             // If the scope has an HttpRequestMessage, we'll use the proper values
             // for the RequestTelemetry
+            Exception fex = new Exception("Boom");
             DateTime now = DateTime.UtcNow;
-            var result = CreateDefaultInstanceLogEntry();
+            var result = CreateDefaultInstanceLogEntry(fex);
 
             var request = new Mock<HttpRequest>();
             request.SetupGet(r => r.Scheme).Returns("http");
@@ -232,13 +253,16 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             MockHttpRequest(request, "1.2.3.4");
 
             ILogger logger = CreateLogger(LogCategories.Results);
-            var scopeProps = CreateScopeDictionary(_invocationId, _functionShortName);
+            var scopeProps = CreateScopeDictionary(_invocationId.ToString(), _functionShortName);
             scopeProps[ApplicationInsightsScopeKeys.HttpRequest] = request.Object;
 
-            Exception fex = new Exception("Boom");
+            // simulate HttpTrigger, which wraps the function call with HTTP details.
             using (logger.BeginScope(scopeProps))
             {
-                logger.LogFunctionResult(_functionShortName, result, TimeSpan.FromMilliseconds(durationMs), fex);
+                using (logger.BeginFunctionScope(CreateFunctionInstance(_invocationId)))
+                {
+                    logger.LogFunctionResult(result);
+                }
             }
 
             // one Exception, one Request
@@ -247,24 +271,26 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             RequestTelemetry requestTelemetry = _channel.Telemetries.Where(t => t is RequestTelemetry).Single() as RequestTelemetry;
             ExceptionTelemetry exceptionTelemetry = _channel.Telemetries.Where(t => t is ExceptionTelemetry).Single() as ExceptionTelemetry;
 
-            Assert.Equal(_invocationId.ToString(), requestTelemetry.Id);
             Assert.Equal(_invocationId.ToString(), requestTelemetry.Context.Operation.Id);
             Assert.Equal(_functionShortName, requestTelemetry.Name);
             Assert.Equal(_functionShortName, requestTelemetry.Context.Operation.Name);
             Assert.Equal("1.2.3.4", requestTelemetry.Context.Location.Ip);
-            Assert.Equal("POST", requestTelemetry.Properties[LoggingKeys.HttpMethod]);
+            Assert.Equal("POST", requestTelemetry.Properties[LogConstants.HttpMethodKey]);
             Assert.Equal(new Uri("http://someuri/api/path"), requestTelemetry.Url);
             Assert.Equal("my custom user agent", requestTelemetry.Context.User.UserAgent);
             Assert.Equal("500", requestTelemetry.ResponseCode);
-            Assert.Equal(LogCategories.Results, requestTelemetry.Properties[LoggingKeys.CategoryName]);
-            Assert.Equal(LogLevel.Error.ToString(), requestTelemetry.Properties[LoggingKeys.LogLevel]);
+            Assert.Equal(LogCategories.Results, requestTelemetry.Properties[LogConstants.CategoryNameKey]);
+            Assert.Equal(LogLevel.Error.ToString(), requestTelemetry.Properties[LogConstants.LogLevelKey]);
+
+            // Starting the telemetry prefixes/postfixes values to the request id, but the original guid is there
+            Assert.Contains(_invocationId.ToString(), requestTelemetry.Id);
 
             // Exception needs to have associated id
             Assert.Equal(_invocationId.ToString(), exceptionTelemetry.Context.Operation.Id);
             Assert.Equal(_functionShortName, exceptionTelemetry.Context.Operation.Name);
             Assert.Same(fex, exceptionTelemetry.Exception);
-            Assert.Equal(LogCategories.Results, exceptionTelemetry.Properties[LoggingKeys.CategoryName]);
-            Assert.Equal(LogLevel.Error.ToString(), exceptionTelemetry.Properties[LoggingKeys.LogLevel]);
+            Assert.Equal(LogCategories.Results, exceptionTelemetry.Properties[LogConstants.CategoryNameKey]);
+            Assert.Equal(LogLevel.Error.ToString(), exceptionTelemetry.Properties[LogConstants.LogLevelKey]);
             // TODO: Beef up validation to include properties
         }
 
@@ -290,7 +316,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             {
                 LogLevel expectedLogLevel;
                 Enum.TryParse(telemetry.Message, out expectedLogLevel);
-                Assert.Equal(expectedLogLevel.ToString(), telemetry.Properties[LoggingKeys.LogLevel]);
+                Assert.Equal(expectedLogLevel.ToString(), telemetry.Properties[LogConstants.LogLevelKey]);
 
                 SeverityLevel expectedSeverityLevel;
                 if (telemetry.Message == "Trace" || telemetry.Message == "Debug")
@@ -303,8 +329,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                 }
                 Assert.Equal(expectedSeverityLevel, telemetry.SeverityLevel);
 
-                Assert.Equal(LogCategories.Function, telemetry.Properties[LoggingKeys.CategoryName]);
-                Assert.Equal(telemetry.Message, telemetry.Properties[LoggingKeys.CustomPropertyPrefix + LoggingKeys.OriginalFormat]);
+                Assert.Equal(LogCategories.Function, telemetry.Properties[LogConstants.CategoryNameKey]);
+                Assert.Equal(telemetry.Message, telemetry.Properties[LogConstants.CustomPropertyPrefix + LogConstants.OriginalFormatKey]);
                 Assert.Equal(scopeGuid.ToString(), telemetry.Context.Operation.Id);
                 Assert.Equal(_functionShortName, telemetry.Context.Operation.Name);
             }
@@ -320,14 +346,14 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
 
             Assert.Equal(SeverityLevel.Information, telemetry.SeverityLevel);
 
-            Assert.Equal(LogCategories.Function, telemetry.Properties[LoggingKeys.CategoryName]);
-            Assert.Equal(LogLevel.Information.ToString(), telemetry.Properties[LoggingKeys.LogLevel]);
+            Assert.Equal(LogCategories.Function, telemetry.Properties[LogConstants.CategoryNameKey]);
+            Assert.Equal(LogLevel.Information.ToString(), telemetry.Properties[LogConstants.LogLevelKey]);
             Assert.Equal("Using {some} custom {properties}. {Test}.",
-                telemetry.Properties[LoggingKeys.CustomPropertyPrefix + LoggingKeys.OriginalFormat]);
+                telemetry.Properties[LogConstants.CustomPropertyPrefix + LogConstants.OriginalFormatKey]);
             Assert.Equal("Using 1 custom 2. 3.", telemetry.Message);
-            Assert.Equal("1", telemetry.Properties[LoggingKeys.CustomPropertyPrefix + "some"]);
-            Assert.Equal("2", telemetry.Properties[LoggingKeys.CustomPropertyPrefix + "properties"]);
-            Assert.Equal("3", telemetry.Properties[LoggingKeys.CustomPropertyPrefix + "Test"]);
+            Assert.Equal("1", telemetry.Properties[LogConstants.CustomPropertyPrefix + "some"]);
+            Assert.Equal("2", telemetry.Properties[LogConstants.CustomPropertyPrefix + "properties"]);
+            Assert.Equal("3", telemetry.Properties[LogConstants.CustomPropertyPrefix + "Test"]);
         }
 
         [Fact]
@@ -346,12 +372,12 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
 
             Assert.Equal(SeverityLevel.Error, telemetry.SeverityLevel);
 
-            Assert.Equal(LogCategories.Function, telemetry.Properties[LoggingKeys.CategoryName]);
-            Assert.Equal(LogLevel.Error.ToString(), telemetry.Properties[LoggingKeys.LogLevel]);
+            Assert.Equal(LogCategories.Function, telemetry.Properties[LogConstants.CategoryNameKey]);
+            Assert.Equal(LogLevel.Error.ToString(), telemetry.Properties[LogConstants.LogLevelKey]);
             Assert.Equal("Error with customer: {customer}.",
-                telemetry.Properties[LoggingKeys.CustomPropertyPrefix + LoggingKeys.OriginalFormat]);
+                telemetry.Properties[LogConstants.CustomPropertyPrefix + LogConstants.OriginalFormatKey]);
             Assert.Equal("Error with customer: John Doe.", telemetry.Message);
-            Assert.Equal("John Doe", telemetry.Properties[LoggingKeys.CustomPropertyPrefix + "customer"]);
+            Assert.Equal("John Doe", telemetry.Properties[LogConstants.CustomPropertyPrefix + "customer"]);
             Assert.Same(ex, telemetry.Exception);
             Assert.Equal(scopeGuid.ToString(), telemetry.Context.Operation.Id);
             Assert.Equal(_functionShortName, telemetry.Context.Operation.Name);
@@ -396,7 +422,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
 
             var telemetry = _channel.Telemetries.Single() as TraceTelemetry;
             Assert.Equal("some string", telemetry.Message);
-            Assert.Equal(LogCategories.Function, telemetry.Properties[LoggingKeys.CategoryName]);
+            Assert.Equal(LogCategories.Function, telemetry.Properties[LogConstants.CategoryNameKey]);
         }
 
         [Fact]
@@ -522,7 +548,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             return new FunctionInstance(id, null, new ExecutionReason(), null, null, descriptor);
         }
 
-        private static IDictionary<string, object> CreateScopeDictionary(Guid invocationId, string functionName)
+        private static IDictionary<string, object> CreateScopeDictionary(string invocationId, string functionName)
         {
             return new Dictionary<string, object>
             {
@@ -536,11 +562,12 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             // used for a FunctionDescriptor
         }
 
-        private FunctionInstanceLogEntry CreateDefaultInstanceLogEntry()
+        private FunctionInstanceLogEntry CreateDefaultInstanceLogEntry(Exception ex = null)
         {
             return new FunctionInstanceLogEntry
             {
                 FunctionName = _functionFullName,
+                LogName = _functionShortName,
                 FunctionInstanceId = _invocationId,
                 StartTime = _startTime,
                 EndTime = _endTime,
@@ -548,7 +575,9 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                 TriggerReason = _triggerReason,
                 ParentId = Guid.NewGuid(), // we do not track this
                 ErrorDetails = null, // we do not use this -- we pass the exception in separately
-                Arguments = _arguments
+                Arguments = _arguments,
+                Duration = TimeSpan.FromMilliseconds(_durationMs),
+                Exception = ex
             };
         }
     }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/FilteringTelemetryProcessorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/FilteringTelemetryProcessorTests.cs
@@ -41,8 +41,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             var processor = new FilteringTelemetryProcessor(filter.Filter, _nextTelemetryProcessorMock.Object);
 
             var telemetry = new TestTelemetry();
-            telemetry.Properties[LoggingKeys.CategoryName] = LogCategories.Results;
-            telemetry.Properties[LoggingKeys.LogLevel] = telemetryLevel.ToString();
+            telemetry.Properties[LogConstants.CategoryNameKey] = LogCategories.Results;
+            telemetry.Properties[LogConstants.LogLevelKey] = telemetryLevel.ToString();
 
             processor.Process(telemetry);
 
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             var processor = new FilteringTelemetryProcessor(filter.Filter, _nextTelemetryProcessorMock.Object);
 
             var telemetry = new TestTelemetry();
-            telemetry.Properties[LoggingKeys.LogLevel] = telemetryLevel.ToString();
+            telemetry.Properties[LogConstants.LogLevelKey] = telemetryLevel.ToString();
             // no category specified
 
             processor.Process(telemetry);
@@ -110,7 +110,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             var processor = new FilteringTelemetryProcessor(filter.Filter, _nextTelemetryProcessorMock.Object);
 
             var telemetry = new TestTelemetry();
-            telemetry.Properties[LoggingKeys.CategoryName] = LogCategories.Results;
+            telemetry.Properties[LogConstants.CategoryNameKey] = LogCategories.Results;
             // no log level specified
 
             processor.Process(telemetry);
@@ -129,8 +129,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             var processor = new FilteringTelemetryProcessor(filter.Filter, _nextTelemetryProcessorMock.Object);
 
             var telemetry = new TestTelemetry();
-            telemetry.Properties[LoggingKeys.CategoryName] = LogCategories.Results;
-            telemetry.Properties[LoggingKeys.LogLevel] = "InvalidLevel";
+            telemetry.Properties[LogConstants.CategoryNameKey] = LogCategories.Results;
+            telemetry.Properties[LogConstants.LogLevelKey] = "InvalidLevel";
 
             processor.Process(telemetry);
             _nextTelemetryProcessorMock.Verify(m => m.Process(telemetry), Times.Once);

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/FunctionResultAggregatorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/FunctionResultAggregatorTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             ILoggerFactory factory = CreateMockLoggerFactory((props) =>
             {
                 publishCalls++;
-                Assert.Equal(batchSize, props[LoggingKeys.Successes]);
+                Assert.Equal(batchSize, props[LogConstants.SuccessesKey]);
             });
 
             var aggregator = new FunctionResultAggregator(batchSize, TimeSpan.FromMinutes(1), factory);
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             ILoggerFactory factory = CreateMockLoggerFactory((props) =>
             {
                 publishCalls++;
-                Assert.Equal(numberToInsert, props[LoggingKeys.Successes]);
+                Assert.Equal(numberToInsert, props[LogConstants.SuccessesKey]);
             });
 
             var aggregator = new FunctionResultAggregator(batchSize, TimeSpan.FromSeconds(1), factory);
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             ILoggerFactory factory = CreateMockLoggerFactory((props) =>
             {
                 publishCalls++;
-                totalSuccesses += Convert.ToInt32(props[LoggingKeys.Successes]);
+                totalSuccesses += Convert.ToInt32(props[LogConstants.SuccessesKey]);
             });
 
             var aggregator = new FunctionResultAggregator(batchSize, TimeSpan.FromSeconds(1), factory);
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             ILoggerFactory factory = CreateMockLoggerFactory((props) =>
             {
                 publishCalls++;
-                Assert.Equal(10, props[LoggingKeys.Successes]);
+                Assert.Equal(10, props[LogConstants.SuccessesKey]);
             });
 
             var aggregator = new FunctionResultAggregator(batchSize, TimeSpan.FromSeconds(1), factory);
@@ -116,8 +116,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             ILoggerFactory factory = CreateMockLoggerFactory((props) =>
             {
                 publishCalls++;
-                Assert.Equal(10, props[LoggingKeys.Successes]);
-                Assert.Equal("SomeTest", props[LoggingKeys.Name]);
+                Assert.Equal(10, props[LogConstants.SuccessesKey]);
+                Assert.Equal("SomeTest", props[LogConstants.NameKey]);
             });
 
             var aggregator = new FunctionResultAggregator(batchSize, TimeSpan.FromSeconds(1), factory);
@@ -134,8 +134,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             ILoggerFactory factory = CreateMockLoggerFactory((props) =>
             {
                 publishCalls++;
-                Assert.Equal(10, props[LoggingKeys.Successes]);
-                Assert.Equal("AnotherClass.SomeTest", props[LoggingKeys.Name]);
+                Assert.Equal(10, props[LogConstants.SuccessesKey]);
+                Assert.Equal("AnotherClass.SomeTest", props[LogConstants.NameKey]);
             });
 
             var aggregator = new FunctionResultAggregator(batchSize, TimeSpan.FromSeconds(1), factory);

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
@@ -232,7 +232,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 "FunctionResultAggregatorConfiguration",
                 "LogCategoryFilter",
                 "LogCategories",
-                "LoggingKeys",
+                "LogConstants",
                 "ScopeKeys",
                 "IDistributedLockManager",
                 "IDistributedLock",


### PR DESCRIPTION
This is the `dev` version of #1265.
 
Also pulling in the change @MikeStall made to fix logger scope (#1248). That change only went into `v2.x`.
