### PR TITLE
Allow NewBatchThreshold to be set to 0 (#1568)

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/JobHostQueuesConfiguration.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/JobHostQueuesConfiguration.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.WebJobs.Host
 
             set
             {
-                if (value <= 0)
+                if (value < 0)
                 {
                     throw new ArgumentOutOfRangeException("value");
                 }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostQueuesConfigurationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostQueuesConfigurationTests.cs
@@ -32,6 +32,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             // on the current BatchSize
             config.BatchSize = 20;
             Assert.Equal(10, config.NewBatchThreshold);
+            config.BatchSize = 1;
+            Assert.Equal(0, config.NewBatchThreshold);
             config.BatchSize = 32;
             Assert.Equal(16, config.NewBatchThreshold);
 
@@ -40,6 +42,9 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             Assert.Equal(1000, config.NewBatchThreshold);
             config.BatchSize = 8;
             Assert.Equal(1000, config.NewBatchThreshold);
+
+            config.NewBatchThreshold = 0;
+            Assert.Equal(0, config.NewBatchThreshold);
         }
 
         [Fact]


### PR DESCRIPTION
Fix for https://github.com/Azure/azure-webjobs-sdk/issues/1568

This has come up many times as a usability issue when trying to explain to people how to enforce singleton processing. I always say set BatchSize=1 and NewBatchThreshold=0 but that isn't allowed currently.