### PR TITLE
[AppInsights] Remove parameter logging for RequestTelemetry

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/LoggerExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/LoggerExtensions.cs
@@ -55,14 +55,6 @@ namespace Microsoft.Extensions.Logging
             properties.Add(LogConstants.DurationKey, logEntry.Duration);
             properties.Add(LogConstants.SucceededKey, succeeded);
 
-            if (logEntry.Arguments != null)
-            {
-                foreach (var arg in logEntry.Arguments)
-                {
-                    properties.Add(LogConstants.ParameterPrefix + arg.Key, arg.Value);
-                }
-            }
-
             FormattedLogValuesCollection payload = new FormattedLogValuesCollection(logString, values, new ReadOnlyDictionary<string, object>(properties));
             LogLevel level = succeeded ? LogLevel.Information : LogLevel.Error;
             logger.Log(level, 0, payload, logEntry.Exception, (s, e) => s.ToString());

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsightsEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsightsEndToEndTests.cs
@@ -244,9 +244,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 Assert.Equal(expectedOperationName, telemetry.Properties[$"{LogConstants.CustomPropertyPrefix}{LogConstants.NameKey}"]);
                 Assert.Equal("This function was programmatically called via the host APIs.", telemetry.Properties[$"{LogConstants.CustomPropertyPrefix}{LogConstants.TriggerReasonKey}"]);
 
-                // TODO: Parameter logging shouldn't have prop__ prefixes. Need to revisit.
-                Assert.Equal("function input", telemetry.Properties[$"{LogConstants.CustomPropertyPrefix}{LogConstants.ParameterPrefix}input"]);
-
                 Assert.IsType<FunctionInvocationException>(telemetry.Exception);
                 Assert.IsType<Exception>(telemetry.Exception.InnerException);
             }
@@ -268,7 +265,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             Assert.NotNull(telemetry.Duration);
             Assert.Equal(success, telemetry.Success);
 
-            Assert.NotNull(telemetry.Properties[$"{LogConstants.ParameterPrefix}input"]);
             Assert.Equal($"ApplicationInsightsEndToEndTests.{operationName}", telemetry.Properties[LogConstants.FullNameKey].ToString());
             Assert.Equal("This function was programmatically called via the host APIs.", telemetry.Properties[LogConstants.TriggerReasonKey].ToString());
 

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsLoggerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsLoggerTests.cs
@@ -90,7 +90,6 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             Assert.Equal(defaultIp, telemetry.Context.Location.Ip);
             Assert.Equal(LogCategories.Results, telemetry.Properties[LogConstants.CategoryNameKey]);
             Assert.Equal(LogLevel.Information.ToString(), telemetry.Properties[LogConstants.LogLevelKey]);
-            Assert.Equal("my message", telemetry.Properties[$"{LogConstants.ParameterPrefix}queueMessage"]);
             Assert.Equal(_triggerReason, telemetry.Properties[LogConstants.TriggerReasonKey]);
             // TODO: Beef up validation to include properties
         }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/LoggerExtensionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/LoggerExtensionsTests.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
 
             var payload = enumerable.ToDictionary(k => k.Key, v => v.Value);
 
-            Assert.Equal(11, payload.Count);
+            Assert.Equal(9, payload.Count);
             Assert.Equal(_functionFullName, payload[LogConstants.FullNameKey]);
             Assert.Equal(_functionShortName, payload[LogConstants.NameKey]);
             Assert.Equal(_invocationId, payload[LogConstants.InvocationIdKey]);
@@ -161,14 +161,9 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             Assert.Equal(_duration, payload[LogConstants.DurationKey]);
             Assert.Equal(_triggerReason, payload[LogConstants.TriggerReasonKey]);
 
-            // verify default arguments were passed with prefix
-            var args = payload.Where(kvp => kvp.Value is string && kvp.Key.ToString().StartsWith(LogConstants.ParameterPrefix));
-            Assert.Equal(_arguments.Count, args.Count());
-            foreach (var arg in _arguments)
-            {
-                var payloadKey = LogConstants.ParameterPrefix + arg.Key;
-                Assert.Equal(arg.Value, args.Single(kvp => kvp.Key == payloadKey).Value.ToString());
-            }
+            // verify that we no longer log parameters
+            var args = payload.Where(kvp => kvp.Key.ToString().StartsWith(LogConstants.ParameterPrefix));
+            Assert.Empty(args);
 
             return payload;
         }


### PR DESCRIPTION
This is the `dev` cherry-pick of #1355 