### PR TITLE
Host Startup Partial Mode (#2497)

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostConfigurationExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostConfigurationExtensions.cs
@@ -277,14 +277,15 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
                         trace,
                         loggerFactory,
                         hostSharedQueue,
-                        defaultTimeout);
+                        defaultTimeout,
+                        config.AllowPartialHostStartup);
 
                     // Important to set this so that the func we passed to DynamicHostIdProvider can pick it up. 
                     services.AddService<IFunctionIndexProvider>(functionIndexProvider);
                 }
 
                 IFunctionIndex functions = await functionIndexProvider.GetAsync(combinedCancellationToken);
-                IListenerFactory functionsListenerFactory = new HostListenerFactory(functions.ReadAll(), singletonManager, activator, nameResolver, trace, loggerFactory);
+                IListenerFactory functionsListenerFactory = new HostListenerFactory(functions.ReadAll(), singletonManager, activator, nameResolver, trace, loggerFactory, config.AllowPartialHostStartup);
 
                 IFunctionExecutor hostCallExecutor;
                 IListener listener;

--- a/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexProvider.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
         private readonly ILoggerFactory _loggerFactory;
         private readonly SharedQueueHandler _sharedQueue;
         private readonly TimeoutAttribute _defaultTimeout;
+        private readonly bool _allowPartialHostStartup;
 
         private IFunctionIndex _index;
 
@@ -39,7 +40,8 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
             TraceWriter trace,
             ILoggerFactory loggerFactory,
             SharedQueueHandler sharedQueue,
-            TimeoutAttribute defaultTimeout)
+            TimeoutAttribute defaultTimeout,
+            bool allowPartialHostStartup = false)
         {
             if (typeLocator == null)
             {
@@ -97,6 +99,7 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
             _loggerFactory = loggerFactory;
             _sharedQueue = sharedQueue;
             _defaultTimeout = defaultTimeout;
+            _allowPartialHostStartup = allowPartialHostStartup;
         }
 
         public async Task<IFunctionIndex> GetAsync(CancellationToken cancellationToken)
@@ -112,7 +115,7 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
         private async Task<IFunctionIndex> CreateAsync(CancellationToken cancellationToken)
         {
             FunctionIndex index = new FunctionIndex();
-            FunctionIndexer indexer = new FunctionIndexer(_triggerBindingProvider, _bindingProvider, _activator, _executor, _extensions, _singletonManager, _trace, _loggerFactory, null, _sharedQueue, _defaultTimeout);
+            FunctionIndexer indexer = new FunctionIndexer(_triggerBindingProvider, _bindingProvider, _activator, _executor, _extensions, _singletonManager, _trace, _loggerFactory, null, _sharedQueue, _defaultTimeout, _allowPartialHostStartup);
             IReadOnlyList<Type> types = _typeLocator.GetTypes();
 
             foreach (Type type in types)

--- a/src/Microsoft.Azure.WebJobs.Host/JobHostConfiguration.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/JobHostConfiguration.cs
@@ -84,6 +84,21 @@ namespace Microsoft.Azure.WebJobs
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the host should be able to start partially
+        /// when some functions are in error. The default is false.
+        /// </summary>
+        /// <remarks>
+        /// Normally when a function encounters an indexing error or its listener fails to start
+        /// the error will propagate and the host will not start. However, with this option set,
+        /// the host will be allowed to start in "partial" mode:
+        ///   - Functions without errors will run normally
+        ///   - Functions with indexing errors will not be running
+        ///   - Functions listener startup failures will be retried in the background
+        ///     until they start.
+        /// </remarks>
+        public bool AllowPartialHostStartup { get; set; }
+
+        /// <summary>
         /// Gets a value indicating whether the <see cref="JobHost"/> is running in a Development environment.
         /// You can use this property in conjunction with <see cref="UseDevelopmentSettings"/> to default
         /// configuration settings to values optimized for local development.

--- a/src/Microsoft.Azure.WebJobs.Host/Listeners/HostListenerFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Listeners/HostListenerFactory.cs
@@ -26,9 +26,10 @@ namespace Microsoft.Azure.WebJobs.Host.Listeners
         private readonly TraceWriter _trace;
         private readonly ILoggerFactory _loggerFactory;
         private readonly ILogger _logger;
+        private readonly bool _allowPartialHostStartup;
 
         public HostListenerFactory(IEnumerable<IFunctionDefinition> functionDefinitions, SingletonManager singletonManager, IJobActivator activator, INameResolver nameResolver,
-            TraceWriter trace, ILoggerFactory loggerFactory)
+            TraceWriter trace, ILoggerFactory loggerFactory, bool allowPartialHostStartup = false)
         {
             _functionDefinitions = functionDefinitions;
             _singletonManager = singletonManager;
@@ -37,6 +38,7 @@ namespace Microsoft.Azure.WebJobs.Host.Listeners
             _trace = trace;
             _loggerFactory = loggerFactory;
             _logger = _loggerFactory?.CreateLogger(LogCategories.Startup);
+            _allowPartialHostStartup = allowPartialHostStartup;
         }
 
         public async Task<IListener> CreateAsync(CancellationToken cancellationToken)
@@ -70,7 +72,7 @@ namespace Microsoft.Azure.WebJobs.Host.Listeners
                 }
 
                 // wrap the listener with a function listener to handle exceptions
-                listener = new FunctionListener(listener, functionDefinition.Descriptor, _trace, _loggerFactory);
+                listener = new FunctionListener(listener, functionDefinition.Descriptor, _trace, _loggerFactory, _allowPartialHostStartup);
                 listeners.Add(listener);
             }
 

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostConfigurationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostConfigurationTests.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             Assert.Equal(TraceLevel.Info, config.Tracing.ConsoleLevel);
             Assert.Equal(0, config.Tracing.Tracers.Count);
             Assert.False(config.Blobs.CentralizedPoisonQueue);
+            Assert.False(config.AllowPartialHostStartup);
 
             StorageClientFactory clientFactory = config.GetService<StorageClientFactory>();
             Assert.NotNull(clientFactory);

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostTests.cs
@@ -491,19 +491,23 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             Assert.Equal("BindingErrorsProgram.Invalid", fex.MethodName);
 
             // verify that the binding error was logged
-            Assert.Equal(5, traceWriter.Traces.Count);
+            Assert.Equal(6, traceWriter.Traces.Count);
             TraceEvent traceEvent = traceWriter.Traces[0];
             Assert.Equal("Error indexing method 'BindingErrorsProgram.Invalid'", traceEvent.Message);
+            Assert.Equal(TraceLevel.Error, traceEvent.Level);
             Assert.Same(fex, traceEvent.Exception);
             Assert.Equal("Invalid container name: invalid$=+1", traceEvent.Exception.InnerException.Message);
+            traceEvent = traceWriter.Traces[1];
+            Assert.Equal("Function 'BindingErrorsProgram.Invalid' failed indexing and will be disabled.", traceEvent.Message);
+            Assert.Equal(TraceLevel.Warning, traceEvent.Level);
 
             // verify that the valid function was still indexed
-            traceEvent = traceWriter.Traces[1];
+            traceEvent = traceWriter.Traces[2];
             Assert.True(traceEvent.Message.Contains("Found the following functions"));
             Assert.True(traceEvent.Message.Contains("BindingErrorsProgram.Valid"));
 
             // verify that the job host was started successfully
-            traceEvent = traceWriter.Traces[4];
+            traceEvent = traceWriter.Traces[5];
             Assert.Equal("Job host started", traceEvent.Message);
 
             host.Stop();


### PR DESCRIPTION
Core changes required to address Functions issue https://github.com/Azure/azure-functions-host/issues/2497. In Functions, we'll set this new mode to true. The default behavior for Functions will be the same as we have now in that we allow the host to start partially - however we'll no longer ignore listener startup failures. Listeners will now be retried in the background.

While this feature is being added primarily for Azure Functions usage, it can be generally useful. E.g. in a continuous WebJob with many different functions, the back end service for one listener might be down for a bit preventing the listener from starting. However all the other functions can run fine. With this feature, rather than the host not being able to start at all until ALL listeners can start (i.e. the standard continuous WebJobs restart loop), most functions can start running while we wait for the one to recover.