### PR TITLE
Allow specifying a timeout at the JobHostConfiguration level.

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostConfigurationExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostConfigurationExtensions.cs
@@ -264,6 +264,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
 
                 if (functionIndexProvider == null)
                 {
+                    var defaultTimeout = config.FunctionTimeout?.ToAttribute();
                     functionIndexProvider = new FunctionIndexProvider(
                         services.GetService<ITypeLocator>(),
                         triggerBindingProvider,
@@ -274,7 +275,8 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
                         singletonManager,
                         trace,
                         loggerFactory,
-                        hostSharedQueue);
+                        hostSharedQueue,
+                        defaultTimeout);
 
                     // Important to set this so that the func we passed to DynamicHostIdProvider can pick it up. 
                     services.AddService<IFunctionIndexProvider>(functionIndexProvider);

--- a/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexProvider.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
         private readonly TraceWriter _trace;
         private readonly ILoggerFactory _loggerFactory;
         private readonly SharedQueueHandler _sharedQueue;
+        private readonly TimeoutAttribute _defaultTimeout;
 
         private IFunctionIndex _index;
 
@@ -37,7 +38,8 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
             SingletonManager singletonManager,
             TraceWriter trace,
             ILoggerFactory loggerFactory,
-            SharedQueueHandler sharedQueue)
+            SharedQueueHandler sharedQueue,
+            TimeoutAttribute defaultTimeout)
         {
             if (typeLocator == null)
             {
@@ -94,6 +96,7 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
             _trace = trace;
             _loggerFactory = loggerFactory;
             _sharedQueue = sharedQueue;
+            _defaultTimeout = defaultTimeout;
         }
 
         public async Task<IFunctionIndex> GetAsync(CancellationToken cancellationToken)
@@ -109,7 +112,7 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
         private async Task<IFunctionIndex> CreateAsync(CancellationToken cancellationToken)
         {
             FunctionIndex index = new FunctionIndex();
-            FunctionIndexer indexer = new FunctionIndexer(_triggerBindingProvider, _bindingProvider, _activator, _executor, _extensions, _singletonManager, _trace, _loggerFactory, null, _sharedQueue);
+            FunctionIndexer indexer = new FunctionIndexer(_triggerBindingProvider, _bindingProvider, _activator, _executor, _extensions, _singletonManager, _trace, _loggerFactory, null, _sharedQueue, _defaultTimeout);
             IReadOnlyList<Type> types = _typeLocator.GetTypes();
 
             foreach (Type type in types)

--- a/src/Microsoft.Azure.WebJobs.Host/JobHostConfiguration.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/JobHostConfiguration.cs
@@ -317,6 +317,12 @@ namespace Microsoft.Azure.WebJobs
         }
 
         /// <summary>
+        /// Default timeout configuration to apply to all functions. 
+        /// If <see cref="TimeoutAttribute"/> is explicitly applied to a function, the values specified by the attribute will take precedence
+        /// </summary>
+        public JobHostFunctionTimeoutConfiguration FunctionTimeout { get; set; }
+
+        /// <summary>
         /// Configures various configuration settings on this <see cref="JobHostConfiguration"/> to
         /// optimize for local development.
         /// </summary>

--- a/src/Microsoft.Azure.WebJobs.Host/JobHostFunctionTimeoutConfiguration.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/JobHostFunctionTimeoutConfiguration.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Threading;
+
+namespace Microsoft.Azure.WebJobs.Host
+{
+    /// <summary>
+    /// Configuration options for controlling function execution timeout behavior.
+    /// </summary>
+    public class JobHostFunctionTimeoutConfiguration
+    {
+        /// <summary>
+        /// Gets the timeout value.
+        /// </summary>
+        public TimeSpan Timeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether function invocations will timeout when
+        /// a <see cref="Timeout"/> is specified and a debugger is attached. False by default.
+        /// </summary>
+        public bool TimeoutWhileDebugging { get; set; }
+
+        /// <summary>
+        /// When true, an exception is thrown when a function timeout expires.
+        /// </summary>
+        public bool ThrowOnTimeout { get; set; }
+
+        /// <summary>
+        /// The amount of time to wait between canceling the timeout <see cref="CancellationToken"/> and throwing
+        /// a FunctionTimeoutException. This gives functions time to perform any graceful shutdown. 
+        /// Only applies if <see cref="ThrowOnTimeout"/> is true.
+        /// </summary>
+        public TimeSpan GracePeriod { get; set; }
+
+        internal TimeoutAttribute ToAttribute()
+        {
+            return new TimeoutAttribute(this.Timeout.ToString())
+            {
+                TimeoutWhileDebugging = this.TimeoutWhileDebugging,
+                ThrowOnTimeout = this.ThrowOnTimeout,
+                GracePeriod = this.GracePeriod,
+            };
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
+++ b/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
@@ -485,6 +485,7 @@
     <Compile Include="Blobs\Listeners\StorageBlobScanInfoManager.cs" />
     <Compile Include="Blobs\ParameterizedBlobUrl.cs" />
     <Compile Include="Blobs\StorageBlobToCloudAppendBlobConverter.cs" />
+    <Compile Include="JobHostFunctionTimeoutConfiguration.cs" />
     <Compile Include="Config\IWebhookProvider.cs" />
     <Compile Include="Config\FluentConverterRules.cs" />
     <Compile Include="Config\FluentBindingRule.cs" />

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
@@ -161,6 +161,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 "JobHostConfiguration",
                 "JobHostQueuesConfiguration",
                 "JobHostBlobsConfiguration",
+                "JobHostFunctionTimeoutConfiguration",
                 "IJobActivator",
                 "ITypeLocator",
                 "INameResolver",


### PR DESCRIPTION
Fix https://github.com/Azure/azure-webjobs-sdk-script/issues/2105
Still need an update in Script to set this. 