### PR TITLE
changing AzureStorageDeploymentValidator to work with Storage SDK 9.0

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/AzureStorageDeploymentValidator.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/AzureStorageDeploymentValidator.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using Microsoft.WindowsAzure.Storage.Table;
 using Microsoft.WindowsAzure.Storage.Table.DataServices;
 
@@ -22,7 +23,11 @@ namespace Microsoft.Azure.WebJobs.Host
         {
             try
             {
-                VerifyTableServiceAssemblyLoad();
+                // Later versions of the Storage SDK removed the dependencies on these assemblies, so this check is skipped in those cases.
+                if (typeof(CloudTableClient).Assembly.GetReferencedAssemblies().Any(a => a.Name == "Microsoft.Data.Services.Client"))
+                {
+                    VerifyTableServiceAssemblyLoad();
+                }
             }
             catch (Exception ex)
             {

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncChainEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncChainEndToEndTests.cs
@@ -136,8 +136,8 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     "User TextWriter log (TestParam)"
                 }.OrderBy(p => p).ToArray();
 
-                bool hasError = consoleOutputLines.Any(p => p.Contains("Function had errors"));
-                Assert.False(hasError);
+                var errors = consoleOutputLines.Where(p => p.Contains("Function had errors"));
+                Assert.False(errors.Any(), string.Join(Environment.NewLine, errors));
 
                 // Validate console output
                 for (int i = 0; i < expectedOutputLines.Length; i++)


### PR DESCRIPTION
Fixes #1574.

Storage SDK version 9.0.0 removed `TableServiceContext`, which means this check fails at runtime. I changed the check to be reflection- and version-based to make sure that we continue to enforce the check on versions where it is required (those under 8,0.0). 

I ran all the tests on both version 7.2.1 and 9.0.0 and they all passed. I manually verified that removing one of the assemblies (Microsoft.Data.Services.Client, Microsoft.Data.OData, Microsoft.Data.Edm) continued to fail this check in 7.2.1.