### PR TITLE
Queue Binding Bug

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Queues/Bindings/QueueBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Queues/Bindings/QueueBindingProvider.cs
@@ -78,9 +78,6 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Bindings
                 binding.SetPostResolveHook(ToReadWriteParameterDescriptorForCollector)
                         .BindToInput<CloudQueue>(builder);
 
-                binding.SetPostResolveHook(ToReadWriteParameterDescriptorForCollector)
-                        .BindToInput<CloudQueue>(builder);
-
                 IConverterManager converterManager = context.Config.ConverterManager;
                 converterManager.AddConverter<object, JObject, QueueAttribute>(SerializeToJobject);
             }


### PR DESCRIPTION
SetPostResolveHook and BindToOutput builder logic duplicated. A clear bug that may be the cause of #1467, but still needs to be investigated. 