### PR TITLE
Migrate event hubs to dotnet core

### DIFF
--- a/WebJobs.sln
+++ b/WebJobs.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26724.1
+VisualStudioVersion = 15.0.26730.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{639967B0-0544-4C52-94AC-9A3D25E33256}"
 EndProject
@@ -36,6 +36,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{3B089351
 		build\common.props = build\common.props
 		build\PublicKey.snk = build\PublicKey.snk
 	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebJobs.EventHubs", "src\Microsoft.Azure.WebJobs.ServiceBus\EventHubs\WebJobs.EventHubs.csproj", "{F78F19F3-0023-4A5C-823B-DA054BC51D07}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebJobs.EventHubs.UnitTests", "test\Microsoft.Azure.WebJobs.EventHubs.UnitTests\WebJobs.EventHubs.UnitTests.csproj", "{27F0E6AC-505E-4BEC-81CA-8DF777DEA9C7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -91,6 +95,14 @@ Global
 		{340AB554-5482-4B3D-B65F-46DFF5AF1684}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{340AB554-5482-4B3D-B65F-46DFF5AF1684}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{340AB554-5482-4B3D-B65F-46DFF5AF1684}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F78F19F3-0023-4A5C-823B-DA054BC51D07}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F78F19F3-0023-4A5C-823B-DA054BC51D07}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F78F19F3-0023-4A5C-823B-DA054BC51D07}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F78F19F3-0023-4A5C-823B-DA054BC51D07}.Release|Any CPU.Build.0 = Release|Any CPU
+		{27F0E6AC-505E-4BEC-81CA-8DF777DEA9C7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{27F0E6AC-505E-4BEC-81CA-8DF777DEA9C7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{27F0E6AC-505E-4BEC-81CA-8DF777DEA9C7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{27F0E6AC-505E-4BEC-81CA-8DF777DEA9C7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -102,6 +114,7 @@ Global
 		{C6B834AB-7B6A-47AE-A7C3-C102B0C861FF} = {639967B0-0544-4C52-94AC-9A3D25E33256}
 		{C8EAAE01-E8CF-4131-9D4B-F0FDF00DA4BE} = {639967B0-0544-4C52-94AC-9A3D25E33256}
 		{340AB554-5482-4B3D-B65F-46DFF5AF1684} = {639967B0-0544-4C52-94AC-9A3D25E33256}
+		{27F0E6AC-505E-4BEC-81CA-8DF777DEA9C7} = {639967B0-0544-4C52-94AC-9A3D25E33256}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {371BFA14-0980-4A43-A18A-CA1C1A9CB784}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,6 +44,8 @@ build_script:
     dotnet pack src\Microsoft.Azure.WebJobs.Logging\WebJobs.Logging.csproj -o ..\..\buildoutput --no-build --version-suffix "-$env:APPVEYOR_BUILD_NUMBER"
 
     dotnet pack src\Microsoft.Azure.WebJobs.Logging.ApplicationInsights\WebJobs.Logging.ApplicationInsights.csproj -o ..\..\buildoutput --no-build --version-suffix "-$env:APPVEYOR_BUILD_NUMBER"
+
+    dotnet pack src\Microsoft.Azure.WebJobs.ServiceBus\EventHubs\WebJobs.EventHubs.csproj -o ..\..\..\buildoutput --no-build --version-suffix "-$env:APPVEYOR_BUILD_NUMBER"
 test_script:
 - ps: >-
     dotnet test .\test\Microsoft.Azure.WebJobs.Host.UnitTests\ -v q --no-build
@@ -53,6 +55,8 @@ test_script:
     dotnet test .\test\Microsoft.Azure.WebJobs.Logging.FunctionalTests\ -v q --no-build
 
     dotnet test .\test\Microsoft.Azure.WebJobs.Host.EndToEndTests\ -v q --no-build
+
+    dotnet test .\test\Microsoft.Azure.WebJobs.EventHubs.UnitTests\ -v q --no-build
 artifacts:
 - path: buildoutput\*.nupkg
   name: Binaries

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubAsyncCollector.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubAsyncCollector.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.EventHubs;
-using Microsoft.Azure.ServiceBus;
 
 namespace Microsoft.Azure.WebJobs.ServiceBus
 {
@@ -17,17 +16,17 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
     /// </summary>
     public class EventHubAsyncCollector : IAsyncCollector<EventData>
     {
+        private const int BatchSize = 100;
+
+        // Suggested to use 240k instead of 256k to leave padding room for headers.
+        private const int MaxByteSize = 240 * 1024;
+
         private readonly EventHubClient _client;
 
         private List<EventData> _list = new List<EventData>();
 
         // total size of bytes in _list that we'll be sending in this batch. 
         private int _currentByteSize = 0;
-
-        private const int BatchSize = 100;
-
-        // Suggested to use 240k instead of 256k to leave padding room for headers.
-        private const int MaxByteSize = 240 * 1024; 
 
         /// <summary>
         /// Create a sender around the given client. 
@@ -59,7 +58,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
             {
                 lock (_list)
                 {
-                    var size = (int)item.SerializedSizeInBytes;
+                    var size = item.Body.Count;
 
                     if (size > MaxByteSize)
                     {
@@ -75,6 +74,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
                         _currentByteSize += size;
                         return;
                     }
+
                     // We should flush. 
                     // Release the lock, flush, and then loop around and try again. 
                 }                    
@@ -115,7 +115,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         /// <param name="batch">the set of events to send</param>
         protected virtual async Task SendBatchAsync(EventData[] batch)
         {
-            await _client.SendBatchAsync(batch);
+            await _client.SendAsync(batch);
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubConfiguration.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubConfiguration.cs
@@ -4,15 +4,10 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Text;
-using Microsoft.Azure.WebJobs.Host;
-using Microsoft.Azure.WebJobs.Host.Bindings;
-using Microsoft.Azure.WebJobs.Host.Config;
-using Microsoft.Azure.WebJobs.Host.Triggers;
 using Microsoft.Azure.EventHubs;
-using Microsoft.Azure.ServiceBus;
 using Microsoft.Azure.EventHubs.Processor;
+using Microsoft.Azure.WebJobs.Host.Config;
 
 namespace Microsoft.Azure.WebJobs.ServiceBus
 {
@@ -53,9 +48,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         /// Constructs a new instance.
         /// </summary>
         /// <param name="options">The optional <see cref="EventProcessorOptions"/> to use when receiving events.</param>
-        /// <param name="partitionOptions">Optional <see cref="PartitionManagerOptions"/> to use to configure any EventProcessorHosts. </param>
-        public EventHubConfiguration(
-            EventProcessorOptions options)
+        public EventHubConfiguration(EventProcessorOptions options)
         {
             if (options == null)
             {
@@ -136,7 +129,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
                 throw new ArgumentNullException("sendConnectionString");
             }
 
-            ServiceBusConnectionStringBuilder sb = new ServiceBusConnectionStringBuilder(sendConnectionString);
+            EventHubsConnectionStringBuilder sb = new EventHubsConnectionStringBuilder(sendConnectionString);
             if (string.IsNullOrWhiteSpace(sb.EntityPath))
             {
                 sb.EntityPath = eventHubName;
@@ -257,7 +250,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
                 // If the connection string provides a hub name, that takes precedence. 
                 // Note that connection strings *can't* specify a consumerGroup, so must always be passed in. 
                 string actualPath = eventHubName;
-                ServiceBusConnectionStringBuilder sb = new ServiceBusConnectionStringBuilder(creds.EventHubConnectionString);
+                EventHubsConnectionStringBuilder sb = new EventHubsConnectionStringBuilder(creds.EventHubConnectionString);
                 if (sb.EntityPath != null)
                 {
                     actualPath = sb.EntityPath;
@@ -271,12 +264,12 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
                 EventProcessorHost host = new EventProcessorHost(
                     hostName: eventProcessorHostName,
                     eventHubPath: actualPath,
-                    consumerGroupName: consumerGroup,
+                    consumerGroupName: consumerGroup, 
                     eventHubConnectionString: sb.ToString(),
-                    storageConnectionString: storageConnectionString,
+                    storageConnectionString: storageConnectionString, 
                     leaseContainerName: LeaseContainerName,
                     storageBlobPrefix: blobPrefix);
-                
+
                 return host;
             }
             else
@@ -340,7 +333,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
             return sb.ToString();
         }
 
-        private static string GetServiceBusNamespace(ServiceBusConnectionStringBuilder connectionString)
+        private static string GetServiceBusNamespace(EventHubsConnectionStringBuilder connectionString)
         {
             // EventHubs only have 1 endpoint. 
             var url = connectionString.Endpoint;

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubListener.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubListener.cs
@@ -6,11 +6,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.EventHubs;
+using Microsoft.Azure.EventHubs.Processor;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Listeners;
-using Microsoft.Azure.ServiceBus;
-using Microsoft.Azure.EventHubs.Processor;
-using Microsoft.Azure.EventHubs;
 
 namespace Microsoft.Azure.WebJobs.ServiceBus
 {
@@ -117,7 +116,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
 
             public Task ProcessErrorAsync(PartitionContext context, Exception error)
             {
-                throw new NotImplementedException();
+                // TODO: log underlying event hubs error
+                return Task.CompletedTask;
             }
 
             public async Task ProcessEventsAsync(PartitionContext context, IEnumerable<EventData> messages)
@@ -163,7 +163,6 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
                 else
                 {
                     // Batch dispatch
-
                     TriggeredFunctionData input = new TriggeredFunctionData
                     {
                         ParentId = null,
@@ -174,10 +173,12 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
                 }
 
                 bool hasEvents = false;
+
                 // Dispose all messages to help with memory pressure. If this is missed, the finalizer thread will still get them. 
                 foreach (var message in messages)
                 {
                     hasEvents = true;
+                    message.Dispose();
                 }
 
                 // Don't checkpoint if no events. This can reset the sequence counter to 0. 

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubTriggerAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubTriggerAttributeBindingProvider.cs
@@ -8,7 +8,7 @@ using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Azure.WebJobs.Host.Triggers;
-using Microsoft.Azure.ServiceBus;
+using Microsoft.Azure.EventHubs;
 
 namespace Microsoft.Azure.WebJobs.ServiceBus
 {
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
 
             string resolvedEventHubName = _nameResolver.ResolveWholeString(attribute.EventHubName);
 
-            string consumerGroup = attribute.ConsumerGroup ?? EventHubConsumerGroup.DefaultGroupName;
+            string consumerGroup = attribute.ConsumerGroup ?? PartitionReceiver.DefaultConsumerGroupName;
             string resolvedConsumerGroup = _nameResolver.ResolveWholeString(consumerGroup);
 
             if (!string.IsNullOrWhiteSpace(attribute.Connection))

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubTriggerInput.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubTriggerInput.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.Azure.EventHubs;
 using Microsoft.Azure.EventHubs.Processor;
-using Microsoft.Azure.ServiceBus;
 
 namespace Microsoft.Azure.WebJobs.ServiceBus
 {
@@ -15,7 +14,16 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         private int _selector = -1;
 
         internal EventData[] Events { get; set; }
+
         internal PartitionContext PartitionContext { get; set; }
+
+        public bool IsSingleDispatch
+        {
+            get
+            {
+                return _selector != -1;
+            }
+        }
 
         public static EventHubTriggerInput New(EventData eventData)
         {
@@ -28,14 +36,6 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
                 },
                 _selector = 0,
             };
-        }
-
-        public bool IsSingleDispatch
-        {
-            get
-            {
-                return _selector != -1;
-            }
         }
 
         public EventHubTriggerInput GetSingleEventTriggerInput(int idx)

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubTriggerInputBindingStrategy.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubTriggerInputBindingStrategy.cs
@@ -4,11 +4,10 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
-using Microsoft.Azure.WebJobs.Host.Bindings;
-using Microsoft.Azure.WebJobs.Host.Triggers;
-using Microsoft.Azure.ServiceBus;
 using Microsoft.Azure.EventHubs;
 using Microsoft.Azure.EventHubs.Processor;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Azure.WebJobs.Host.Triggers;
 
 namespace Microsoft.Azure.WebJobs.ServiceBus
 {
@@ -109,23 +108,23 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
 
             for (int i = 0; i < events.Length; i++)
             {
-                partitionKeys[i] = events[i].PartitionKey;
-                offsets[i] = events[i].Offset;
-                sequenceNumbers[i] = events[i].SequenceNumber;
-                enqueuedTimesUtc[i] = events[i].EnqueuedTimeUtc;
+                partitionKeys[i] = events[i].SystemProperties?.PartitionKey;
+                offsets[i] = events[i].SystemProperties?.Offset;
+                sequenceNumbers[i] = events[i].SystemProperties?.SequenceNumber ?? 0;
+                enqueuedTimesUtc[i] = events[i].SystemProperties?.EnqueuedTimeUtc ?? DateTime.MinValue;
                 properties[i] = events[i].Properties;
-                systemProperties[i] = events[i].SystemProperties;
+                systemProperties[i] = events[i].SystemProperties?.ToDictionary();
             }
         }
 
         private static void AddBindingData(Dictionary<string, object> bindingData, EventData eventData)
         {
-            SafeAddValue(() => bindingData.Add(nameof(eventData.PartitionKey), eventData.PartitionKey));
-            SafeAddValue(() => bindingData.Add(nameof(eventData.Offset), eventData.Offset));
-            SafeAddValue(() => bindingData.Add(nameof(eventData.SequenceNumber), eventData.SequenceNumber));
-            SafeAddValue(() => bindingData.Add(nameof(eventData.EnqueuedTimeUtc), eventData.EnqueuedTimeUtc));
+            SafeAddValue(() => bindingData.Add(nameof(eventData.SystemProperties.PartitionKey), eventData.SystemProperties?.PartitionKey));
+            SafeAddValue(() => bindingData.Add(nameof(eventData.SystemProperties.Offset), eventData.SystemProperties?.Offset));
+            SafeAddValue(() => bindingData.Add(nameof(eventData.SystemProperties.SequenceNumber), eventData.SystemProperties?.SequenceNumber ?? 0));
+            SafeAddValue(() => bindingData.Add(nameof(eventData.SystemProperties.EnqueuedTimeUtc), eventData.SystemProperties?.EnqueuedTimeUtc ?? DateTime.MinValue));
             SafeAddValue(() => bindingData.Add(nameof(eventData.Properties), eventData.Properties));
-            SafeAddValue(() => bindingData.Add(nameof(eventData.SystemProperties), eventData.SystemProperties));
+            SafeAddValue(() => bindingData.Add(nameof(eventData.SystemProperties), eventData.SystemProperties?.ToDictionary()));
         }
 
         private static void SafeAddValue(Action addValue)

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("WebJobs.EventHubs.UnitTests")]

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/SystemPropertiesCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/SystemPropertiesCollectionExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+using static Microsoft.Azure.EventHubs.EventData;
+
+namespace Microsoft.Azure.WebJobs.ServiceBus
+{
+    static internal class SystemPropertiesCollectionExtensions
+    {
+        internal static IDictionary<string, object> ToDictionary(this SystemPropertiesCollection collection)
+        {
+            return JObject.FromObject(collection).ToObject<IDictionary<string, object>>();
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/WebJobs.EventHubs.csproj
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/WebJobs.EventHubs.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\..\build\common.props" />
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>Microsoft.Azure.WebJobs.EventHubs</AssemblyName>
+    <RootNamespace>Microsoft.Azure.WebJobs.ServiceBus</RootNamespace>
+    <PackageId>Microsoft.Azure.WebJobs.Extensions.EventHubs</PackageId>
+    <Description>Microsoft Azure WebJobs SDK EventHubs Extension</Description>
+    <SignAssembly>false</SignAssembly>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.EventHubs.Processor" Version="1.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Microsoft.Azure.WebJobs.Host\WebJobs.Host.csproj" />
+    <ProjectReference Include="..\..\Microsoft.Azure.WebJobs\WebJobs.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/Microsoft.Azure.WebJobs.EventHubs.UnitTests/WebJobs.EventHubs.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.EventHubs.UnitTests/WebJobs.EventHubs.UnitTests.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <RootNamespace>Microsoft.Azure.WebJobs.ServiceBus.UnitTests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170810-02" />
+    <PackageReference Include="Moq" Version="4.7.99" />
+    <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta3-build3705" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Microsoft.Azure.WebJobs.ServiceBus.UnitTests\EventHubAsyncCollectorTests.cs" Link="EventHubAsyncCollectorTests.cs" />
+    <Compile Include="..\Microsoft.Azure.WebJobs.ServiceBus.UnitTests\EventHubTests.cs" Link="EventHubTests.cs" />
+    <Compile Include="..\Microsoft.Azure.WebJobs.ServiceBus.UnitTests\Listeners\EventHubListenerTests.cs" Link="EventHubListenerTests.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.Azure.WebJobs.ServiceBus\EventHubs\WebJobs.EventHubs.csproj" />
+    <ProjectReference Include="..\Microsoft.Azure.WebJobs.Host.TestCommon\WebJobs.Host.TestCommon.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncChainEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncChainEndToEndTests.cs
@@ -531,7 +531,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             Assert.Equal(0, traceErrors.Length);
 
             // Validate Logger
-            LogMessage[] logErrors = _loggerProvider.GetAllLogMessages().Where(l => l.Level == Extensions.Logging.LogLevel.Error).ToArray();
+            LogMessage[] logErrors = _loggerProvider.GetAllLogMessages().Where(l => l.Level == Microsoft.Extensions.Logging.LogLevel.Error).ToArray();
             Assert.Equal(0, logErrors.Length);
         }
 

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AzureStorageEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AzureStorageEndToEndTests.cs
@@ -423,7 +423,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             Assert.True(errors.All(t => t.Exception.InnerException.InnerException is FormatException));
 
             // Validate Logger
-            var loggerErrors = loggerProvider.GetAllLogMessages().Where(l => l.Level == Extensions.Logging.LogLevel.Error);
+            var loggerErrors = loggerProvider.GetAllLogMessages().Where(l => l.Level == Microsoft.Extensions.Logging.LogLevel.Error);
             Assert.True(loggerErrors.All(t => t.Exception.InnerException.InnerException is FormatException));
         }
 

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/EventHubEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/EventHubEndToEndTests.cs
@@ -1,17 +1,14 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-#if SERVICE_BUS
 using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.Azure.WebJobs.Host.TestCommon;
-#if SERVICE_BUS
+using Microsoft.Azure.EventHubs;
 using Microsoft.Azure.WebJobs.ServiceBus;
-using Microsoft.ServiceBus.Messaging;
-#endif
+using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
@@ -111,10 +108,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
             public static void SendEvent_TestHub(string input, [EventHub(TestHubName)] out EventData evt)
             {
-                evt = new EventData(Encoding.UTF8.GetBytes(input))
-                {
-                    PartitionKey = "TestPartition"
-                };
+                evt = new EventData(Encoding.UTF8.GetBytes(input));
                 evt.Properties.Add("TestProp1", "value1");
                 evt.Properties.Add("TestProp2", "value2");
             }
@@ -125,7 +119,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 for (int i = 0; i < numEvents; i++)
                 {
                     var evt = new EventData(Encoding.UTF8.GetBytes(input));
-                    evt.PartitionKey = "TestPartition";
                     evt.Properties.Add("TestIndex", i);
                     evt.Properties.Add("TestProp1", "value1");
                     evt.Properties.Add("TestProp2", "value2");
@@ -140,14 +133,10 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 // filter for the ID the current test is using
                 if (evt == EventId)
                 {
-                    Assert.Equal("TestPartition", partitionKey);
                     Assert.True((DateTime.Now - enqueuedTimeUtc).TotalSeconds < 30);
 
-                    Assert.Equal(2, properties.Count);
                     Assert.Equal("value1", properties["TestProp1"]);
                     Assert.Equal("value2", properties["TestProp2"]);
-
-                    Assert.Equal(8, systemProperties.Count);
 
                     Result = evt;
                 }
@@ -164,9 +153,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
                 for (int i = 0; i < events.Length; i++)
                 {
-                    Assert.Equal("TestPartition", partitionKeyArray[i]);
-                    Assert.Equal(3, propertiesArray[i].Count);
-                    Assert.Equal(8, systemPropertiesArray[i].Count);
                     Assert.Equal(i, propertiesArray[i]["TestIndex"]);
                 }
 
@@ -179,4 +165,3 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         }
     }
 }
-#endif

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/WebJobs.Host.EndToEndTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/WebJobs.Host.EndToEndTests.csproj
@@ -29,6 +29,7 @@
     <ProjectReference Include="..\..\src\Microsoft.Azure.WebJobs.Logging.ApplicationInsights\WebJobs.Logging.ApplicationInsights.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Azure.WebJobs.Logging\WebJobs.Logging.csproj" />
     <ProjectReference Include="..\Microsoft.Azure.WebJobs.Host.TestCommon\WebJobs.Host.TestCommon.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.Azure.WebJobs.ServiceBus\EventHubs\WebJobs.EventHubs.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/TestHelpers.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/TestHelpers.cs
@@ -52,7 +52,17 @@ namespace Microsoft.Azure.WebJobs.Host.TestCommon
         public static void SetField(object target, string fieldName, object value)
         {
             FieldInfo field = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+            if (field == null)
+            {
+                field = target.GetType().GetField($"<{fieldName}>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic);
+            }
             field.SetValue(target, value);
+        }
+
+        public static T New<T>()
+        {
+            var constructor = typeof(T).GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, null, new Type[] { }, null);
+            return (T)constructor.Invoke(null);
         }
 
         // Test that we get an indexing error (FunctionIndexingException)  

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/EventHubAsyncCollectorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/EventHubAsyncCollectorTests.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using Microsoft.ServiceBus.Messaging;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.EventHubs;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests
@@ -32,7 +31,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests
                 {
                     foreach (var e in batch)
                     {
-                        var payloadBytes = e.GetBytes();
+                        var payloadBytes = e.Body.Array;
                         Assert.NotNull(payloadBytes);
                         _sentEvents.Add(payloadBytes);
                     }
@@ -64,9 +63,6 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests
             await collector.FlushAsync();
             Assert.Equal(1, collector._sentEvents.Count);
             Assert.Equal(payload, collector._sentEvents[0]);
-
-            // Verify the event was disposed.
-            Assert.Throws<ObjectDisposedException>(() => e1.GetBodyStream());
         }
 
         // If we send enough events, that will eventually tip over and flush. 
@@ -127,7 +123,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests
             catch (InvalidOperationException e)
             {
                 // Exact error message (and serialization byte size) is subject to change. 
-                Assert.Equal("Event is too large. Event is approximately 307208b and max size is 245760b", e.Message);
+                Assert.Contains("Event is too large", e.Message);
             }
 
             // Verify we didn't queue anything

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Listeners/EventHubListenerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Listeners/EventHubListenerTests.cs
@@ -1,18 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System.Diagnostics;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Azure.WebJobs.Host;
-using Microsoft.Azure.WebJobs.Host.Executors;
-using Microsoft.Azure.WebJobs.ServiceBus.Listeners;
-using Microsoft.ServiceBus.Messaging;
-using Moq;
-using Xunit;
 using System;
+using System.Threading.Tasks;
+using Xunit;
 
-namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Listeners
+namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests
 {
     public class EventHubListenerTests
     {


### PR DESCRIPTION
@MikeStall made the convincing argument for backporting changes

related https://github.com/Azure/azure-webjobs-sdk-extensions/pull/267