### PR TITLE
make blob enqueue concurrent

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Blobs/Listeners/BlobListenerFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Blobs/Listeners/BlobListenerFactory.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
                 new SharedQueueWatcherFactory(_messageEnqueuedWatcherSetter));
 
             SharedBlobListener sharedBlobListener = _sharedContextProvider.GetOrCreateInstance<SharedBlobListener>(
-                new SharedBlobListenerFactory(hostId, _hostAccount, _exceptionHandler, _blobWrittenWatcherSetter));
+                new SharedBlobListenerFactory(hostId, _hostAccount, _exceptionHandler, _blobWrittenWatcherSetter, _trace));
 
             // Register the blob container we wish to monitor with the shared blob listener.
             await RegisterWithSharedBlobListenerAsync(hostId, sharedBlobListener, primaryBlobClient,

--- a/src/Microsoft.Azure.WebJobs.Host/Blobs/Listeners/SharedBlobListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Blobs/Listeners/SharedBlobListener.cs
@@ -20,9 +20,9 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
         private bool _disposed;
 
         public SharedBlobListener(string hostId, IStorageAccount storageAccount,
-            IWebJobsExceptionHandler exceptionHandler)
+            IWebJobsExceptionHandler exceptionHandler, TraceWriter trace)
         {
-            _strategy = CreateStrategy(hostId, storageAccount);
+            _strategy = CreateStrategy(hostId, storageAccount, trace);
             // Start the first iteration immediately.
             _timer = new TaskSeriesTimer(_strategy, exceptionHandler, initialWait: Task.Delay(0));
         }
@@ -87,12 +87,12 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
             }
         }
 
-        private static IBlobListenerStrategy CreateStrategy(string hostId, IStorageAccount account)
+        private static IBlobListenerStrategy CreateStrategy(string hostId, IStorageAccount account, TraceWriter trace)
         {
             if (!StorageClient.IsDevelopmentStorageAccount(account))
             {
                 IBlobScanInfoManager scanInfoManager = new StorageBlobScanInfoManager(hostId, account.CreateBlobClient());
-                return new ScanBlobScanLogHybridPollingStrategy(scanInfoManager);
+                return new ScanBlobScanLogHybridPollingStrategy(scanInfoManager, trace);
             }
             else
             {

--- a/src/Microsoft.Azure.WebJobs.Host/Blobs/Listeners/SharedBlobListenerFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Blobs/Listeners/SharedBlobListenerFactory.cs
@@ -14,10 +14,12 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
         private readonly IWebJobsExceptionHandler _exceptionHandler;
         private readonly IContextSetter<IBlobWrittenWatcher> _blobWrittenWatcherSetter;
         private readonly string _hostId;
+        private readonly TraceWriter _trace;
 
         public SharedBlobListenerFactory(string hostId, IStorageAccount account,
             IWebJobsExceptionHandler exceptionHandler,
-            IContextSetter<IBlobWrittenWatcher> blobWrittenWatcherSetter)
+            IContextSetter<IBlobWrittenWatcher> blobWrittenWatcherSetter,
+            TraceWriter trace)
         {
             if (account == null)
             {
@@ -38,12 +40,13 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
             _account = account;
             _exceptionHandler = exceptionHandler;
             _blobWrittenWatcherSetter = blobWrittenWatcherSetter;
+            _trace = trace;
         }
 
         [SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]
         public SharedBlobListener Create()
         {
-            SharedBlobListener listener = new SharedBlobListener(_hostId, _account, _exceptionHandler);
+            SharedBlobListener listener = new SharedBlobListener(_hostId, _account, _exceptionHandler, _trace);
             _blobWrittenWatcherSetter.SetValue(listener.BlobWritterWatcher);
             return listener;
         }


### PR DESCRIPTION
tested with very simple blob trigger
here is the result of processing 100 new blobs (running on my local machine)
1. sequential:
![image](https://user-images.githubusercontent.com/6531400/33094105-d1d3977a-ceb3-11e7-951a-44871c80b783.png)
average time spent on writing to sharedBlobQueue is (51150-171)/100=509 ms/blob
2. parallel:
![image](https://user-images.githubusercontent.com/6531400/33094184-26ad72de-ceb4-11e7-9bff-be460714ee12.png)
average time spent on writing to sharedBlobQueue is (1488-122)/100=13 ms/blob
since my socket upper limit is 50(same as in Azure) , there is basically two group send, each cost (1488-122)/2=683 ms (a little longer than single message send, but the quantity make up for it)

Here is a simulation using the old method (when function execution is fairly short)
```
blobListener thread                      queueListener thread
finished enqueuing blobA
started enqueuing blobB                   dequeued blobA
finished enqueuing blobB                  finished blobA
started enqueuing blobC                   dequeued blobB
```
when enqueue speed is similar to the dequeue and execution speed, we will see blob jobs 
being executed sequentially, no matter what the batch size user specified, we are always dequeuing 1 message at a time, which cost bandwidth and also stop us from scaling. https://github.com/Azure/azure-webjobs-sdk/issues/1427
