### PR TITLE
EventHubTrigger not resolved in .net standard

### DIFF
--- a/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubTriggerAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubTriggerAttribute.cs
@@ -16,10 +16,10 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         /// <summary>
         /// Create an instance of this attribute.
         /// </summary>
-        /// <param name="eventHubName">Event hub to listen on for messages. </param>
-        public EventHubTriggerAttribute(string eventHubName)
+        /// <param name="path">Event hub to listen on for messages. </param>
+        public EventHubTriggerAttribute(string path)
         {
-            this.EventHubName = eventHubName;
+            this.EventHubName = path;
         }
 
         /// <summary>


### PR DESCRIPTION
Related to:
https://github.com/Azure/Azure-Functions/issues/652
https://github.com/Azure/Azure-Functions/issues/620

The problem resides between the difference of what is generated inside the "function.json" and what is expected in the EventHubTriggerAttribute constructor.

"path" vs "eventhubname".

If this is the best place to do the change, I don't know