### PR TITLE
Update ServiceBusTrigger Error Message V2 (always appends "AzureWebJobs" to connection string name)

### DIFF
--- a/src/Microsoft.Azure.WebJobs.ServiceBus/ServiceBusAccount.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/ServiceBusAccount.cs
@@ -42,9 +42,10 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
 
                     if (string.IsNullOrEmpty(_connectionString))
                     {
+                        var defaultConnectionName = "AzureWebJobs" + ConnectionStringNames.ServiceBus;
                         throw new InvalidOperationException(
-                            string.Format(CultureInfo.InvariantCulture, "Microsoft Azure WebJobs SDK ServiceBus connection string '{0}{1}' is missing or empty.",
-                            "AzureWebJobs", Sanitizer.Sanitize(_connectionProvider.Connection) ?? ConnectionStringNames.ServiceBus));
+                            string.Format(CultureInfo.InvariantCulture, "Microsoft Azure WebJobs SDK ServiceBus connection string '{0}' is missing or empty.",
+                            Sanitizer.Sanitize(_connectionProvider.Connection) ?? defaultConnectionName));
                     }
                 }
 

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/ServiceBusAccountTests.cs
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/ServiceBusAccountTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests
                 var account = new ServiceBusAccount(config, attribute);
                 var cs = account.ConnectionString;
             });
-            Assert.Equal("Microsoft Azure WebJobs SDK ServiceBus connection string 'AzureWebJobsMissingConnection' is missing or empty.", ex.Message);
+            Assert.Equal("Microsoft Azure WebJobs SDK ServiceBus connection string 'MissingConnection' is missing or empty.", ex.Message);
 
             attribute.Connection = null;
             config.ConnectionString = null;


### PR DESCRIPTION
Changes to "missing connection string" error message to distinguish between missing custom-defined connection string vs. missing unnamed (default) connection string.

Resolves #1524 