### PR TITLE
Expose a way to configure the timer mode to use.

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/JobHostConfiguration.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/JobHostConfiguration.cs
@@ -20,6 +20,12 @@ using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.Azure.WebJobs
 {
+    public enum TimerMode
+    {
+        File,
+        Storage
+    }
+
     /// <summary>
     /// Represents the configuration settings for a <see cref="JobHost"/>.
     /// </summary>
@@ -86,6 +92,7 @@ namespace Microsoft.Azure.WebJobs
                 _storageAccountProvider = new DefaultStorageAccountProvider(this);
             }
 
+            TimerMode = TimerMode.Storage;
             Singleton = new SingletonConfiguration();
             Aggregator = new FunctionResultAggregatorConfiguration();
 
@@ -281,6 +288,15 @@ namespace Microsoft.Azure.WebJobs
         {
             get;
             private set;
+        }
+
+        /// <summary>
+        /// Gets or sets the timers config.
+        /// </summary>
+        public TimerMode TimerMode
+        {
+            get;
+            set;
         }
 
         /// <summary>


### PR DESCRIPTION
This will be used to decide between the FileSystemScheduleMonitor or the StorageScheduleMonitor implementation. The standalone host will need the FileSystemScheduleMonitor to avoid the AzureStorage dependency.
NOTE: This is part of a bigger change that needs changes on this repo and in azure-webjobs-sdk-extensions and azure-webjobs-sdk-script to create a custom host for standalone workloads.