### PR TITLE
Extra logging that will help For Type Version mismatch

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Indexers/DefaultTypeLocator.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Indexers/DefaultTypeLocator.cs
@@ -121,9 +121,19 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
             }
             catch (ReflectionTypeLoadException ex)
             {
+				
                 _log.WriteLine("Warning: Only got partial types from assembly: {0}", assembly.FullName);
-                _log.WriteLine("Exception message: {0}", ex.ToString());
+				if(ex?.LoaderExceptions != null)
+				{
+					foreach(var loaderException in ex.LoaderExceptions)
+					{
+						_log.WriteLine("Exception message: Loader Exception: {0}", loaderException);
+					}
+					
+				}
 
+				_log.WriteLine("Exception message: {0}", ex.ToString());
+				
                 // In case of a type load exception, at least get the types that did succeed in loading
                 types = ex.Types;
             }

--- a/src/Microsoft.Azure.WebJobs.Host/Indexers/DefaultTypeLocator.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Indexers/DefaultTypeLocator.cs
@@ -123,11 +123,11 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
             {
 				
                 _log.WriteLine("Warning: Only got partial types from assembly: {0}", assembly.FullName);
-				if(ex?.LoaderExceptions != null)
+				if(ex.LoaderExceptions != null)
 				{
 					foreach(var loaderException in ex.LoaderExceptions)
 					{
-						_log.WriteLine("Exception message: Loader Exception: {0}", loaderException);
+						_log.WriteLine("Loader Exception: {0}", loaderException);
 					}
 					
 				}


### PR DESCRIPTION
In the case of a ReflectionTypeLoadException, write out the loader exception to assist in debugging.

This can happen if the runtime has a version of a library loaded that is not the same version that a customer library is using.