### PR TITLE
delay sharedQueue initialization error

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Listeners/ListenerFactoryContext.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Listeners/ListenerFactoryContext.cs
@@ -66,14 +66,13 @@ namespace Microsoft.Azure.WebJobs.Host.Listeners
                     throw new InvalidOperationException("Please provide a call back function");
                 }
 
-                if (_sharedQueue.InitializationEx == null)
+                if (_sharedQueue.RegisterHandler(Descriptor.Id, handler))
                 {
-                    _sharedQueue.RegisterHandler(Descriptor.Id, handler);
                     _dispatchQueue = new DispatchQueueHandler(_sharedQueue, Descriptor.Id);
                 }
                 else
                 {
-                    // failed to initialize sharedQueue, fall back to in memory implementation
+                    // failed to register messageHandler, fall back to in memory implementation
                     _dispatchQueue = new InMemoryDispatchQueueHandler(handler);
                 }
             }


### PR DESCRIPTION
previous behavior:
if user does not provide a storage acc
=> logError for sharedQueue, continue execution with in memory implementation
current behavior:
if user does not provide a storage acc 
=> fall back to in memory implementation, but only **logWarning** when developer tried to **register** sharedQueue callback (actual consumer)

Technically I could initialize the sharedQueue when `registerHandler` is first called, so that initialization error would be logged when encountered, but since extensions are free to call `registerHandler`...I don't want to deal with synchronization where there are simultaneous registrations from different extensions (unless we enforce registration to be done in listener constructor, which are being invoked sequentially)