### PR TITLE
Applying Obsolete to non-baked APIs

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/AttributeCloner.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/AttributeCloner.cs
@@ -6,12 +6,10 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Reflection;
-using System.Threading.Tasks;
-using Microsoft.Azure.WebJobs.Description;
 using Microsoft.Azure.WebJobs.Host.Bindings.Path;
 
 namespace Microsoft.Azure.WebJobs.Host.Bindings
-{    
+{
     using BindingData = IReadOnlyDictionary<string, object>;
     using BindingDataContract = IReadOnlyDictionary<string, System.Type>;
     // Func to transform Attribute,BindingData into value for cloned attribute property/constructor arg

--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/IResolutionPolicy.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/IResolutionPolicy.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
     /// The default policy is a direct substitution for the binding data.
     /// Derived policies can enforce formatting or escaping when they do injection.
     /// </summary>
+    [Obsolete("Not ready for public consumption.")]
     public interface IResolutionPolicy
     {
         /// <summary>

--- a/src/Microsoft.Azure.WebJobs.Host/Config/FluentBindingRule.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Config/FluentBindingRule.cs
@@ -6,8 +6,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Text;
-using System.Threading.Tasks;
-using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Protocols;
 using Microsoft.Azure.WebJobs.Host.Triggers;
@@ -19,6 +17,7 @@ namespace Microsoft.Azure.WebJobs.Host.Config
     /// Helpers for adding binding rules to a given attribute.
     /// </summary>
     /// <typeparam name="TAttribute"></typeparam>
+    [Obsolete("Not ready for public consumption.")]
     public class FluentBindingRule<TAttribute> : FluentConverterRules<TAttribute, FluentBindingRule<TAttribute>>
         where TAttribute : Attribute
     {

--- a/src/Microsoft.Azure.WebJobs.Host/Config/FluentConverterRules.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Config/FluentConverterRules.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Azure.WebJobs.Host.Config
     /// </summary>
     /// <typeparam name="TAttribute">The attribute type this applies to. Literally <see cref="Attribute"/> if it applies to all attributes.</typeparam>
     /// <typeparam name="TThis">For fluent API, the type to return</typeparam>
+    [Obsolete("Not ready for public consumption.")]
     public abstract class FluentConverterRules<TAttribute, TThis> where TAttribute : Attribute
     {
         // Access the converter manager that we're adding rules to. 

--- a/src/Microsoft.Azure.WebJobs.Host/Config/IWebhookProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Config/IWebhookProvider.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.WebJobs.Host.Config
     /// <summary>
     /// Allow a host to expose a HTTP web hook for extensions. 
     /// </summary>
-    [Obsolete("preview")]
+    [Obsolete("Not ready for public consumption.")]
     public interface IWebHookProvider
     {
         /// <summary>

--- a/src/Microsoft.Azure.WebJobs.Host/Diagnostics/ExceptionFormatter.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Diagnostics/ExceptionFormatter.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.Azure.WebJobs.Host.Diagnostics
 {

--- a/src/Microsoft.Azure.WebJobs.Host/Dispatch/DispatchQueueHandler.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Dispatch/DispatchQueueHandler.cs
@@ -7,14 +7,19 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Host.Dispatch
 {
-    /// It is a wrapper around <see cref="SharedQueueHandler"/>
+    /// <summary>
+    /// Wrapper around <see cref="SharedQueueHandler"/>
+    /// </summary>
+    /// <remarks>
+    /// The main purpose of this class is to encapsulate the function ID
+    /// so that when the user enqueues an invocation they only need to
+    /// worry about the message content.
+    /// </remarks>
     internal class DispatchQueueHandler : IDispatchQueueHandler
     {
         private readonly SharedQueueHandler _sharedQueue;
         private readonly string _functionId;
-        // the main purpose of this class is to encapsulate _functionId
-        // so that when user try to enqueue function triggering message
-        // they will only need to worry about the message content
+
         internal DispatchQueueHandler(SharedQueueHandler sharedQueue, string functionId)
         {
             _sharedQueue = sharedQueue;

--- a/src/Microsoft.Azure.WebJobs.Host/Dispatch/IDispatchQueueHandler.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Dispatch/IDispatchQueueHandler.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
@@ -12,6 +13,7 @@ namespace Microsoft.Azure.WebJobs.Host.Dispatch
     /// these messages will be distributed to multiple worker instance
     /// for later processing
     /// </summary>
+    [Obsolete("Not ready for public consumption.")]
     public interface IDispatchQueueHandler
     {
         /// <summary> Add a message to the shared queue.</summary>

--- a/src/Microsoft.Azure.WebJobs.Host/Dispatch/IMessageHandler.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Dispatch/IMessageHandler.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Executors;
@@ -10,9 +11,10 @@ using Newtonsoft.Json.Linq;
 namespace Microsoft.Azure.WebJobs.Host.Dispatch
 {
     /// <summary>
-    /// Defining the contract for executing a triggered function with shared queue message.
+    /// Defines the contract for executing a triggered function using a dispatch queue.
     /// <see cref="ListenerFactoryContext.GetDispatchQueue(IMessageHandler)"/>
     /// </summary>
+    [Obsolete("Not ready for public consumption.")]
     public interface IMessageHandler
     {
         /// <summary>

--- a/src/Microsoft.Azure.WebJobs.Host/Dispatch/InMemoryDispatchQueueHandler.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Dispatch/InMemoryDispatchQueueHandler.cs
@@ -7,10 +7,13 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Host.Dispatch
 {
-    // an implementation of DispatchQueueHandler without azure storage account
+    /// <summary>
+    /// An implementation of DispatchQueueHandler that doesn't rely on Azure Storage.
+    /// </summary>
     internal class InMemoryDispatchQueueHandler : IDispatchQueueHandler
     {
         private readonly IMessageHandler _messageHandler;
+
         internal InMemoryDispatchQueueHandler(IMessageHandler messageHandler)
         {
             _messageHandler = messageHandler;

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/TriggeredFunctionData.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/TriggeredFunctionData.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
         /// <summary>
         /// Optional handler function for processing the invocation.
         /// </summary>
+        [Obsolete("Not ready for public consumption.")]
         public Func<Func<Task>, Task> InvokeHandler { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Extensions/IJobHostMetadataProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Extensions/IJobHostMetadataProvider.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Azure.WebJobs.Host
     /// <summary>
     /// Interface for providing <see cref="JobHost"/> function binding metadata.
     /// </summary>
+    [Obsolete("Not ready for public consumption.")]
     public interface IJobHostMetadataProvider
     {
         /// <summary>

--- a/src/Microsoft.Azure.WebJobs.Host/HostQueueNames.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/HostQueueNames.cs
@@ -25,18 +25,22 @@ namespace Microsoft.Azure.WebJobs.Host
             return HostBlobTriggerQueuePrefix + hostId;
         }
 
-        /// <summary>Gets the shared host queue name.</summary>
+        /// <summary>
+        /// Gets the shared host queue name.
+        /// </summary>
         /// <param name="hostId">The host ID.</param>
         /// <returns>The shared host queue name.</returns>
-        public static string GetHostSharedQueueName(string hostId)
+        internal static string GetHostSharedQueueName(string hostId)
         {
             return HostSharedQueuePrefix + hostId;
         }
 
-        /// <summary>Gets the shared host poison queue name.</summary>
+        /// <summary>
+        /// Gets the shared host poison queue name.
+        /// </summary>
         /// <param name="hostId">The host ID.</param>
         /// <returns>The shared host poison queue name.</returns>
-        public static string GetHostSharedPoisonQueueName(string hostId)
+        internal static string GetHostSharedPoisonQueueName(string hostId)
         {
             return HostSharedPoisonPrefix + hostId;
         }

--- a/src/Microsoft.Azure.WebJobs.Host/JobHostConfiguration.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/JobHostConfiguration.cs
@@ -210,6 +210,7 @@ namespace Microsoft.Azure.WebJobs
         /// Get the converter manager, which can be used to register additional conversions for 
         /// customizing model binding. 
         /// </summary>
+        [Obsolete("Not ready for public consumption.")]
         public IConverterManager ConverterManager
         {
             get
@@ -221,6 +222,7 @@ namespace Microsoft.Azure.WebJobs
         /// <summary>
         /// Gets a helper object for constructing common binding rules for extensions.
         /// </summary>
+        [Obsolete("Not ready for public consumption.")]
         public BindingFactory BindingFactory
         {
             get

--- a/src/Microsoft.Azure.WebJobs.Host/Listeners/ListenerFactoryContext.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Listeners/ListenerFactoryContext.cs
@@ -18,7 +18,14 @@ namespace Microsoft.Azure.WebJobs.Host.Listeners
         private readonly SharedQueueHandler _sharedQueue;
         private IDispatchQueueHandler _dispatchQueue;
 
-        internal ListenerFactoryContext(FunctionDescriptor descriptor, ITriggeredFunctionExecutor executor, SharedQueueHandler sharedQueue, CancellationToken cancellationToken)
+        /// <summary>
+        /// Creates a new instance
+        /// </summary>
+        /// <param name="descriptor">The <see cref="FunctionDescriptor"/> to create a listener for.</param>
+        /// <param name="executor">The <see cref="ITriggeredFunctionExecutor"/> that should be used to invoke the
+        /// target job function when the trigger fires.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
+        public ListenerFactoryContext(FunctionDescriptor descriptor, ITriggeredFunctionExecutor executor, CancellationToken cancellationToken)
         {
             if (descriptor == null)
             {
@@ -27,8 +34,21 @@ namespace Microsoft.Azure.WebJobs.Host.Listeners
 
             Descriptor = descriptor;
             Executor = executor;
-            _sharedQueue = sharedQueue;
             CancellationToken = cancellationToken;
+        }
+
+        /// <summary>
+        /// Creates a new instance
+        /// </summary>
+        /// <param name="descriptor">The <see cref="FunctionDescriptor"/> to create a listener for.</param>
+        /// <param name="executor">The <see cref="ITriggeredFunctionExecutor"/> that should be used to invoke the
+        /// target job function when the trigger fires.</param>
+        /// <param name="sharedQueue">The shared queue.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
+        internal ListenerFactoryContext(FunctionDescriptor descriptor, ITriggeredFunctionExecutor executor, SharedQueueHandler sharedQueue, CancellationToken cancellationToken)
+            : this(descriptor, executor, cancellationToken)
+        {
+            _sharedQueue = sharedQueue;
         }
 
         /// <summary>
@@ -57,6 +77,7 @@ namespace Microsoft.Azure.WebJobs.Host.Listeners
         /// If you have registered once, you can retrieve the same queue by passing a null to this function
         /// </param>
         /// <returns> The <see cref="IDispatchQueueHandler"/> is used to enqueue messages </returns>
+        [Obsolete("Not ready for public consumption.")]
         public IDispatchQueueHandler GetDispatchQueue(IMessageHandler handler)
         {
             if (_dispatchQueue == null)
@@ -80,6 +101,7 @@ namespace Microsoft.Azure.WebJobs.Host.Listeners
             {
                 throw new InvalidOperationException("Cannot register more than one handler with a single function");
             }
+
             return _dispatchQueue;
         }
     }

--- a/src/Microsoft.Azure.WebJobs.Host/Singleton/IDistributedLock.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Singleton/IDistributedLock.cs
@@ -2,14 +2,13 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Microsoft.Azure.WebJobs.Host
 {
     /// <summary>
     /// Handle for a lock returned by <see cref="IDistributedLockManager"/>
     /// </summary>
+    [Obsolete("Not ready for public consumption.")]
     public interface IDistributedLock
     {
         /// <summary>

--- a/src/Microsoft.Azure.WebJobs.Host/Singleton/IDistributedLockManager.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Singleton/IDistributedLockManager.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Azure.WebJobs.Host
     /// 1. Account can be null or it may be a storage account name intended for <see cref="IStorageAccountProvider"/>. 
     /// 2. lockId has the same naming restrictions as blobs.     
     /// </remarks>    
+    [Obsolete("Not ready for public consumption.")]
     public interface IDistributedLockManager
     {        
         /// <summary>


### PR DESCRIPTION
Applying Obsolete to some more new APIs that we've added since 2.0, that we likely want more bake-time for. This is in preparation for the forthcoming 2.1 release.