### PR TITLE
Namespace updates, remove [Obsolete]s

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/DefaultAttributeInvokerDescriptor.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/DefaultAttributeInvokerDescriptor.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Microsoft.Azure.WebJobs.Description;
 using Newtonsoft.Json;
 
 namespace Microsoft.Azure.WebJobs.Host.Bindings

--- a/src/Microsoft.Azure.WebJobs.Host/Config/ExtensionConfigContextExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Config/ExtensionConfigContextExtensions.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.Azure.WebJobs.Host.Bindings;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -14,64 +13,6 @@ namespace Microsoft.Azure.WebJobs.Host.Config
     [Obsolete("Not ready for public consumption.")]
     public static class ExtensionConfigContextExtensions
     {
-        /// <summary>
-        /// Register a set of rules to handle binding to a given attribute. 
-        /// </summary>
-        /// <typeparam name="TAttribute">The attribute to bind to</typeparam>
-        /// <param name="context"></param>
-        /// <param name="validator">a validator function to invoke on the attribute before runtime. </param>
-        /// <param name="bindingProviders">list of binding providers to handle this attribute. 
-        /// If none of these handle the attribute, an error is thrown at indexing. </param>
-        public static void RegisterBindingRules<TAttribute>(
-            this ExtensionConfigContext context,
-            Action<TAttribute, Type> validator,
-            params IBindingProvider[] bindingProviders)
-            where TAttribute : Attribute
-        {
-            if (context == null)
-            {
-                throw new ArgumentNullException("context");
-            }
-            if (validator == null)
-            {
-                throw new ArgumentNullException("validator");
-            }
-            if (bindingProviders == null)
-            {
-                throw new ArgumentNullException("bindingProviders");
-            }
-
-            IExtensionRegistry extensions = context.Config.GetService<IExtensionRegistry>();
-            INameResolver nameResolver = context.Config.NameResolver;
-            extensions.RegisterBindingRules<TAttribute>(validator, nameResolver, bindingProviders);
-        }
-
-        /// <summary>
-        /// Register a set of rules to handle binding to a given attribute. 
-        /// </summary>
-        /// <typeparam name="TAttribute">The attribute to bind to</typeparam>
-        /// <param name="context"></param>
-        /// <param name="bindingProviders">list of binding providers to handle this attribute. 
-        /// If none of these handle the attribute, an error is thrown at indexing. </param>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter")]
-        public static void RegisterBindingRules<TAttribute>(
-            this ExtensionConfigContext context,
-            params IBindingProvider[] bindingProviders)
-            where TAttribute : Attribute
-        {
-            if (context == null)
-            {
-                throw new ArgumentNullException("context");
-            }
-            if (bindingProviders == null)
-            {
-                throw new ArgumentNullException("bindingProviders");
-            }
-
-            IExtensionRegistry extensions = context.Config.GetService<IExtensionRegistry>();
-            extensions.RegisterBindingRules<TAttribute>(bindingProviders);
-        }
-
         /// <summary>
         /// Get the configuration object for this extension. 
         /// </summary>

--- a/src/Microsoft.Azure.WebJobs/AppSettingAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs/AppSettingAttribute.cs
@@ -3,13 +3,12 @@
 
 using System;
 
-namespace Microsoft.Azure.WebJobs
+namespace Microsoft.Azure.WebJobs.Description
 {
     /// <summary>
     /// Place this on binding attributes properties to tell the binders that that the property
     /// should be automatically resolved as an app setting
     /// </summary>
-    [Obsolete("Not ready for public consumption.")]
     [AttributeUsage(AttributeTargets.Property)]
     public sealed class AppSettingAttribute : Attribute
     {

--- a/src/Microsoft.Azure.WebJobs/AutoResolveAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs/AutoResolveAttribute.cs
@@ -3,13 +3,12 @@
 
 using System;
 
-namespace Microsoft.Azure.WebJobs
+namespace Microsoft.Azure.WebJobs.Description
 {
     /// <summary>
     /// Attribute used to indicate that a binding attribute property should have
     /// automatic resolution of {} and %% binding expressions applied.
     /// </summary>
-    [Obsolete("Not ready for public consumption.")]
     [AttributeUsage(AttributeTargets.Property)]
     public sealed class AutoResolveAttribute : Attribute
     {

--- a/src/Microsoft.Azure.WebJobs/IAttributeInvokeDescriptor.cs
+++ b/src/Microsoft.Azure.WebJobs/IAttributeInvokeDescriptor.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace Microsoft.Azure.WebJobs
+namespace Microsoft.Azure.WebJobs.Description
 {
     /// <summary>
     /// Describes how an attribute is converted to and from an string-representation that can be both logged 
@@ -12,7 +12,6 @@ namespace Microsoft.Azure.WebJobs
     /// An attribute may implement this interface, or a default implementation may be inferred. 
     /// </summary>
     /// <typeparam name="TAttribute">Type of the attribute on this binding.</typeparam>
-    [Obsolete("Not ready for public consumption.")]
     public interface IAttributeInvokeDescriptor<TAttribute>
     {
         /// <summary>


### PR DESCRIPTION
Anything used to decorate a binding attribute goes into the Microsoft.Azure.WebJobs.Description namespace.

Notably [AppSetting] and [AutoResolve]
Remove more [Obsolete] attributes.