### PR TITLE
Fix exception that is thrown when duplicate keys are used

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
@@ -252,7 +252,23 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                     stringValue = property.Value.ToString();
                 }
 
-                telemetry.Properties.Add($"{propertyPrefix}{property.Key}", stringValue);
+                //use 
+                var duplicateKeyQuantifier = 0;
+                while(true) 
+                {
+                    //if there are duplicates then append the quantifier to the prop key
+                    var quantifier_str = duplicateKeyQuantifier == 0 ? String.Empty : duplicateKeyQuantifier.ToString();
+                    var key = $"{propertyPrefix}{quantifier_str}{property.Key}";
+                    
+                    if(telemetry.Properties.ContainsKey(key))
+                    {
+                        telemetry.Properties[key] = stringValue;
+                        break;
+                    }
+
+                    duplicateKeyQuantifier++;
+                }
+                
             }
         }
 

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
@@ -252,7 +252,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                     stringValue = property.Value.ToString();
                 }
 
-                //use 
+                //only used when duplicate keys are detected
                 var duplicateKeyQuantifier = 0;
                 while(true) 
                 {

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
@@ -259,8 +259,8 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                     //if there are duplicates then append the quantifier to the prop key
                     var quantifier_str = duplicateKeyQuantifier == 0 ? String.Empty : duplicateKeyQuantifier.ToString();
                     var key = $"{propertyPrefix}{quantifier_str}{property.Key}";
-                    
-                    if(telemetry.Properties.ContainsKey(key))
+
+                    if(!telemetry.Properties.ContainsKey(key))
                     {
                         telemetry.Properties[key] = stringValue;
                         break;


### PR DESCRIPTION
This code will add an incrementer to the key for the telemetry property dictionary whenever duplicates are detected. This can be the case especially when using a scoped logging pattern.

This may not be the best way to solve this problem, I am open to other solutions.