### PR TITLE
Exposing basic configuration extensibility

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/AmbientConnectionStringProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/AmbientConnectionStringProvider.cs
@@ -35,12 +35,12 @@ namespace Microsoft.Azure.WebJobs.Host
         {
             // first try prefixing
             string prefixedConnectionStringName = GetPrefixedConnectionStringName(connectionStringName);
-            string connectionString = ConfigurationUtility.GetConnectionFromConfigOrEnvironment(prefixedConnectionStringName);
+            string connectionString = ConfigurationUtility.GetConnectionString(prefixedConnectionStringName);
 
             if (string.IsNullOrEmpty(connectionString))
             {
                 // next try a direct unprefixed lookup
-                connectionString = ConfigurationUtility.GetConnectionFromConfigOrEnvironment(connectionStringName);
+                connectionString = ConfigurationUtility.GetConnectionString(connectionStringName);
             }
 
             return connectionString;

--- a/src/Microsoft.Azure.WebJobs.Host/DefaultNameResolver.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/DefaultNameResolver.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.WebJobs
         /// <returns>The token value from App Settings or environment variables. If the token is not found, null is returned.</returns>
         public virtual string Resolve(string name)
         {
-            return ConfigurationUtility.GetSettingFromConfigOrEnvironment(name);
+            return ConfigurationUtility.GetSetting(name);
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/JobHostConfiguration.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/JobHostConfiguration.cs
@@ -16,6 +16,7 @@ using Microsoft.Azure.WebJobs.Host.Timers;
 using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
+using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.Azure.WebJobs
 {
@@ -38,7 +39,27 @@ namespace Microsoft.Azure.WebJobs
         /// Initializes a new instance of the <see cref="JobHostConfiguration"/> class.
         /// </summary>
         public JobHostConfiguration()
-            : this(null)
+            : this(null, null)
+        {
+        }
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JobHostConfiguration"/> class, using the
+        /// specified connection string for both reading and writing data as well as Dashboard logging.
+        /// </summary>
+        /// <param name="dashboardAndStorageConnectionString">The Azure Storage connection string to use.
+        /// </param>
+        public JobHostConfiguration(string dashboardAndStorageConnectionString)
+            : this(dashboardAndStorageConnectionString, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JobHostConfiguration"/> class.
+        /// </summary>
+        /// <param name="configuration">A configuration object that will be used as the source of application settings.</param>
+        /// </param>
+        public JobHostConfiguration(IConfiguration configuration)
+            : this(null, configuration)
         {
         }
 
@@ -47,9 +68,15 @@ namespace Microsoft.Azure.WebJobs
         /// specified connection string for both reading and writing data as well as Dashboard logging.
         /// </summary>
         /// <param name="dashboardAndStorageConnectionString">The Azure Storage connection string to use.
+        /// <param name="configuration">A configuration object that will be used as the source of application settings.</param>
         /// </param>
-        public JobHostConfiguration(string dashboardAndStorageConnectionString)
+        public JobHostConfiguration(string dashboardAndStorageConnectionString, IConfiguration configuration)
         {
+            if (configuration != null)
+            {
+                ConfigurationUtility.SetConfigurationFactory(() => configuration);
+            }
+
             if (!string.IsNullOrEmpty(dashboardAndStorageConnectionString))
             {
                 _storageAccountProvider = new DefaultStorageAccountProvider(this, dashboardAndStorageConnectionString);
@@ -80,7 +107,7 @@ namespace Microsoft.Azure.WebJobs
             AddService<IWebJobsExceptionHandler>(exceptionHandler);
             AddService<IFunctionResultAggregatorFactory>(new FunctionResultAggregatorFactory());
 
-            string value = ConfigurationUtility.GetSettingFromConfigOrEnvironment(Host.Constants.EnvironmentSettingName);
+            string value = ConfigurationUtility.GetSetting(Host.Constants.EnvironmentSettingName);
             IsDevelopment = string.Compare(Host.Constants.DevelopmentEnvironmentValue, value, StringComparison.OrdinalIgnoreCase) == 0;
         }
 

--- a/src/Microsoft.Azure.WebJobs.Host/Listeners/HostListenerFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Listeners/HostListenerFactory.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Azure.WebJobs.Host.Listeners
 
             // check the target setting and return false (disabled) if the value exists
             // and is "falsey"
-            string value = ConfigurationUtility.GetSettingFromConfigOrEnvironment(settingName);
+            string value = ConfigurationUtility.GetSetting(settingName);
             if (!string.IsNullOrEmpty(value) &&
                 (string.Compare(value, "1", StringComparison.OrdinalIgnoreCase) == 0 ||
                  string.Compare(value, "true", StringComparison.OrdinalIgnoreCase) == 0))

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/StorageAccountTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/StorageAccountTests.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Azure.WebJobs.Storage.IntegrationTests
         }
 
         private static string GetConnectionString(string connectionStringName)
-            => ConfigurationUtility.GetConnectionFromConfigOrEnvironment(connectionStringName);
+            => ConfigurationUtility.GetConnectionString(connectionStringName);
 
         private static string GetQueueName(string infix)
         {

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/ConfigurationUtilityTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/ConfigurationUtilityTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         {
             ConfigurationUtility.Reset();
 
-            string value = ConfigurationUtility.GetSettingFromConfigOrEnvironment("DNE");
+            string value = ConfigurationUtility.GetSetting("DNE");
             Assert.Equal(null, value);
         }
 
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         {
             ConfigurationUtility.Reset();
 
-            string value = ConfigurationUtility.GetSettingFromConfigOrEnvironment(null);
+            string value = ConfigurationUtility.GetSetting(null);
             Assert.Equal(null, value);
         }
 
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         {
             ConfigurationUtility.Reset();
 
-            string value = ConfigurationUtility.GetSettingFromConfigOrEnvironment("DisableSetting0");
+            string value = ConfigurationUtility.GetSetting("DisableSetting0");
             Assert.Equal("0", value);
         }
 
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
 
             Environment.SetEnvironmentVariable("EnvironmentSetting", "1");
 
-            string value = ConfigurationUtility.GetSettingFromConfigOrEnvironment("EnvironmentSetting");
+            string value = ConfigurationUtility.GetSetting("EnvironmentSetting");
             Assert.Equal("1", value);
 
             Environment.SetEnvironmentVariable("EnvironmentSetting", null);
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
 
             Environment.SetEnvironmentVariable("DisableSetting0", "1");
 
-            string value = ConfigurationUtility.GetSettingFromConfigOrEnvironment("DisableSetting0");
+            string value = ConfigurationUtility.GetSetting("DisableSetting0");
             Assert.Equal("0", value);
 
             Environment.SetEnvironmentVariable("DisableSetting0", null);


### PR DESCRIPTION
This is a small change to better enable the CLI (and other clients) to more cleanly pass configuration settings.