### PR TITLE
Add error details on Azure Storage batched operation failures (v2)

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Tables/TableEntityWriter.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Tables/TableEntityWriter.cs
@@ -172,7 +172,7 @@ namespace Microsoft.Azure.WebJobs.Host.Tables
                 {
                     if (!e.IsNotFoundTableNotFound())
                     {
-                        throw;
+                        throw new StorageException(e.GetDetailedErrorMessage(), e);
                     }
 
                     exception = e;
@@ -180,12 +180,25 @@ namespace Microsoft.Azure.WebJobs.Host.Tables
 
                 if (exception != null)
                 {
-                    // Make sure the table exists
-                    await _table.CreateIfNotExistsAsync(cancellationToken);
-
                     // Commit the batch
                     await _table.ExecuteBatchAsync(batch, cancellationToken);
                 }
+            }
+        }
+
+        private async Task CreateTableAndExecuteBatch(IStorageTableBatchOperation batch, CancellationToken cancellationToken)
+        {
+            // Make sure the table exists
+            await _table.CreateIfNotExistsAsync(cancellationToken);
+
+            // Commit the batch
+            try
+            {
+                await _table.ExecuteBatchAsync(batch, cancellationToken);
+            }
+            catch (StorageException e)
+            {
+                throw new StorageException(e.GetDetailedErrorMessage(), e);
             }
         }
 

--- a/src/Microsoft.Azure.WebJobs.Host/Tables/TableEntityWriter.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Tables/TableEntityWriter.cs
@@ -172,7 +172,7 @@ namespace Microsoft.Azure.WebJobs.Host.Tables
                 {
                     if (!e.IsNotFoundTableNotFound())
                     {
-                        throw new StorageException(e.GetDetailedErrorMessage(), e);
+                        throw new StorageException(e.GetDetailedErrorMessage());
                     }
 
                     exception = e;
@@ -197,7 +197,7 @@ namespace Microsoft.Azure.WebJobs.Host.Tables
             }
             catch (StorageException e)
             {
-                throw new StorageException(e.GetDetailedErrorMessage(), e);
+                throw new StorageException(e.GetDetailedErrorMessage());
             }
         }
 

--- a/src/Microsoft.Azure.WebJobs.Host/Tables/TableEntityWriter.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Tables/TableEntityWriter.cs
@@ -180,8 +180,7 @@ namespace Microsoft.Azure.WebJobs.Host.Tables
 
                 if (exception != null)
                 {
-                    // Commit the batch
-                    await _table.ExecuteBatchAsync(batch, cancellationToken);
+                    await CreateTableAndExecuteBatch(batch, cancellationToken);
                 }
             }
         }

--- a/src/Microsoft.Azure.WebJobs.Storage/StorageExceptionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Storage/StorageExceptionExtensions.cs
@@ -833,10 +833,9 @@ namespace Microsoft.Azure.WebJobs.Host.Storage
 
             if (exception.RequestInformation != null)
             {
-                message += String.Format(" (HTTP status code {0}: {1}. {2})",
-                    exception.RequestInformation.HttpStatusCode.ToString(),
-                    exception.RequestInformation.ExtendedErrorInformation?.ErrorCode,
-                    exception.RequestInformation.ExtendedErrorInformation?.ErrorMessage);
+                message += $" (HTTP status code {exception.RequestInformation.HttpStatusCode.ToString()}: "
+                    + $"{exception.RequestInformation.ExtendedErrorInformation?.ErrorCode}. "
+                    + $"{exception.RequestInformation.ExtendedErrorInformation?.ErrorMessage})";
             }
 
             return message;

--- a/src/Microsoft.Azure.WebJobs.Storage/StorageExceptionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Storage/StorageExceptionExtensions.cs
@@ -817,7 +817,8 @@ namespace Microsoft.Azure.WebJobs.Host.Storage
         }
 
         /// <summary>
-        /// Returns a custom detailed error message for Storage Exceptions
+        /// Returns a custom detailed error message for a StorageException. This is a workaround for bad error messages
+        /// returned by Azure Storage.
         /// </summary>
         /// <param name="exception">The storage exception.</param>
         /// <returns>The error message.</returns>
@@ -829,6 +830,7 @@ namespace Microsoft.Azure.WebJobs.Host.Storage
             }
 
             string message = exception.Message;
+
             if (exception.RequestInformation != null)
             {
                 message += String.Format(" (HTTP status code {0}: {1}. {2})",

--- a/src/Microsoft.Azure.WebJobs.Storage/StorageExceptionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Storage/StorageExceptionExtensions.cs
@@ -815,5 +815,29 @@ namespace Microsoft.Azure.WebJobs.Host.Storage
 
             return extendedInformation.ErrorCode;
         }
+
+        /// <summary>
+        /// Returns a custom detailed error message for Storage Exceptions
+        /// </summary>
+        /// <param name="exception">The storage exception.</param>
+        /// <returns>The error message.</returns>
+        public static string GetDetailedErrorMessage(this StorageException exception)
+        {
+            if (exception == null)
+            {
+                throw new ArgumentNullException("exception");
+            }
+
+            string message = exception.Message;
+            if (exception.RequestInformation != null)
+            {
+                message += String.Format(" (HTTP status code {0}: {1}. {2})",
+                    exception.RequestInformation.HttpStatusCode.ToString(),
+                    exception.RequestInformation.ExtendedErrorInformation?.ErrorCode,
+                    exception.RequestInformation.ExtendedErrorInformation?.ErrorMessage);
+            }
+
+            return message;
+        }
     }
 }


### PR DESCRIPTION
Adding extension method for getting and showing extra data on StorageException's from failed batch operations. This is a workaround to patch the unspecific error message 'Element {i} in the batch returned an unexpected response code'.

Resolves #1300

(v1 version of the PR: https://github.com/Azure/azure-webjobs-sdk/pull/1480)

Tested manually locally, tested v1 change in prod too
![image](https://user-images.githubusercontent.com/8888531/35306874-d8493f56-0054-11e8-9e5f-db6544aa0664.png)