### PR TITLE
[AppInsights] reducing metrics from Aggregator

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/Aggregator/FunctionResultAggregate.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/Aggregator/FunctionResultAggregate.cs
@@ -11,27 +11,23 @@ namespace Microsoft.Azure.WebJobs.Logging
     {
         public string Name { get; set; }
         public DateTimeOffset Timestamp { get; set; }
-        public TimeSpan AverageDuration { get; set; }
+        public TimeSpan TotalDuration { get; set; }
         public TimeSpan MaxDuration { get; set; }
         public TimeSpan MinDuration { get; set; }
         public int Successes { get; set; }
         public int Failures { get; set; }
-        public int Count => Successes + Failures;
-        public double SuccessRate => Math.Round((Successes / (double)Count) * 100, 2);
 
         public IReadOnlyDictionary<string, object> ToReadOnlyDictionary()
         {
             return new ReadOnlyDictionary<string, object>(new Dictionary<string, object>
             {
                 [LogConstants.NameKey] = Name,
-                [LogConstants.CountKey] = Count,
                 [LogConstants.TimestampKey] = Timestamp,
-                [LogConstants.AverageDurationKey] = AverageDuration,
-                [LogConstants.MaxDurationKey] = MaxDuration,
-                [LogConstants.MinDurationKey] = MinDuration,
+                [LogConstants.TotalDurationKey] = TotalDuration.TotalMilliseconds,
+                [LogConstants.MaxDurationKey] = MaxDuration.TotalMilliseconds,
+                [LogConstants.MinDurationKey] = MinDuration.TotalMilliseconds,
                 [LogConstants.SuccessesKey] = Successes,
                 [LogConstants.FailuresKey] = Failures,
-                [LogConstants.SuccessRateKey] = SuccessRate
             });
         }
     }

--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/Aggregator/FunctionResultAggregator.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/Aggregator/FunctionResultAggregator.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Azure.WebJobs.Logging
                     Failures = e.Count(f => f.ErrorDetails != null),
                     MinDuration = e.Min(f => f.Duration),
                     MaxDuration = e.Max(f => f.Duration),
-                    AverageDuration = new TimeSpan((long)e.Average(f => f.Duration.Ticks))
+                    TotalDuration = new TimeSpan(e.Sum(f => f.Duration.Ticks))
                 });
 
             return metrics;

--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/Constants/LogConstants.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/Constants/LogConstants.cs
@@ -21,11 +21,6 @@ namespace Microsoft.Azure.WebJobs.Logging
         public const string NameKey = "Name";
 
         /// <summary>
-        /// Gets the name of the key used to store the number of invocations.
-        /// </summary>
-        public const string CountKey = "Count";
-
-        /// <summary>
         /// Gets the name of the key used to store the success count.
         /// </summary>
         public const string SuccessesKey = "Successes";
@@ -36,14 +31,9 @@ namespace Microsoft.Azure.WebJobs.Logging
         public const string FailuresKey = "Failures";
 
         /// <summary>
-        /// Gets the name of the key used to store the success rate.
+        /// Gets the name of the key used to store the total duration in milliseconds.
         /// </summary>
-        public const string SuccessRateKey = "SuccessRate";
-
-        /// <summary>
-        /// Gets the name of the key used to store the average duration in milliseconds.
-        /// </summary>
-        public const string AverageDurationKey = "AvgDurationMs";
+        public const string TotalDurationKey = "TotalDurationMs";
 
         /// <summary>
         /// Gets the name of the key used to store the maximum duration in milliseconds.
@@ -128,7 +118,7 @@ namespace Microsoft.Azure.WebJobs.Logging
         /// <summary>
         /// Gets the function start event name.
         /// </summary>
-        public const string FunctionStartEvent = "FunctionStart";        
+        public const string FunctionStartEvent = "FunctionStart";
 
         /// <summary>
         /// Gets the event id for a metric event.

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerProvider.cs
@@ -16,12 +16,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
 
         public ApplicationInsightsLoggerProvider(ITelemetryClientFactory clientFactory)
         {
-            if (clientFactory == null)
-            {
-                throw new ArgumentNullException(nameof(clientFactory));
-            }
-
-            _clientFactory = clientFactory;
+            _clientFactory = clientFactory ?? throw new ArgumentNullException(nameof(clientFactory));
             _client = _clientFactory.Create();
         }
 

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/DefaultTelemetryClientFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/DefaultTelemetryClientFactory.cs
@@ -109,8 +109,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
             ITelemetryChannel channel = CreateTelemetryChannel();
 
             // call Initialize if available
-            ITelemetryModule module = channel as ITelemetryModule;
-            if (module != null)
+            if (channel is ITelemetryModule module)
             {
                 module.Initialize(config);
             }

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/FilteringTelemetryProcessor.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/FilteringTelemetryProcessor.cs
@@ -32,22 +32,17 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
         {
             bool enabled = true;
 
-            ISupportProperties telemetry = item as ISupportProperties;
-
-            if (telemetry != null && _filter != null)
+            if (item is ISupportProperties telemetry && _filter != null)
             {
-                string categoryName = null;
-                if (!telemetry.Properties.TryGetValue(LogConstants.CategoryNameKey, out categoryName))
+                if (!telemetry.Properties.TryGetValue(LogConstants.CategoryNameKey, out string categoryName))
                 {
                     // If no category is specified, it will be filtered by the default filter
                     categoryName = string.Empty;
                 }
 
                 // Extract the log level and apply the filter
-                string logLevelString = null;
-                LogLevel logLevel;
-                if (telemetry.Properties.TryGetValue(LogConstants.LogLevelKey, out logLevelString) &&
-                    Enum.TryParse(logLevelString, out logLevel))
+                if (telemetry.Properties.TryGetValue(LogConstants.LogLevelKey, out string logLevelString) &&
+                    Enum.TryParse(logLevelString, out LogLevel logLevel))
                 {
                     enabled = _filter(categoryName, logLevel);
                 }

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobsTelemetryInitializer.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobsTelemetryInitializer.cs
@@ -39,8 +39,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
             telemetry.Context.Operation.Name = scopeProps.GetValueOrDefault<string>(ScopeKeys.FunctionName);
 
             // Apply Category and LogLevel to all telemetry
-            ISupportProperties telemetryProps = telemetry as ISupportProperties;
-            if (telemetryProps != null)
+            if (telemetry is ISupportProperties telemetryProps)
             {
                 string category = scopeProps.GetValueOrDefault<string>(LogConstants.CategoryNameKey);
                 if (category != null)

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/LoggerExtensionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/LoggerExtensionsTests.cs
@@ -98,16 +98,14 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                 // nothing logged
                 Assert.Null(f(payload, ex));
 
-                Assert.Equal(9, payload.Count);
+                Assert.Equal(7, payload.Count);
                 Assert.Equal(_functionShortName, payload[LogConstants.NameKey]);
                 Assert.Equal(4, payload[LogConstants.FailuresKey]);
                 Assert.Equal(116, payload[LogConstants.SuccessesKey]);
-                Assert.Equal(TimeSpan.FromMilliseconds(200), (TimeSpan)payload[LogConstants.MinDurationKey]);
-                Assert.Equal(TimeSpan.FromMilliseconds(2180), (TimeSpan)payload[LogConstants.MaxDurationKey]);
-                Assert.Equal(TimeSpan.FromMilliseconds(340), (TimeSpan)payload[LogConstants.AverageDurationKey]);
+                Assert.Equal(200, (double)payload[LogConstants.MinDurationKey]);
+                Assert.Equal(2180, (double)payload[LogConstants.MaxDurationKey]);
+                Assert.Equal(40800, (double)payload[LogConstants.TotalDurationKey]);
                 Assert.Equal(now, payload[LogConstants.TimestampKey]);
-                Assert.Equal(120, payload[LogConstants.CountKey]);
-                Assert.Equal(96.67, payload[LogConstants.SuccessRateKey]);
             });
 
             var resultAggregate = new FunctionResultAggregate
@@ -117,7 +115,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                 Successes = 116,
                 MinDuration = TimeSpan.FromMilliseconds(200),
                 MaxDuration = TimeSpan.FromMilliseconds(2180),
-                AverageDuration = TimeSpan.FromMilliseconds(340),
+                TotalDuration = TimeSpan.FromMilliseconds(40800),
                 Timestamp = now
             };
 


### PR DESCRIPTION
Fixes #1323.  

App Insights has support for Max/Min/Sum on each of their metrics. Previously we were sending MaxDuration/MinDuration/AvgDuration as individual metrics. This change now sends a single Duration metric with Count/Min/Max/Sum all populated.