### PR TITLE
Port timeout fix

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostConfigurationExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostConfigurationExtensions.cs
@@ -281,6 +281,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
 
                 if (functionIndexProvider == null)
                 {
+                    var defaultTimeout = config.FunctionTimeout?.ToAttribute();
                     functionIndexProvider = new FunctionIndexProvider(
                         services.GetService<ITypeLocator>(),
                         triggerBindingProvider,
@@ -290,7 +291,8 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
                         extensions,
                         singletonManager,                        
                         loggerFactory,
-                        hostSharedQueue);
+                        hostSharedQueue,
+                        defaultTimeout);
 
                     // Important to set this so that the func we passed to DynamicHostIdProvider can pick it up. 
                     services.AddService<IFunctionIndexProvider>(functionIndexProvider);

--- a/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexProvider.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
         private readonly SingletonManager _singletonManager;
         private readonly ILoggerFactory _loggerFactory;
         private readonly SharedQueueHandler _sharedQueue;
+        private readonly TimeoutAttribute _defaultTimeout;
 
         private IFunctionIndex _index;
 
@@ -35,7 +36,8 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
             IExtensionRegistry extensions,
             SingletonManager singletonManager,
             ILoggerFactory loggerFactory,
-            SharedQueueHandler sharedQueue)
+            SharedQueueHandler sharedQueue,
+            TimeoutAttribute defaultTimeout)
         {
 
             _typeLocator = typeLocator ?? throw new ArgumentNullException(nameof(typeLocator));
@@ -48,6 +50,7 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
             _sharedQueue = sharedQueue ?? throw new ArgumentNullException(nameof(sharedQueue));
 
             _loggerFactory = loggerFactory;
+            _defaultTimeout = defaultTimeout;
         }
 
         public async Task<IFunctionIndex> GetAsync(CancellationToken cancellationToken)

--- a/src/Microsoft.Azure.WebJobs.Host/JobHostConfiguration.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/JobHostConfiguration.cs
@@ -338,6 +338,12 @@ namespace Microsoft.Azure.WebJobs
         }
 
         /// <summary>
+        /// Default timeout configuration to apply to all functions. 
+        /// If <see cref="TimeoutAttribute"/> is explicitly applied to a function, the values specified by the attribute will take precedence
+        /// </summary>
+        public JobHostFunctionTimeoutConfiguration FunctionTimeout { get; set; }
+
+        /// <summary>
         /// Configures various configuration settings on this <see cref="JobHostConfiguration"/> to
         /// optimize for local development.
         /// </summary>

--- a/src/Microsoft.Azure.WebJobs.Host/JobHostFunctionTimeoutConfiguration.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/JobHostFunctionTimeoutConfiguration.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Threading;
+
+namespace Microsoft.Azure.WebJobs.Host
+{
+    /// <summary>
+    /// Configuration options for controlling function execution timeout behavior.
+    /// </summary>
+    public class JobHostFunctionTimeoutConfiguration
+    {
+        /// <summary>
+        /// Gets the timeout value.
+        /// </summary>
+        public TimeSpan Timeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether function invocations will timeout when
+        /// a <see cref="Timeout"/> is specified and a debugger is attached. False by default.
+        /// </summary>
+        public bool TimeoutWhileDebugging { get; set; }
+
+        /// <summary>
+        /// When true, an exception is thrown when a function timeout expires.
+        /// </summary>
+        public bool ThrowOnTimeout { get; set; }
+
+        /// <summary>
+        /// The amount of time to wait between canceling the timeout <see cref="CancellationToken"/> and throwing
+        /// a FunctionTimeoutException. This gives functions time to perform any graceful shutdown. 
+        /// Only applies if <see cref="ThrowOnTimeout"/> is true.
+        /// </summary>
+        public TimeSpan GracePeriod { get; set; }
+
+        internal TimeoutAttribute ToAttribute()
+        {
+            return new TimeoutAttribute(this.Timeout.ToString())
+            {
+                TimeoutWhileDebugging = this.TimeoutWhileDebugging,
+                ThrowOnTimeout = this.ThrowOnTimeout,
+                GracePeriod = this.GracePeriod,
+            };
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
@@ -158,6 +158,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 "JobHostInternalStorageConfiguration",
                 "JobHostQueuesConfiguration",
                 "JobHostBlobsConfiguration",
+                "JobHostFunctionTimeoutConfiguration",
                 "IJobActivator",
                 "ITypeLocator",
                 "INameResolver",


### PR DESCRIPTION
https://github.com/Azure/azure-webjobs-sdk/pull/1464 from Functions v1 (sdk v2) branch

Allow specifying a timeout at the JobHostConfiguration level rather than only via per-function Timeout attributes.

Fix https://github.com/Azure/azure-webjobs-sdk-script/issues/2105