### PR TITLE
Event Hubs cancellation token fix for batched mode

### DIFF
--- a/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubListener.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubListener.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
                         TriggerValue = value
                     };
 
-                    FunctionResult result = await this._parent._executor.TryExecuteAsync(input, CancellationToken.None);
+                    FunctionResult result = await this._parent._executor.TryExecuteAsync(input, _cts.Token);
                 }
 
                 bool hasEvents = false;


### PR DESCRIPTION
Resolves #1626 

The same cancellation token should be passed through to user code in both the single dispatch and multi dispatch case.

I briefly looked at creating a unit test for this but its pretty painful due to the coupling with the Event Hubs types that aren't really mockable.

I'll send a matching PR for V2.