### PR TITLE
Update ServiceBusTrigger Error Message V1 (always appends "AzureWebJobs" to connection string name)

### DIFF
--- a/src/Microsoft.Azure.WebJobs.ServiceBus/MessagingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/MessagingProvider.cs
@@ -133,9 +133,10 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
 
             if (string.IsNullOrEmpty(connectionString))
             {
+                var defaultConnectionName = "AzureWebJobs" + ConnectionStringNames.ServiceBus;
                 throw new InvalidOperationException(
-                    string.Format(CultureInfo.InvariantCulture, "Microsoft Azure WebJobs SDK ServiceBus connection string '{0}{1}' is missing or empty.",
-                    "AzureWebJobs", connectionStringName ?? ConnectionStringNames.ServiceBus));
+                    string.Format(CultureInfo.InvariantCulture, "Microsoft Azure WebJobs SDK ServiceBus connection string '{0}' is missing or empty.",
+                    connectionStringName ?? defaultConnectionName));
             }
 
             return connectionString;

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/MessagingProviderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/MessagingProviderTests.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests
             {
                 _provider.GetConnectionString("MissingConnection");
             });
-            Assert.Equal("Microsoft Azure WebJobs SDK ServiceBus connection string 'AzureWebJobsMissingConnection' is missing or empty.", ex.Message);
+            Assert.Equal("Microsoft Azure WebJobs SDK ServiceBus connection string 'MissingConnection' is missing or empty.", ex.Message);
 
             _config.ConnectionString = null;
             ex = Assert.Throws<InvalidOperationException>(() =>


### PR DESCRIPTION
Changes to "missing connection string" error message to distinguish between missing custom-defined connection string vs. missing unnamed (default) connection string.

Resolves #1524