### PR TITLE
add covariance and contravariance

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/FuncConverter.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/FuncConverter.cs
@@ -16,6 +16,6 @@ namespace Microsoft.Azure.WebJobs
     /// <param name="attribute">attribute</param>
     /// <param name="context">binding context that may have additional parameters to influence conversion. </param>
     [Obsolete("Not ready for public consumption.")]
-    public delegate TDestination FuncConverter<TSource, TAttribute, TDestination>(TSource src, TAttribute attribute, ValueBindingContext context)
+    public delegate TDestination FuncConverter<in TSource, in TAttribute, out TDestination>(TSource src, TAttribute attribute, ValueBindingContext context)
             where TAttribute : Attribute;
 }


### PR DESCRIPTION
it is essentially a `Func<TSource, TAttribute, ValueBindingContext, TDestination>` but unlike `Func` covariance and contravariance is not handled by c# compiler

I am having an issue where `GetConverter()` will return a `FuncConverter<JObject, EventGridTriggerAttribute, POCO>` which will converter a `JObject` to a `POCO` and it can be any user defined class (at runtime)...It is difficult to write function that consumes such `FuncConverter` delegate with invariant generic types: https://github.com/Azure/azure-functions-eventgrid-extension/pull/26

TODO add tests