### PR TITLE
Adds ability to pass Id along on TriggeredFunctionData

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Executors/TriggeredFunctionData.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/TriggeredFunctionData.cs
@@ -12,6 +12,10 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
     public class TriggeredFunctionData
     {
         /// <summary>
+        /// The ID for the triggered function invocation
+        /// </summary>
+        public Guid? Id { get; set; }
+        /// <summary>
         /// The parent ID for the triggered function invocation.
         /// </summary>
         public Guid? ParentId { get; set; }

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/TriggeredFunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/TriggeredFunctionExecutor.cs
@@ -35,7 +35,8 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             var context = new FunctionInstanceFactoryContext<TTriggerValue>()
             {
                 TriggerValue = (TTriggerValue)input.TriggerValue,
-                ParentId = input.ParentId
+                ParentId = input.ParentId,
+                Id = input.Id.GetValueOrDefault(Guid.NewGuid())
             };
 
             if (input.InvokeHandler != null)

--- a/src/Microsoft.Azure.WebJobs.Host/Triggers/TriggeredFunctionInstanceFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Triggers/TriggeredFunctionInstanceFactory.cs
@@ -30,10 +30,15 @@ namespace Microsoft.Azure.WebJobs.Host.Triggers
                 throw new ArgumentNullException(nameof(context));
             }
 
+            if (context.Id == null)
+            {
+                throw new ArgumentNullException($"{nameof(context)}.id");
+            }
+
             IBindingSource bindingSource = new TriggerBindingSource<TTriggerValue>(_binding, context.TriggerValue);
             var invoker = CreateInvoker(context);
 
-            return new FunctionInstance(Guid.NewGuid(), context.ParentId, ExecutionReason.AutomaticTrigger, bindingSource, invoker, _descriptor);
+            return new FunctionInstance(context.Id, context.ParentId, ExecutionReason.AutomaticTrigger, bindingSource, invoker, _descriptor);
         }
 
         public IFunctionInstance Create(FunctionInstanceFactoryContext context)


### PR DESCRIPTION
fixes https://github.com/Azure/azure-webjobs-sdk/issues/1324

@cgillum / @brettsam, you both had some use cases in mind for this. I didn't end up consuming this surface area, but totally possible to pass an id along now when you call TryExecuteAsync via the TriggeredFunctionData object. LMK if this works for your scenarios.