### PR TITLE
Support having abstract IExtensionConfigProvider

### DIFF
--- a/src/Analyzer/WebJobs.VSAnalyzer.Core/AssemblyCache.cs
+++ b/src/Analyzer/WebJobs.VSAnalyzer.Core/AssemblyCache.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Azure.WebJobs.Analyzer
             // Traverseing the exported types will cause type loads and possible type-load failures. 
             foreach (var type in assembly.ExportedTypes)
             {
-                if (!typeof(IExtensionConfigProvider).IsAssignableFrom(type))
+                if (!typeof(IExtensionConfigProvider).IsAssignableFrom(type) || type.IsAbstract)
                 {
                     continue;
                 }

--- a/src/Analyzer/WebJobs.VSAnalyzer.Core/AssemblyCache.cs
+++ b/src/Analyzer/WebJobs.VSAnalyzer.Core/AssemblyCache.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Azure.WebJobs.Analyzer
             // Traverseing the exported types will cause type loads and possible type-load failures. 
             foreach (var type in assembly.ExportedTypes)
             {
-                if (!typeof(IExtensionConfigProvider).IsAssignableFrom(type) || type.IsAbstract)
+                if (type.IsAbstract || !typeof(IExtensionConfigProvider).IsAssignableFrom(type))
                 {
                     continue;
                 }


### PR DESCRIPTION
Feature:
Currently, the webjobs pipeline throws when trying to instantiate an abstract class that implements IExtensionConfigProvider. I'd like to request support for enabling abstract implementations of IExtensionConfigProvider.

Use Case:
I have a IExtensionConfigProvider implementation that mimics DI on a function, and I would like to move this logic into a library package. However, the client need to be able to bind dependencies at runtime. See example:

On library side:
```
  public abstract class NinjectConfiguration : IExtensionConfigProvider
  {
    private readonly IKernel _kernel;

    public NinjectConfiguration()
    {
      _kernel = new StandardKernel();
    }

    public void Initialize(ExtensionConfigContext context)
    {
      RegisterServices(_kernel, context);

      context
        .AddBindingRule<InjectAttribute>()
        .BindToInput<object>(i =>
        {
          return _kernel.GetRequiredService(i.Type);
        });
    }

    public abstract void RegisterServices(IKernel kernel, ExtensionConfigContext context);
  }
```

On client side
```
public class NinjectRegistrar : NinjectConfiguration
  {
    public override void RegisterServices(IKernel kernel, ExtensionConfigContext context)
    {
      // Register services
    }
  }
```
