### PR TITLE
[WIP] Added HandlesReturnValue attribute.

### DIFF
--- a/src/Microsoft.Azure.WebJobs/BindingAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs/BindingAttribute.cs
@@ -12,5 +12,10 @@ namespace Microsoft.Azure.WebJobs.Description
     [AttributeUsage(AttributeTargets.Class)]
     public sealed class BindingAttribute : Attribute
     {
+        /// <summary>
+        /// Indicates that a trigger binding is capable of handling return values
+        /// from a function.
+        /// </summary>
+        public bool TriggerHandlesReturnValue { get; set; }
     }
 }


### PR DESCRIPTION
* HandlesReturnValue attribute is intended for use by extension trigger bindings to indicate to non-C# languages that a return value should be expected.