### PR TITLE
Allow SDK to run purely off just a SAS connection string to a container

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/ConnectionStringNames.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/ConnectionStringNames.cs
@@ -16,5 +16,8 @@ namespace Microsoft.Azure.WebJobs
 
         /// <summary>Gets the Azure ServiceBus connection string name.</summary>
         public static readonly string ServiceBus = "ServiceBus";
+
+        /// <summary>Gets an Azure Storage SAS connection for a blob container to use with internal operations.</summary>
+        public static readonly string InternalSasStorage = "InternalSasBlobContainer";
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/DefaultStorageAccountProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/DefaultStorageAccountProvider.cs
@@ -114,6 +114,17 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             }
         }
 
+        /// <summary>
+        /// Get a SAS connection to a blob Container for use with SDK internal operations. 
+        /// </summary>
+        public string InternalSasStorage
+        {
+            get
+            {
+                return _ambientConnectionStringProvider.GetConnectionString(ConnectionStringNames.InternalSasStorage);
+            }
+        }
+
         private IStorageAccount DashboardAccount
         {
             get

--- a/src/Microsoft.Azure.WebJobs.Host/JobHostConfiguration.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/JobHostConfiguration.cs
@@ -16,6 +16,7 @@ using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 using Microsoft.Extensions.Configuration;
+using Microsoft.WindowsAzure.Storage.Blob;
 
 namespace Microsoft.Azure.WebJobs
 {
@@ -82,6 +83,18 @@ namespace Microsoft.Azure.WebJobs
             else
             {
                 _storageAccountProvider = new DefaultStorageAccountProvider(this);
+            }
+
+            var sasBlobContainer = _storageAccountProvider.InternalSasStorage;
+            if (sasBlobContainer != null)
+            {
+                var uri = new Uri(sasBlobContainer);
+                var sdkContainer = new CloudBlobContainer(uri);
+
+                this.InternalStorageConfiguration = new JobHostInternalStorageConfiguration
+                {
+                     InternalContainer = sdkContainer
+                };
             }
 
             Singleton = new SingletonConfiguration();
@@ -195,6 +208,11 @@ namespace Microsoft.Azure.WebJobs
             get { return _storageAccountProvider.StorageConnectionString; }
             set { _storageAccountProvider.StorageConnectionString = value; }
         }
+
+        /// <summary>
+        /// Gets or sets a the storage configuration that the runtime needs for its internal operations.
+        /// </summary>
+        public JobHostInternalStorageConfiguration InternalStorageConfiguration { get; set; }
 
         /// <summary>Gets or sets the type locator.</summary>
         public ITypeLocator TypeLocator

--- a/src/Microsoft.Azure.WebJobs.Host/JobHostInternalStorageConfiguration.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/JobHostInternalStorageConfiguration.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.WindowsAzure.Storage.Blob;
+
+namespace Microsoft.Azure.WebJobs
+{
+    /// <summary>
+    /// The storage configuration that the JobHost needs for its own operations (independent of binding)
+    /// For example, this can support <see cref="SingletonAttribute"/>, blob leases, timers, etc. 
+    /// This provides a common place to set storage that the various subsequent services can use. 
+    /// </summary>
+    public class JobHostInternalStorageConfiguration
+    {
+        /// <summary>
+        /// A SAS to a Blob Container. This allows services to create blob leases and do distributed locking.
+        /// If this is set, <see cref="JobHostConfiguration.StorageConnectionString"/> and 
+        /// <see cref="JobHostConfiguration.DashboardConnectionString"/> can be set to null and the runtime will use the container.
+        /// </summary>
+        public CloudBlobContainer InternalContainer { get; set; }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/InternalStorageTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/InternalStorageTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             var account1 = CloudStorageAccount.Parse(acs);
             var client = account1.CreateCloudBlobClient();
             var container = client.GetContainerReference(containerName);
-            await container.CreateIfNotExistsAsync();
+            await container.CreateIfNotExistsAsync(); // this will throw if acs is bad
 
             var now = DateTime.UtcNow;
             var sig = container.GetSharedAccessSignature(new SharedAccessBlobPolicy
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             });
 
             var fakeSasUri = container.Uri + sig;
-
+            
             // Set env to the SAS container and clear out all other storage. 
             using (EnvVarHolder.Set("AzureWebJobsInternalSasBlobContainer", fakeSasUri))
             using (EnvVarHolder.Set("AzureWebJobsStorage", null))

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/InternalStorageTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/InternalStorageTests.cs
@@ -1,0 +1,90 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Microsoft.Azure.WebJobs.Host.Timers;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Blob;
+using Microsoft.WindowsAzure.Storage.Queue;
+using Microsoft.WindowsAzure.Storage.Table;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
+{
+    public class InternalStorageTests 
+    {
+        // End-2-end test that we can run a JobHost from purely a SAS connection string. 
+        [Fact]
+        public async Task Test()
+        {
+            var containerName = "test-internal1";
+
+            var acs = Environment.GetEnvironmentVariable("AzureWebJobsStorage");
+            if (acs == null)
+            {
+                Assert.False(true, "Missing AzureWebJobsStorage setting");
+            }
+
+            // Create a real Blob Container Sas URI
+            var account1 = CloudStorageAccount.Parse(acs);
+            var client = account1.CreateCloudBlobClient();
+            var container = client.GetContainerReference(containerName);
+            await container.CreateIfNotExistsAsync();
+
+            var now = DateTime.UtcNow;
+            var sig = container.GetSharedAccessSignature(new SharedAccessBlobPolicy
+            {
+                 Permissions = SharedAccessBlobPermissions.Read | SharedAccessBlobPermissions.Write | SharedAccessBlobPermissions.List ,
+                 SharedAccessStartTime = now.AddDays(-10),
+                 SharedAccessExpiryTime = now.AddDays(10)
+            });
+
+            var fakeSasUri = container.Uri + sig;
+
+            // Set env to the SAS container and clear out all other storage. 
+            using (EnvVarHolder.Set("AzureWebJobsInternalSasBlobContainer", fakeSasUri))
+            using (EnvVarHolder.Set("AzureWebJobsStorage", null))
+            using (EnvVarHolder.Set("AzureWebJobsDashboard", null))
+            {
+                var prog = new BasicProg();
+                var activator = new FakeActivator(prog);
+                JobHostConfiguration config = new JobHostConfiguration()
+                {
+                    TypeLocator = new FakeTypeLocator(typeof(BasicProg))                    
+                };
+
+                Assert.NotNull(config.InternalStorageConfiguration);
+                Assert.Equal(container.Name, config.InternalStorageConfiguration.InternalContainer.Name);
+
+                config.JobActivator = activator;
+                config.HostId = Guid.NewGuid().ToString("n");
+                config.DashboardConnectionString = null;
+                config.StorageConnectionString = null;
+
+
+                var host = new JobHost(config);
+                await host.CallAsync("Foo");
+
+                Assert.Equal(1, prog._count); // Verify successfully called.
+            }
+        }
+
+        public class BasicProg
+        {
+            public int _count;
+
+            [Singleton] // Singleton will force usage of SAS container
+            [NoAutomaticTrigger]
+            public void Foo()
+            {
+                _count++;
+            }
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/EnvVarHolder.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/EnvVarHolder.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using Microsoft.Azure.WebJobs.Host;
 using System;
 
 namespace Microsoft.Azure.WebJobs
@@ -10,6 +11,8 @@ namespace Microsoft.Azure.WebJobs
     {
         public static IDisposable Set(string name, string value)
         {
+            ConfigurationUtility.Reset();
+
             string prevStorage = Environment.GetEnvironmentVariable(name);
 
             Environment.SetEnvironmentVariable(name, value);
@@ -29,6 +32,7 @@ namespace Microsoft.Azure.WebJobs
             public void Dispose()
             {
                 Environment.SetEnvironmentVariable(_name, _value);
+                ConfigurationUtility.Reset();
             }
         }
     }

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/EnvVarHolder.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/EnvVarHolder.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Azure.WebJobs
+{
+    // Test helper for setting & resetting an env variable. 
+    public class EnvVarHolder
+    {
+        public static IDisposable Set(string name, string value)
+        {
+            string prevStorage = Environment.GetEnvironmentVariable(name);
+
+            Environment.SetEnvironmentVariable(name, value);
+            return new Holder
+            {
+                _name = name,
+                _value = prevStorage
+            };
+        }
+
+
+        public class Holder : IDisposable
+        {
+            public string _name;
+            public string _value;
+
+            public void Dispose()
+            {
+                Environment.SetEnvironmentVariable(_name, _value);
+            }
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostConfigurationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostConfigurationTests.cs
@@ -19,8 +19,17 @@ using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Host.UnitTests
 {
-    public class JobHostConfigurationTests
+    public class JobHostConfigurationTests : IDisposable
     {
+        public JobHostConfigurationTests()
+        {
+            ConfigurationUtility.Reset();
+        }
+        void IDisposable.Dispose()
+        {
+            ConfigurationUtility.Reset();
+        }
+
         [Fact]
         public void ConstructorDefaults()
         {
@@ -271,37 +280,30 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         [InlineData("development", true)]
         public void IsDevelopment_ReturnsCorrectValue(string settingValue, bool expected)
         {
-            // Forces configuration to be re-read:
-            ConfigurationUtility.Reset();
-
-            string prev = Environment.GetEnvironmentVariable(Constants.EnvironmentSettingName);
-            Environment.SetEnvironmentVariable(Constants.EnvironmentSettingName, settingValue);
-
-            JobHostConfiguration config = new JobHostConfiguration();
-            Assert.Equal(config.IsDevelopment, expected);
-
-            Environment.SetEnvironmentVariable(Constants.EnvironmentSettingName, prev);
+            using (EnvVarHolder.Set(Constants.EnvironmentSettingName, settingValue))
+            {
+                JobHostConfiguration config = new JobHostConfiguration();
+                Assert.Equal(config.IsDevelopment, expected);
+            }
         }
 
         public void UseDevelopmentSettings_ConfiguresCorrectValues()
         {
-            ConfigurationUtility.Reset();
-            string prev = Environment.GetEnvironmentVariable(Constants.EnvironmentSettingName);
-            Environment.SetEnvironmentVariable(Constants.EnvironmentSettingName, "Development");
-
-            JobHostConfiguration config = new JobHostConfiguration();
-            Assert.False(config.UsingDevelopmentSettings);
-
-            if (config.IsDevelopment)
+            using (EnvVarHolder.Set(Constants.EnvironmentSettingName, "Development"))
             {
-                config.UseDevelopmentSettings();
+                JobHostConfiguration config = new JobHostConfiguration();
+                Assert.False(config.UsingDevelopmentSettings);
+
+                if (config.IsDevelopment)
+                {
+                    config.UseDevelopmentSettings();
+                }
+
+                Assert.True(config.UsingDevelopmentSettings);
+                Assert.Equal(TimeSpan.FromSeconds(2), config.Queues.MaxPollingInterval);
+                Assert.Equal(TimeSpan.FromSeconds(15), config.Singleton.ListenerLockPeriod);
+
             }
-
-            Assert.True(config.UsingDevelopmentSettings);
-            Assert.Equal(TimeSpan.FromSeconds(2), config.Queues.MaxPollingInterval);
-            Assert.Equal(TimeSpan.FromSeconds(15), config.Singleton.ListenerLockPeriod);
-
-            Environment.SetEnvironmentVariable(Constants.EnvironmentSettingName, prev);
         }
 
         private static void TestHostIdThrows(string hostId)
@@ -343,22 +345,38 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             }
         }
 
+        // Verify that JobHostConfig pulls a Sas container from appsettings. 
+        [Fact]
+        public void JobHost_UsesSas()
+        {
+            var fakeSasUri = "https://contoso.blob.core.windows.net/myContainer?signature=foo";
+            using (EnvVarHolder.Set("AzureWebJobsInternalSasBlobContainer", fakeSasUri))
+            {
+                JobHostConfiguration config = new JobHostConfiguration();
+
+                Assert.NotNull(config.InternalStorageConfiguration); // Env var should cause this to get initialized 
+
+                var container = config.InternalStorageConfiguration.InternalContainer;
+                Assert.NotNull(container);
+
+                Assert.Equal(container.Name, "myContainer"); // specified in sas. 
+            }
+        }
+
         // Test that we can explicitly disable storage and call through a function
         // And enable the fast table logger and ensure that's getting events.
         [Fact]
         public void JobHost_NoStorage_Succeeds()
         {
-            string prevStorage = Environment.GetEnvironmentVariable("AzureWebJobsStorage");
-            string prevDashboard = Environment.GetEnvironmentVariable("AzureWebJobsDashboard");
-            try
+            using (EnvVarHolder.Set("AzureWebJobsStorage", null))
+            using (EnvVarHolder.Set("AzureWebJobsDashboard", null))
             {
-                Environment.SetEnvironmentVariable("AzureWebJobsStorage", null);
-                Environment.SetEnvironmentVariable("AzureWebJobsDashboard", null);
-
                 JobHostConfiguration config = new JobHostConfiguration()
                 {
                     TypeLocator = new FakeTypeLocator(typeof(BasicTest))
                 };
+                Assert.Null(config.InternalStorageConfiguration);
+
                 // Explicitly disalbe storage.
                 config.HostId = Guid.NewGuid().ToString("n");
                 config.DashboardConnectionString = null;
@@ -406,11 +424,6 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 Assert.Equal("val=" + randomValue, endMsg.LogOutput.Trim());
 
                 Assert.Same(FastLogger.FlushEntry, fastLogger.List[2]);
-            }
-            finally
-            {
-                Environment.SetEnvironmentVariable("AzureWebJobsStorage", prevStorage);
-                Environment.SetEnvironmentVariable("AzureWebJobsDashboard", prevDashboard);
             }
         }
 

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostConfigurationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostConfigurationTests.cs
@@ -19,17 +19,8 @@ using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Host.UnitTests
 {
-    public class JobHostConfigurationTests : IDisposable
+    public class JobHostConfigurationTests
     {
-        public JobHostConfigurationTests()
-        {
-            ConfigurationUtility.Reset();
-        }
-        void IDisposable.Dispose()
-        {
-            ConfigurationUtility.Reset();
-        }
-
         [Fact]
         public void ConstructorDefaults()
         {

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
@@ -155,6 +155,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 "ConnectionStringNames",
                 "JobHost",
                 "JobHostConfiguration",
+                "JobHostInternalStorageConfiguration",
                 "JobHostQueuesConfiguration",
                 "JobHostBlobsConfiguration",
                 "IJobActivator",

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Singleton/SingletonManagerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Singleton/SingletonManagerTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Singleton
                 return null;
             }
             return (SingletonLockHandle)handle.InnerLock;
-        }
+    }
     }
 
     public class SingletonManagerTests
@@ -110,7 +110,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Singleton
             loggerFactory.AddProvider(_loggerProvider);
 
             var logger = loggerFactory?.CreateLogger(LogCategories.Singleton);
-            _core = new BlobLeaseDistributedLockManager(_mockAccountProvider.Object, logger);
+            _core = new BlobLeaseDistributedLockManager.DedicatedStorage(_mockAccountProvider.Object, logger);
 
             _singletonManager = new SingletonManager(_core, _singletonConfig, _mockExceptionDispatcher.Object, loggerFactory, new FixedHostIdProvider(TestHostId), _nameResolver);
 


### PR DESCRIPTION
Allow when we have no full Connection strings involved, just a SAS URL to storage container. Added a new property on JobHostConfiguration to describe the sas. 

Config looks like:
    config.HostId = "hostid1234";
    config.StorageConnectionString = null;
    config.DashboardConnectionString = null;
    **config.SaSContainerConnectionString= "xxxx my container SAS xxxx"**