### PR TITLE
Make BindingProviders type match exactly to bind

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingProviders/GenericCompositeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingProviders/GenericCompositeBindingProvider.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
         {
             var attr = context.Parameter.GetCustomAttribute<TAttribute>();
 
-            if (attr == null)
+            if (attr == null || attr.GetType() != typeof(TAttribute))
             {
                 return null;
             }

--- a/src/Microsoft.Azure.WebJobs.Host/Config/FluentBindingRule.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Config/FluentBindingRule.cs
@@ -304,7 +304,7 @@ namespace Microsoft.Azure.WebJobs.Host.Config
             JobHostMetadataProvider.DumpRule(binding, output);
         }
 
-        private IBindingProvider CreateBinding()
+        internal IBindingProvider CreateBinding()
         {
             var all = new GenericCompositeBindingProvider<TAttribute>(_validator, this._parent.NameResolver, _binders.ToArray());
             return all;


### PR DESCRIPTION
If you have binding attributes that are subtypes of another attribute with a binding provider, and the supertype's attribute happens to be higher in the order of binding provider's checked, then the binding provider for that attribute's exact type will never be hit.

This may not be an ideal fix, as you lose the ability to apply a rule on a super type and also have that work for it's subtypes. This goes into what the design should be for binding attributes that inherit from each other, and whether we want to even support that.