### PR TITLE
Perf improvement on queue/table bindings in high throughput scenarios (V1)

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Executors/DefaultStorageAccountProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/DefaultStorageAccountProvider.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
         private readonly IStorageCredentialsValidator _storageCredentialsValidator;
         private readonly IStorageAccountParser _storageAccountParser;
         private readonly IServiceProvider _services;
-        private readonly ConcurrentDictionary<string, IStorageAccount> _accounts = new ConcurrentDictionary<string, IStorageAccount>();
+        private readonly ConcurrentDictionary<string, Task<IStorageAccount>> _accounts = new ConcurrentDictionary<string, Task<IStorageAccount>>();
 
         private IStorageAccount _dashboardAccount;
         private bool _dashboardAccountSet;
@@ -188,17 +188,8 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             return account;
         }
 
-        public async Task<IStorageAccount> TryGetAccountAsync(string connectionStringName, CancellationToken cancellationToken)
-        {
-            IStorageAccount account;
-            if (!_accounts.TryGetValue(connectionStringName, out account))
-            {
-                // in rare cases createAndValidateAccountAsync could be called multiple times for the same account
-                account = await CreateAndValidateAccountAsync(connectionStringName, cancellationToken);
-                _accounts.AddOrUpdate(connectionStringName, (cs) => account, (cs, a) => account);
-            }
-            return account;
-        }
+        public Task<IStorageAccount> TryGetAccountAsync(string connectionStringName, CancellationToken cancellationToken) =>
+            _accounts.GetOrAdd(connectionStringName, s => CreateAndValidateAccountAsync(s, cancellationToken));
 
         private IStorageAccount ParseAccount(string connectionStringName)
         {

--- a/src/Microsoft.Azure.WebJobs.Host/Queues/Bindings/QueueBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Queues/Bindings/QueueBindingProvider.cs
@@ -108,9 +108,8 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Bindings
 
             private ParameterDescriptor ToParameterDescriptorForCollector(QueueAttribute attr, ParameterInfo parameter, INameResolver nameResolver, FileAccess access)
             {
-                Task<IStorageAccount> t = Task.Run(() =>
-                    _accountProvider.GetStorageAccountAsync(attr, CancellationToken.None, nameResolver));
-                IStorageAccount account = t.GetAwaiter().GetResult();
+                // Avoid using the sync over async pattern (Async().GetAwaiter().GetResult()) whenever possible
+                IStorageAccount account = _accountProvider.GetStorageAccountAsync(attr, CancellationToken.None, nameResolver).GetAwaiter().GetResult();
 
                 string accountName = account.Credentials.AccountName;
 
@@ -184,7 +183,19 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Bindings
 
             internal IStorageQueue GetQueue(QueueAttribute attrResolved)
             {
-                var account = Task.Run(() => _accountProvider.GetStorageAccountAsync(attrResolved, CancellationToken.None)).GetAwaiter().GetResult();
+                // Avoid using the sync over async pattern (Async().GetAwaiter().GetResult()) whenever possible
+                var account = _accountProvider.GetStorageAccountAsync(attrResolved, CancellationToken.None).GetAwaiter().GetResult();
+                return GetQueue(attrResolved, account);
+            }
+
+            internal async Task<IStorageQueue> GetQueueAsync(QueueAttribute attrResolved)
+            {
+                var account = await _accountProvider.GetStorageAccountAsync(attrResolved, CancellationToken.None);
+                return GetQueue(attrResolved, account);
+            }
+
+            internal static IStorageQueue GetQueue(QueueAttribute attrResolved, IStorageAccount account)
+            {
                 var client = account.CreateQueueClient();
 
                 string queueName = attrResolved.QueueName.ToLowerInvariant();
@@ -209,7 +220,7 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Bindings
                 QueueAttribute attrResolved,
                 CancellationToken cancellation)
             {
-                IStorageQueue queue = _bindingProvider.GetQueue(attrResolved);
+                IStorageQueue queue = await _bindingProvider.GetQueueAsync(attrResolved);
                 await queue.CreateIfNotExistsAsync(CancellationToken.None);
                 return queue;
             }

--- a/src/Microsoft.Azure.WebJobs.Host/Tables/TableExtension.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Tables/TableExtension.cs
@@ -68,16 +68,27 @@ namespace Microsoft.Azure.WebJobs.Host.Tables
         // Get the storage table from the attribute.
         private IStorageTable GetTable(TableAttribute attribute)
         {
-            var account = Task.Run(() => this._accountProvider.GetStorageAccountAsync(attribute, CancellationToken.None)).GetAwaiter().GetResult();
+            // Avoid using the sync over async pattern (Async().GetAwaiter().GetResult()) whenever possible
+            var account = this._accountProvider.GetStorageAccountAsync(attribute, CancellationToken.None).GetAwaiter().GetResult();
+            return GetTable(attribute, account);
+        }
+
+        private async Task<IStorageTable> GetTableAsync(TableAttribute attribute)
+        {
+            var account = await this._accountProvider.GetStorageAccountAsync(attribute, CancellationToken.None);
+            return GetTable(attribute, account);
+        }
+
+        private static IStorageTable GetTable(TableAttribute attribute, IStorageAccount account)
+        {
             var tableClient = account.CreateTableClient();
             return tableClient.GetTableReference(attribute.TableName);
         }
 
         private ParameterDescriptor ToParameterDescriptorForCollector(TableAttribute attribute, ParameterInfo parameter, INameResolver nameResolver)
         {
-            Task<IStorageAccount> t = Task.Run(() =>
-                _accountProvider.GetStorageAccountAsync(attribute, CancellationToken.None, nameResolver));
-            IStorageAccount account = t.GetAwaiter().GetResult();
+            // Avoid using the sync over async pattern (Async().GetAwaiter().GetResult()) whenever possible
+            IStorageAccount account = _accountProvider.GetStorageAccountAsync(attribute, CancellationToken.None, nameResolver).GetAwaiter().GetResult();
             string accountName = account.Credentials.AccountName;
 
             return new TableParameterDescriptor
@@ -224,7 +235,7 @@ namespace Microsoft.Azure.WebJobs.Host.Tables
 
             async Task<CloudTable> IAsyncConverter<TableAttribute, CloudTable>.ConvertAsync(TableAttribute attribute, CancellationToken cancellation)
             {
-                var table = _bindingProvider.GetTable(attribute);
+                var table = await _bindingProvider.GetTableAsync(attribute);
                 await table.CreateIfNotExistsAsync(CancellationToken.None);
 
                 return table.SdkObject;
@@ -232,7 +243,7 @@ namespace Microsoft.Azure.WebJobs.Host.Tables
 
             async Task<JObject> IAsyncConverter<TableAttribute, JObject>.ConvertAsync(TableAttribute attribute, CancellationToken cancellation)
             {
-                var table = _bindingProvider.GetTable(attribute);
+                var table = await _bindingProvider.GetTableAsync(attribute);
 
                 IStorageTableOperation retrieve = table.CreateRetrieveOperation<DynamicTableEntity>(
                   attribute.PartitionKey, attribute.RowKey);
@@ -252,7 +263,7 @@ namespace Microsoft.Azure.WebJobs.Host.Tables
             // Used as an alternative to binding to IQueryable.
             async Task<JArray> IAsyncConverter<TableAttribute, JArray>.ConvertAsync(TableAttribute attribute, CancellationToken cancellation)
             {
-                var table = _bindingProvider.GetTable(attribute).SdkObject;
+                var table = (await _bindingProvider.GetTableAsync(attribute)).SdkObject;
 
                 string finalQuery = attribute.Filter;
                 if (!string.IsNullOrEmpty(attribute.PartitionKey))

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncCancellationEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncCancellationEndToEndTests.cs
@@ -249,7 +249,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     _invokeInFunction = () => { tokenSource.Cancel(); };
 
                     PrepareHostForTrigger(host, startHost: false);
-                    Assert.True(host.StartAsync(tokenSource.Token).WaitUntilCompleted(2 * DefaultTimeout));
+                    Assert.True(host.StartAsync(tokenSource.Token).WaitUntilCompleted(DefaultTimeout));
 
                     EvaluateTriggeredCancellation(expectedCancellation: false);
                 }

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncCancellationEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncCancellationEndToEndTests.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         private static EventWaitHandle _functionStarted;
         private static EventWaitHandle _functionCompleted;
         private static bool _tokenCancelled;
-        private static SynchronizationContext _oldContext;
 
         private readonly CloudStorageAccount _storageAccount;
         private readonly RandomNameResolver _resolver;
@@ -30,9 +29,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
         public AsyncCancellationEndToEndTests()
         {
-            // Run tests in multithreaded environment
-            _oldContext = SynchronizationContext.Current;
-            SynchronizationContext.SetSynchronizationContext(null);
             _resolver = new RandomNameResolver();
 
             _hostConfiguration = new JobHostConfiguration()
@@ -62,7 +58,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     testQueue.Delete();
                 }
             }
-            SynchronizationContext.SetSynchronizationContext(_oldContext);
         }
 
 
@@ -109,6 +104,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         [Fact]
         public void WebJobsShutdown_WhenUsingHostCall_TriggersCancellationToken()
         {
+            // Run test in multithreaded environment
             var oldContext = SynchronizationContext.Current;
             try
             {
@@ -146,6 +142,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         [Fact]
         public void Stop_WhenUsingHostCall_DoesNotTriggerCancellationToken()
         {
+            // Run test in multithreaded environment
             var oldContext = SynchronizationContext.Current;
             try
             {
@@ -184,6 +181,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         public void Dispose_WhenUsingHostCall_TriggersCancellationToken()
         {
             Task callTask;
+            // Run test in multithreaded environment
             var oldContext = SynchronizationContext.Current;
             try
             {
@@ -215,6 +213,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         [Fact]
         public void CallCancellationToken_WhenUsingHostCall_TriggersCancellationToken()
         {
+            // Run test in multithreaded environment
             var oldContext = SynchronizationContext.Current;
             try
             {
@@ -238,6 +237,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         [Fact]
         public void CallCancellationToken_WhenUsingTriggeredFunction_DoesNotTriggerCancellationToken()
         {
+            // Run test in multithreaded environment
             var oldContext = SynchronizationContext.Current;
             try
             {

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncCancellationEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncCancellationEndToEndTests.cs
@@ -109,14 +109,23 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         [Fact]
         public void WebJobsShutdown_WhenUsingHostCall_TriggersCancellationToken()
         {
-            using (WebJobsShutdownContext shutdownContext = new WebJobsShutdownContext())
-            using (JobHost host = new JobHost(_hostConfiguration))
+            var oldContext = SynchronizationContext.Current;
+            try
             {
-                _invokeInFunction = () => { shutdownContext.NotifyShutdown(); };
+                SynchronizationContext.SetSynchronizationContext(null);
+                using (WebJobsShutdownContext shutdownContext = new WebJobsShutdownContext())
+                using (JobHost host = new JobHost(_hostConfiguration))
+                {
+                    _invokeInFunction = () => { shutdownContext.NotifyShutdown(); };
 
-                Task callTask = InvokeNoAutomaticTriggerFunction(host);
+                    Task callTask = InvokeNoAutomaticTriggerFunction(host);
 
-                EvaluateNoAutomaticTriggerCancellation(callTask, expectedCancellation: true);
+                    EvaluateNoAutomaticTriggerCancellation(callTask, expectedCancellation: true);
+                }
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(oldContext);
             }
         }
 
@@ -137,15 +146,24 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         [Fact]
         public void Stop_WhenUsingHostCall_DoesNotTriggerCancellationToken()
         {
-            using (JobHost host = new JobHost(_hostConfiguration))
+            var oldContext = SynchronizationContext.Current;
+            try
             {
-                host.Start();
+                SynchronizationContext.SetSynchronizationContext(null);
+                using (JobHost host = new JobHost(_hostConfiguration))
+                {
+                    host.Start();
 
-                Task callTask = InvokeNoAutomaticTriggerFunction(host);
+                    Task callTask = InvokeNoAutomaticTriggerFunction(host);
 
-                host.Stop();
+                    host.Stop();
 
-                EvaluateNoAutomaticTriggerCancellation(callTask, expectedCancellation: false);
+                    EvaluateNoAutomaticTriggerCancellation(callTask, expectedCancellation: false);
+                }
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(oldContext);
             }
         }
 
@@ -166,13 +184,21 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         public void Dispose_WhenUsingHostCall_TriggersCancellationToken()
         {
             Task callTask;
-
-            using (JobHost host = new JobHost(_hostConfiguration))
+            var oldContext = SynchronizationContext.Current;
+            try
             {
-                callTask = InvokeNoAutomaticTriggerFunction(host);
-            }
+                SynchronizationContext.SetSynchronizationContext(null);
+                using (JobHost host = new JobHost(_hostConfiguration))
+                {
+                    callTask = InvokeNoAutomaticTriggerFunction(host);
+                }
 
-            EvaluateNoAutomaticTriggerCancellation(callTask, expectedCancellation: true);
+                EvaluateNoAutomaticTriggerCancellation(callTask, expectedCancellation: true);
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(oldContext);
+            }
         }
 
         [Fact]
@@ -189,29 +215,48 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         [Fact]
         public void CallCancellationToken_WhenUsingHostCall_TriggersCancellationToken()
         {
-            using (CancellationTokenSource tokenSource = new CancellationTokenSource())
-            using (JobHost host = new JobHost(_hostConfiguration))
+            var oldContext = SynchronizationContext.Current;
+            try
             {
-                _invokeInFunction = () => { tokenSource.Cancel(); };
+                SynchronizationContext.SetSynchronizationContext(null);
+                using (CancellationTokenSource tokenSource = new CancellationTokenSource())
+                using (JobHost host = new JobHost(_hostConfiguration))
+                {
+                    _invokeInFunction = () => { tokenSource.Cancel(); };
 
-                Task callTask = InvokeNoAutomaticTriggerFunction(host, tokenSource.Token);
+                    Task callTask = InvokeNoAutomaticTriggerFunction(host, tokenSource.Token);
 
-                EvaluateNoAutomaticTriggerCancellation(callTask, expectedCancellation: true);
+                    EvaluateNoAutomaticTriggerCancellation(callTask, expectedCancellation: true);
+                }
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(oldContext);
             }
         }
 
         [Fact]
         public void CallCancellationToken_WhenUsingTriggeredFunction_DoesNotTriggerCancellationToken()
         {
-            using (CancellationTokenSource tokenSource = new CancellationTokenSource())
-            using (JobHost host = new JobHost(_hostConfiguration))
+            var oldContext = SynchronizationContext.Current;
+            try
             {
-                _invokeInFunction = () => { tokenSource.Cancel(); };
+                SynchronizationContext.SetSynchronizationContext(null);
 
-                PrepareHostForTrigger(host, startHost: false);
-                Assert.True(host.StartAsync(tokenSource.Token).WaitUntilCompleted(DefaultTimeout));
+                using (CancellationTokenSource tokenSource = new CancellationTokenSource())
+                using (JobHost host = new JobHost(_hostConfiguration))
+                {
+                    _invokeInFunction = () => { tokenSource.Cancel(); };
 
-                EvaluateTriggeredCancellation(expectedCancellation: false);
+                    PrepareHostForTrigger(host, startHost: false);
+                    Assert.True(host.StartAsync(tokenSource.Token).WaitUntilCompleted(2 * DefaultTimeout));
+
+                    EvaluateTriggeredCancellation(expectedCancellation: false);
+                }
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(oldContext);
             }
         }
 

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncCancellationEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncCancellationEndToEndTests.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         private static EventWaitHandle _functionStarted;
         private static EventWaitHandle _functionCompleted;
         private static bool _tokenCancelled;
+        private static SynchronizationContext _oldContext;
 
         private readonly CloudStorageAccount _storageAccount;
         private readonly RandomNameResolver _resolver;
@@ -29,6 +30,9 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
         public AsyncCancellationEndToEndTests()
         {
+            // Run tests in multithreaded environment
+            _oldContext = SynchronizationContext.Current;
+            SynchronizationContext.SetSynchronizationContext(null);
             _resolver = new RandomNameResolver();
 
             _hostConfiguration = new JobHostConfiguration()
@@ -58,6 +62,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     testQueue.Delete();
                 }
             }
+            SynchronizationContext.SetSynchronizationContext(_oldContext);
         }
 
 


### PR DESCRIPTION
Dupe of PR #1631, which had strange merge behavior
In the binding flow, there is a point where we transition from async code => sync code => async code. In the sync => async transition, we force the async code to run synchronously by using Task.Run(() => AsyncMethod().GetAwaiter().GetResult() on the async method.

This pattern leads to thread pool contention.

Task.Run() creates a child thread, AsyncMethod() does the work that the parent thread needs, and GetAwaiter().GetResult() blocks the parent thread until the work from AsyncMethod() is completed. In low throughput scenarios, this pattern doesn't cause visible issues because there are enough threads in the thread pool to complete the work in AsyncMethod(). However, when there is a high volume of requests through this code path that blocks on GetAwaiter().GetResult(), the child threads that are spun up to do work that unblock the parents end up queued, waiting for blocked parent threads (this happens because there are a limited number of threads in the thread pool, read [2] for more details). Although work eventually completes, significant delays have led to timeouts (this fix therefore resolves #1467).

Background
There are a number of places where we are not writing our methods so that they are sync OR async all the way down (should not be a combination of both). This blog post [1] from Stephen Toub details some of the dangers of wrapping a synchronous method in an async wrapper. This blog post [2] details some of the dangers with wrapping an async method in an sync wrapper

[1] Async over sync
[2] Sync over async