### PR TITLE
Fix unable to bind custom CancellationTokens

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/Cancellation/CancellationTokenBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/Cancellation/CancellationTokenBinding.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings.Cancellation
 
         public Task<IValueProvider> BindAsync(object value, ValueBindingContext context)
         {
-            if (value is CancellationToken)
+            if (!(value is CancellationToken))
             {
                 throw new InvalidOperationException("Unable to convert value to CancellationToken.");
             }


### PR DESCRIPTION
Fix being unable to call an instance of the `JobHost `with a custom `CancellationToken`.

```
CancellationToken customCancellationToken = cancellationTokenSource.Token;
_jobHost.Call(testFunction, new {customCancellationToken});
```
This currently gives an `Unable to convert value to CancellationToken.` error.