### PR TITLE
ServiceBus MessageProcessor fix (#1605)

### DIFF
--- a/src/Microsoft.Azure.WebJobs.ServiceBus/MessageProcessor.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/MessageProcessor.cs
@@ -70,8 +70,11 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
             }
             else
             {
+                // if the invocation failed, we must propagate the
+                // exception back to SB so it can handle message state
+                // correctly
                 cancellationToken.ThrowIfCancellationRequested();
-                await message.AbandonAsync();
+                throw result.Exception;
             }
         }
     }

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/MessageProcessorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/MessageProcessorTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests
         }
 
         [Fact]
-        public async Task CompleteProcessingMessageAsync_Failure_AbandonsMessage()
+        public async Task CompleteProcessingMessageAsync_Failure_PropagatesException()
         {
             OnMessageOptions options = new OnMessageOptions
             {
@@ -44,14 +44,14 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests
             MessageProcessor processor = new MessageProcessor(options);
 
             BrokeredMessage message = new BrokeredMessage();
-            FunctionResult result = new FunctionResult(false);
+            var functionException = new InvalidOperationException("Kaboom!");
+            FunctionResult result = new FunctionResult(functionException);
             var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             {
                 await processor.CompleteProcessingMessageAsync(message, result, CancellationToken.None);
             });
 
-            // this verifies that we initiated the abandon
-            Assert.True(ex.ToString().Contains("Microsoft.ServiceBus.Messaging.BrokeredMessage.BeginAbandon"));
+            Assert.Same(functionException, ex);
         }
 
         [Fact]


### PR DESCRIPTION
Fix for https://github.com/Azure/azure-webjobs-sdk/issues/1605

As you can see from the ServiceBus [message pump source code](https://github.com/Azure/azure-service-bus-dotnet/blob/90ce19dd89cad09065103ed7bb7994e73c6cc8bb/src/Microsoft.Azure.ServiceBus/MessageReceivePump.cs#L143) the contract when using the MessageReceiver.OnMessageAsync callback pattern is that SB handles the message state for you based on whether your callback throws an exception or not.

Here's what was happening:

- user function throws an exception
- our MessageProcessor calls `BrokeredMessage.AbandonAsync()` but **does not propagate exception**
- SB interprets lack of exception as success and internally calls `BrokeredMessage.CompleteAsync()`, completing an already abandoned message
- from my testing this causes all sorts of issues and message reprocessing 

Before/After

- with the fix in this PR, the repro app can run for 5 minutes with NO reprocessed messages
- without the changes, in 5 minutes my repro app resulted in TONS of reprocessed messages (like 170 or so)