### PR TITLE
Changing configuration setup order so environment variables take precendence over app settings

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/ConfigurationUtility.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/ConfigurationUtility.cs
@@ -53,8 +53,8 @@ namespace Microsoft.Azure.WebJobs.Host
         private static IConfigurationRoot BuildConfiguration()
         {
             var configurationBuilder = new ConfigurationBuilder()
-                .AddEnvironmentVariables()
-                .AddJsonFile("appsettings.json", optional: true);
+                .AddJsonFile("appsettings.json", optional: true)
+                .AddEnvironmentVariables();
 
             return configurationBuilder.Build();
         }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/ConfigurationUtilityTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/ConfigurationUtilityTests.cs
@@ -49,14 +49,14 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         }
 
         [Fact]
-        public void GetSettingFromConfigOrEnvironment_ConfigAndEnvironment_ConfigWins()
+        public void GetSettingFromConfigOrEnvironment_ConfigAndEnvironment_EnvironmentWins()
         {
             ConfigurationUtility.Reset();
 
             Environment.SetEnvironmentVariable("DisableSetting0", "1");
 
             string value = ConfigurationUtility.GetSetting("DisableSetting0");
-            Assert.Equal("0", value);
+            Assert.Equal("1", value);
 
             Environment.SetEnvironmentVariable("DisableSetting0", null);
         }


### PR DESCRIPTION
Resolves #1408 

This is a temporary fix as the `ConfigurationUtility` type will be removed as part of the DI work, but the default behavior introduced with this change will be maintained.