### PR TITLE
Port change from dev

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionInvoker.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionInvoker.cs
@@ -48,17 +48,18 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             get { return _parameterNames; }
         }
 
-        public async Task<object> InvokeAsync(object[] arguments)
+        public object CreateInstance()
+        {
+            TReflected instance = _instanceFactory.Create();
+            return instance;
+        }
+
+        public async Task<object> InvokeAsync(object instance, object[] arguments)
         {
             // Return a task immediately in case the method is not async.
             await Task.Yield();
 
-            TReflected instance = _instanceFactory.Create();
-
-            using (instance as IDisposable)
-            {
-                return await _methodInvoker.InvokeAsync(instance, arguments);
-            }
+            return await _methodInvoker.InvokeAsync((TReflected)instance, arguments);
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/IFunctionInvoker.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/IFunctionInvoker.cs
@@ -11,6 +11,12 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
         IReadOnlyList<string> ParameterNames { get; }
 
         // The cancellation token, if any, is provided along with the other arguments.
-        Task<object> InvokeAsync(object[] arguments);
+        // Caller can get an instance via NewInstance(). 
+        // Caller is responsible for calling dispose. 
+        Task<object> InvokeAsync(object instance, object[] arguments);
+
+        // Create an instance that can be passed into Invoke. 
+        // This exists separately so that callers can inspect the instance before it is invoked. 
+        object CreateInstance();
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Triggers/TriggeredFunctionInstanceFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Triggers/TriggeredFunctionInstanceFactory.cs
@@ -68,10 +68,15 @@ namespace Microsoft.Azure.WebJobs.Host.Triggers
             }
             public IReadOnlyList<string> ParameterNames => _inner.ParameterNames;
 
-            public Task<object> InvokeAsync(object[] arguments)
+            public Task<object> InvokeAsync(object instance, object[] arguments)
             {
-                Func<Task<object>> inner = () => _inner.InvokeAsync(arguments);
+                Func<Task<object>> inner = () => _inner.InvokeAsync(instance, arguments);
                 return _handler(inner);
+            }
+
+            public object CreateInstance()
+            {
+                return _inner.CreateInstance();
             }
         }
     }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/FunctionExecutorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/FunctionExecutorTests.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
         {
             bool called = false;
             Mock<IFunctionInvoker> mockInvoker = new Mock<IFunctionInvoker>();
-            mockInvoker.Setup(i => i.InvokeAsync(It.IsAny<object[]>()))
+            mockInvoker.Setup(i => i.InvokeAsync(It.IsAny<object>(), It.IsAny<object[]>()))
                 .Returns(() =>
                 {
                     called = true;
@@ -146,8 +146,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
         {
             bool called = false;
             Mock<IFunctionInvoker> mockInvoker = new Mock<IFunctionInvoker>();
-            mockInvoker.Setup(i => i.InvokeAsync(It.IsAny<object[]>()))
-                .Returns<object[]>(async (invokeParameters) =>
+            mockInvoker.Setup(i => i.InvokeAsync(It.IsAny<object>(), It.IsAny<object[]>()))
+                .Returns<object, object[]>(async (invokeInstance, invokeParameters) =>
                 {
                     var token = (CancellationToken)invokeParameters[0];
                     while (!token.IsCancellationRequested)
@@ -174,7 +174,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
         public async Task InvokeAsync_Timeout_Throw()
         {
             Mock<IFunctionInvoker> mockInvoker = new Mock<IFunctionInvoker>();
-            mockInvoker.Setup(i => i.InvokeAsync(It.IsAny<object[]>()))
+            mockInvoker.Setup(i => i.InvokeAsync(It.IsAny<object>(), It.IsAny<object[]>()))
                 .Returns(async () =>
                 {
                     bool exit = false;
@@ -210,8 +210,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
         {
             bool called = false;
             Mock<IFunctionInvoker> mockInvoker = new Mock<IFunctionInvoker>();
-            mockInvoker.Setup(i => i.InvokeAsync(It.IsAny<object[]>()))
-                .Returns<object[]>(async (invokeParameters) =>
+            mockInvoker.Setup(i => i.InvokeAsync(It.IsAny<object>(), It.IsAny<object[]>()))
+                .Returns<object, object[]>(async (invokeInstance, invokeParameters) =>
                 {
                     var token = (CancellationToken)invokeParameters[0];
                     while (!token.IsCancellationRequested)
@@ -239,8 +239,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
         {
             bool called = false;
             Mock<IFunctionInvoker> mockInvoker = new Mock<IFunctionInvoker>();
-            mockInvoker.Setup(i => i.InvokeAsync(It.IsAny<object[]>()))
-                .Returns<object[]>(async (invokeParameters) =>
+            mockInvoker.Setup(i => i.InvokeAsync(It.IsAny<object>(), It.IsAny<object[]>()))
+                .Returns<object, object[]>(async (invokeInstance, invokeParameters) =>
                 {
                     var token = (CancellationToken)invokeParameters[0];
                     while (!token.IsCancellationRequested)
@@ -268,7 +268,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
         public async Task InvokeAsync_Stop_Timeout_Throw()
         {
             Mock<IFunctionInvoker> mockInvoker = new Mock<IFunctionInvoker>();
-            mockInvoker.Setup(i => i.InvokeAsync(It.IsAny<object[]>()))
+            mockInvoker.Setup(i => i.InvokeAsync(It.IsAny<object>(), It.IsAny<object[]>()))
                 .Returns(async () =>
                 {
                     bool exit = false;

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/FunctionInvokerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/FunctionInvokerTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Moq;
 using Xunit;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
 
 namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
 {
@@ -34,61 +35,52 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             IFunctionInvoker product = CreateProductUnderTest(instanceFactory, methodInvoker);
 
             // Act
-            product.InvokeAsync(expectedArguments).GetAwaiter().GetResult();
+            var instance = product.CreateInstance();
+            product.InvokeAsync(instance, expectedArguments).GetAwaiter().GetResult();
             
             // Assert
             instanceFactoryMock.VerifyAll();
             methodInvokerMock.VerifyAll();
         }
 
-        [Fact]
-        public void InvokeAsync_IfInstanceIsDisposable_Disposes()
+        // Simple program to test IDisposable.
+        public class MyProg : IDisposable
         {
-            // Arrange
-            bool disposed = false;
+            public bool _disposed;
 
-            Mock<IDisposable> disposableMock = new Mock<IDisposable>(MockBehavior.Strict);
-            disposableMock.Setup(d => d.Dispose()).Callback(() => { disposed = true; });
-            IDisposable disposable = disposableMock.Object;
+            public Task _waiter = Task.CompletedTask;
 
-            IFactory<object> instanceFactory = CreateStubFactory(disposable);
-            IMethodInvoker<object, object> methodInvoker = CreateStubMethodInvoker();
+            public void Dispose()
+            {
+                _disposed = true;
+            }
 
-            IFunctionInvoker product = CreateProductUnderTest(instanceFactory, methodInvoker);
-            object[] arguments = new object[0];
-
-            // Act
-            product.InvokeAsync(arguments).GetAwaiter().GetResult();
-
-            // Assert
-            Assert.True(disposed);
+            [NoAutomaticTrigger]
+            public async Task Method()
+            {
+                // Allow this method to pause while the test verifies that Dispose is not yet called. 
+                await _waiter;
+            }
         }
 
         [Fact]
-        public void InvokeAsync_IfInstanceIsDisposable_DoesNotDisposeWhileTaskIsRunning()
+        public void InvokeAsync_IfInstanceIsDisposable_DoesNotDisposeWhileTaskIsRunning2()
         {
-            // Arrange
-            bool disposed = false;
+            var prog = new MyProg();
+            var tsc = new TaskCompletionSource<object>();
+            prog._waiter = tsc.Task;
+            var activator = new FakeActivator(prog);
+            var host = TestHelpers.NewJobHost<MyProg>(activator);
 
-            Mock<IDisposable> disposableMock = new Mock<IDisposable>(MockBehavior.Strict);
-            disposableMock.Setup(d => d.Dispose()).Callback(() => { disposed = true; });
-            IDisposable disposable = disposableMock.Object;
+            var task = host.CallAsync("MyProg.Method");
+            Assert.True(!task.IsCompleted);
 
-            IFactory<object> instanceFactory = CreateStubFactory(disposable);
-            TaskCompletionSource<object> taskSource = new TaskCompletionSource<object>();
-            IMethodInvoker<object, object> methodInvoker = CreateStubMethodInvoker(taskSource.Task);
+            Assert.False(prog._disposed, "User job should not yet be disposed.");
+            tsc.SetResult(true); // This will let method run to completion and call dispose. 
 
-            IFunctionInvoker product = CreateProductUnderTest(instanceFactory, methodInvoker);
-            object[] arguments = new object[0];
-
-            // Act
-            Task task = product.InvokeAsync(arguments);
-
-            // Assert
-            Assert.NotNull(task);
-            Assert.False(disposed);
-            taskSource.SetResult(null);
-            task.GetAwaiter().GetResult();
+            task.Wait(3000);
+            Assert.True(task.IsCompleted);
+            Assert.True(prog._disposed, "User job should be disposed.");
         }
 
         private static FunctionInvoker<object, object> CreateProductUnderTest(IFactory<object> instanceFactory,
@@ -103,27 +95,6 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             IMethodInvoker<TReflected, TReturnValue> methodInvoker)
         {
             return new FunctionInvoker<TReflected, TReturnValue>(parameterNames, instanceFactory, methodInvoker);
-        }
-
-        private static IFactory<object> CreateStubFactory(object instance)
-        {
-            Mock<IFactory<object>> mock = new Mock<IFactory<object>>(MockBehavior.Strict);
-            mock.Setup(f => f.Create())
-                .Returns(instance);
-            return mock.Object;
-        }
-
-        private static IMethodInvoker<object, object> CreateStubMethodInvoker()
-        {
-            return CreateStubMethodInvoker(Task.FromResult<object>(null));
-        }
-
-        private static IMethodInvoker<object, object> CreateStubMethodInvoker(Task<object> task)
-        {
-            Mock<IMethodInvoker<object, object>> mock = new Mock<IMethodInvoker<object, object>>(MockBehavior.Strict);
-            mock.Setup(i => i.InvokeAsync(It.IsAny<object>(), It.IsAny<object[]>()))
-                .Returns(task);
-            return mock.Object;
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/TriggeredFunctionExecutorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/TriggeredFunctionExecutorTests.cs
@@ -21,13 +21,13 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             mockExecutor.Setup(m => m.TryExecuteAsync(It.IsAny<IFunctionInstance>(), It.IsAny<CancellationToken>())).
                 Returns<IFunctionInstance, CancellationToken>((x, y) =>
                 {
-                    x.Invoker.InvokeAsync(null).Wait();
+                    x.Invoker.InvokeAsync(null, null).Wait();
                     return Task.FromResult<IDelayedException>(null);
                 });
 
             bool innerInvokerInvoked = false;
             Mock<IFunctionInvoker> mockInvoker = new Mock<IFunctionInvoker>();
-            mockInvoker.Setup(m => m.InvokeAsync(null)).Returns(() =>
+            mockInvoker.Setup(m => m.InvokeAsync(null, null)).Returns(() =>
             {
                 innerInvokerInvoked = true;
                 return Task.FromResult<object>(null);


### PR DESCRIPTION
IFunctionInvoker needs to take in the job instance separately from InvokeAsync() so we can use it in filters.