### PR TITLE
build improvements

### DIFF
--- a/WebJobs.proj
+++ b/WebJobs.proj
@@ -124,8 +124,36 @@
       </Binplace>
     </ItemGroup>
   </Target>
+    
+  <Target Name="UpdateAssemblyInfo">   
+    <PropertyGroup>
+      <CommonAssemblyInfoFile>$(MSBuildProjectDirectory)\src\Common\CommonAssemblyInfo.cs</CommonAssemblyInfoFile>
+      <BuildMessage Condition="'$(BuildNumber)' != ''">build $(BuildNumber), </BuildMessage>
+      <CommitMessage Condition="'$(CommitHash)' != ''">$(BuildMessage)commit $(CommitHash)</CommitMessage>
+    </PropertyGroup>
+    
+    <Message 
+      Condition="'$(BuildNumber)' != ''"
+      Importance="High"
+      Text="Updating the AssemblyFileVersion to include the build number: $(BuildNumber)" />     
+    <ReplaceFileText 
+      Condition="'$(BuildNumber)' != ''"
+      FileName="$(CommonAssemblyInfoFile)"
+      MatchExpression="(?&lt;=\[assembly: AssemblyFileVersion\(&quot;\d+.\d+.)\d+(?=.\d+&quot;\)\])"      
+      ReplacementText="$(BuildNumber)" />
 
-  <Target Name="Build" DependsOnTargets="RestorePackages;GetBinplace">
+    <Message 
+      Condition="'$(CommitHash)' != ''"
+      Importance="High"
+      Text="Updating the AssemblyInformationalVersion to include: '$(CommitMessage)'" />
+    <ReplaceFileText 
+      Condition="'$(CommitHash)' != ''"
+      FileName="$(CommonAssemblyInfoFile)"
+      MatchExpression="(?&lt;=\[assembly: AssemblyInformationalVersion\(&quot;).*(?=&quot;\)\])" 
+      ReplacementText="$(CommitMessage)" />
+  </Target>
+
+  <Target Name="Build" DependsOnTargets="RestorePackages;GetBinplace;UpdateAssemblyInfo">
     <MSBuild Projects="@(Binplace)"
              BuildInParallel="$(BuildInParallel)"/>
   </Target>
@@ -294,4 +322,23 @@
       </Code>
     </Task>
   </UsingTask>
+  
+  <UsingTask TaskName="ReplaceFileText" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
+  <ParameterGroup>
+    <FileName ParameterType="System.String" Required="true" />    
+    <MatchExpression ParameterType="System.String" Required="true" />
+    <ReplacementText ParameterType="System.String" Required="true" />
+  </ParameterGroup>
+  <Task>
+    <Reference Include="System.Core" />
+    <Using Namespace="System" />
+    <Using Namespace="System.IO" />
+    <Using Namespace="System.Text.RegularExpressions" />
+    <Code Type="Fragment" Language="cs">
+      <![CDATA[
+            File.WriteAllText(FileName, Regex.Replace(File.ReadAllText(FileName), MatchExpression, ReplacementText));
+          ]]>
+    </Code>
+  </Task>
+</UsingTask>
 </Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,13 +13,13 @@ branches:
   - master
   - v2.x
 image: Visual Studio 2017
+max_jobs: 1
 configuration: Release
 platform: x86
 clone_folder: c:\projects\azure-webjobs-sdk
-environment:
-  IncludeBuildNumberInVersion: 1
 build_script:
-- cmd: msbuild "WebJobs.proj" /t:GetBitsToSign;BuildTestBinaries /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /property:Configuration=Release;Platform=AnyCPU
+- cmd: IF "%APPVEYOR_REPO_TAG_NAME%"=="" SET PackageSuffixCmd=/p:PackageSuffix=-%APPVEYOR_BUILD_NUMBER%
+- cmd: msbuild "WebJobs.proj" /verbosity:minimal /t:GetBitsToSign;BuildTestBinaries /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /p:Configuration=Release;Platform=AnyCPU /p:BuildNumber=%APPVEYOR_BUILD_NUMBER% /p:CommitHash=%APPVEYOR_REPO_COMMIT% %PackageSuffixCmd%    
 test_script:
 - cmd: "vstest.console /logger:Appveyor /TestAdapterPath:bin test/Microsoft.Azure.WebJobs.Host.UnitTests/bin/Release/Microsoft.Azure.WebJobs.Host.UnitTests.dll test/Microsoft.Azure.WebJobs.Host.FunctionalTests/bin/Release/Microsoft.Azure.WebJobs.Host.FunctionalTests.dll test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/bin/Release/Microsoft.Azure.WebJobs.ServiceBus.UnitTests.dll test/Dashboard.UnitTests/bin/Release/Dashboard.UnitTests.dll \n\nvstest.console /logger:Appveyor /TestAdapterPath:bin test/Microsoft.Azure.WebJobs.Host.EndToEndTests/bin/Release/Microsoft.Azure.WebJobs.Host.EndToEndTests.dll"
 on_finish:

--- a/src/Common/CommonAssemblyInfo.cs
+++ b/src/Common/CommonAssemblyInfo.cs
@@ -1,13 +1,21 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyProduct("Microsoft Azure WebJobs SDK")]
 [assembly: AssemblyCompany("Microsoft Corporation")]
 [assembly: AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+
+[assembly: AssemblyVersion("2.2.0.0")]
+
+// The official build will replace the third place with the build number.
+// For example, 1.0.0.0 becomes 1.0.1234.0
+[assembly: AssemblyFileVersion("2.2.0.0")]
+
+// The official build will insert the commit hash here.
+[assembly: AssemblyInformationalVersion("")]
 
 [assembly: ComVisible(false)]
 

--- a/src/Dashboard/Properties/AssemblyInfo.cs
+++ b/src/Dashboard/Properties/AssemblyInfo.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System.Reflection;
 using System.Runtime.CompilerServices;
-
-[assembly: AssemblyVersion("2.1.0.0")]
-[assembly: AssemblyFileVersion("2.1.0.0")]
 
 [assembly: InternalsVisibleTo("Dashboard.UnitTests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]

--- a/src/Microsoft.Azure.WebJobs.Host/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Properties/AssemblyInfo.cs
@@ -1,12 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System.Reflection;
-using System.Resources;
 using System.Runtime.CompilerServices;
-
-[assembly: AssemblyVersion("2.1.0.0")]
-[assembly: AssemblyFileVersion("2.1.0.0")]
 
 [assembly: InternalsVisibleTo("Dashboard.UnitTests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Properties/AssemblyInfo.cs
@@ -1,30 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("d3ff0fde-ebdf-4751-8131-3375cf2a5c21")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.1.0.0")]
-[assembly: AssemblyFileVersion("2.1.0.0")]
 
 [assembly: InternalsVisibleTo("Microsoft.Azure.WebJobs.Host.UnitTests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
@@ -135,6 +135,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\Common\CommonAssemblyInfo.cs">
+      <Link>Properties\CommonAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="ApplicationInsightsLogger.cs" />
     <Compile Include="ApplicationInsightsLoggerExtensions.cs" />
     <Compile Include="ApplicationInsightsLoggerProvider.cs" />

--- a/src/Microsoft.Azure.WebJobs.Logging/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging/Properties/AssemblyInfo.cs
@@ -1,28 +1,3 @@
-﻿using System;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("b5a04006-ab0c-4800-ae4c-080d31867de3")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-
-[assembly: AssemblyVersion("2.1.0.0")]
-[assembly: AssemblyFileVersion("2.1.0.0")]
+﻿using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Microsoft.Azure.WebJobs.Logging.FunctionalTests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]

--- a/src/Microsoft.Azure.WebJobs.Logging/WebJobs.Logging.csproj
+++ b/src/Microsoft.Azure.WebJobs.Logging/WebJobs.Logging.csproj
@@ -92,6 +92,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\Common\CommonAssemblyInfo.cs">
+      <Link>Properties\CommonAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="ActivationEvent.cs" />
     <Compile Include="FunctionId.cs" />
     <Compile Include="FunctionVolumeTimelineEntry.cs" />

--- a/src/Microsoft.Azure.WebJobs.Protocols/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Azure.WebJobs.Protocols/Properties/AssemblyInfo.cs
@@ -1,7 +1,0 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
-
-using System.Reflection;
-
-[assembly: AssemblyVersion("2.1.0.0")]
-[assembly: AssemblyFileVersion("2.1.0.0")]

--- a/src/Microsoft.Azure.WebJobs.Protocols/WebJobs.Protocols.csproj
+++ b/src/Microsoft.Azure.WebJobs.Protocols/WebJobs.Protocols.csproj
@@ -59,7 +59,6 @@
     <Compile Include="FunctionStatusMessage.cs" />
     <Compile Include="JTokenExtensions.cs" />
     <Compile Include="ParameterDisplayHints.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SingletonParameterLog.cs" />
     <Compile Include="TriggerParameterDescriptor.cs" />
     <Compile Include="WriteBlobParameterLog.cs" />

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Properties/AssemblyInfo.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System.Reflection;
 using System.Runtime.CompilerServices;
-
-[assembly: AssemblyVersion("2.1.0.0")]
-[assembly: AssemblyFileVersion("2.1.0.0")]
 
 [assembly: InternalsVisibleTo("Microsoft.Azure.WebJobs.ServiceBus.UnitTests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]

--- a/src/Microsoft.Azure.WebJobs.Storage/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Azure.WebJobs.Storage/Properties/AssemblyInfo.cs
@@ -1,7 +1,0 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
-
-using System.Reflection;
-
-[assembly: AssemblyVersion("2.1.0.0")]
-[assembly: AssemblyFileVersion("2.1.0.0")]

--- a/src/Microsoft.Azure.WebJobs.Storage/WebJobs.Storage.csproj
+++ b/src/Microsoft.Azure.WebJobs.Storage/WebJobs.Storage.csproj
@@ -70,7 +70,6 @@
     <Compile Include="Blob\IStorageBlobClient.cs" />
     <Compile Include="Blob\IStorageBlobContainer.cs" />
     <Compile Include="Blob\IStorageBlockBlob.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Queue\IStorageQueueMessage.cs" />
     <Compile Include="Queue\IStorageQueue.cs" />
     <Compile Include="Queue\IStorageQueueClient.cs" />

--- a/src/Microsoft.Azure.WebJobs/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Azure.WebJobs/Properties/AssemblyInfo.cs
@@ -1,7 +1,0 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
-
-using System.Reflection;
-
-[assembly: AssemblyVersion("2.1.0.0")]
-[assembly: AssemblyFileVersion("2.1.0.0")]

--- a/src/Microsoft.Azure.WebJobs/WebJobs.csproj
+++ b/src/Microsoft.Azure.WebJobs/WebJobs.csproj
@@ -84,7 +84,6 @@
     <Compile Include="IConnectionProvider.cs" />
     <Compile Include="TableAttribute.cs" />
     <Compile Include="NoAutomaticTriggerAttribute.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TimeoutAttribute.cs" />
     <Compile Include="TraceLevelAttribute.cs" />
   </ItemGroup>

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncChainEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncChainEndToEndTests.cs
@@ -365,7 +365,10 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 }
                 else
                 {
-                    Assert.Equal(0, traceEvent.Properties.Count);
+                    int count = traceEvent.Properties.Count;
+                    string errorMessage = $"Expected 0 properties. Actual: {count}. Message: '{traceEvent.Message}'. Properties: {Environment.NewLine}";
+                    errorMessage += string.Join(Environment.NewLine, traceEvent.Properties.Select(p => $"{p.Key}: {p.Value}"));
+                    Assert.True(count == 0, errorMessage);
                 }
             }
         }

--- a/tools/NuGetProj.settings.targets
+++ b/tools/NuGetProj.settings.targets
@@ -6,17 +6,8 @@
     <WebJobsPackageEULA>http://www.microsoft.com/web/webpi/eula/aspnetcomponent_rtw_enu.htm</WebJobsPackageEULA>
     <Version>2.2.0</Version>
     <PrereleaseTag>-beta1</PrereleaseTag>
+    
+    <!-- $(PackageSuffix), typically something like '-12345', is passed in as a build property. -->
+    <WebJobsPackageVersion>$(Version)$(PrereleaseTag)$(PackageSuffix)</WebJobsPackageVersion>
   </PropertyGroup>
-  <Choose>
-    <When Condition=" '$(IncludeBuildNumberInVersion)' == '1'">
-      <PropertyGroup>
-        <WebJobsPackageVersion>$(Version)$(PrereleaseTag)-$(BUILD_NUMBER)</WebJobsPackageVersion>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup>
-        <WebJobsPackageVersion>$(Version)$(PrereleaseTag)</WebJobsPackageVersion>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
 </Project>


### PR DESCRIPTION
Improving some build processes:
- all projects now use `CommonAssemblyInfo.cs`
- inject the build number into `AssemblyFileVersion`
- inject the build number and commit SHA into `AssemblyInformationalVersion`
- remove need for `IncludeBuildNumberInVersion` environment variable. Now we'll append the build number *unless* the commit we're building has a tag. Then we assume it's official and leave it off.