### PR TITLE
Perf improvement on queue/table bindings in high throughput scenarios (V2)

### DIFF
--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncCancellationEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncCancellationEndToEndTests.cs
@@ -249,7 +249,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     _invokeInFunction = () => { tokenSource.Cancel(); };
 
                     PrepareHostForTrigger(host, startHost: false);
-                    Assert.True(host.StartAsync(tokenSource.Token).WaitUntilCompleted(2 * DefaultTimeout));
+                    Assert.True(host.StartAsync(tokenSource.Token).WaitUntilCompleted(DefaultTimeout));
 
                     EvaluateTriggeredCancellation(expectedCancellation: false);
                 }

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncCancellationEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncCancellationEndToEndTests.cs
@@ -23,7 +23,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         private static EventWaitHandle _functionStarted;
         private static EventWaitHandle _functionCompleted;
         private static bool _tokenCancelled;
-        private static SynchronizationContext _oldContext;
 
         private readonly CloudStorageAccount _storageAccount;
         private readonly RandomNameResolver _resolver;
@@ -31,10 +30,8 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
         public AsyncCancellationEndToEndTests()
         {
-            // Run tests in multithreaded environment
             _resolver = new RandomNameResolver();
-            _oldContext = SynchronizationContext.Current;
-            SynchronizationContext.SetSynchronizationContext(null);
+
             _hostConfiguration = new JobHostConfiguration()
             {
                 NameResolver = _resolver,
@@ -62,7 +59,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     testQueue.DeleteAsync().Wait();
                 }
             }
-            SynchronizationContext.SetSynchronizationContext(_oldContext);
         }
 
         [NoAutomaticTrigger]
@@ -108,6 +104,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         [Fact]
         public void WebJobsShutdown_WhenUsingHostCall_TriggersCancellationToken()
         {
+            // Run test in multithreaded environment
             var oldContext = SynchronizationContext.Current;
             try
             {
@@ -145,6 +142,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         [Fact]
         public void Stop_WhenUsingHostCall_DoesNotTriggerCancellationToken()
         {
+            // Run test in multithreaded environment
             var oldContext = SynchronizationContext.Current;
             try
             {
@@ -183,6 +181,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         public void Dispose_WhenUsingHostCall_TriggersCancellationToken()
         {
             Task callTask;
+            // Run test in multithreaded environment
             var oldContext = SynchronizationContext.Current;
             try
             {
@@ -214,6 +213,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         [Fact]
         public void CallCancellationToken_WhenUsingHostCall_TriggersCancellationToken()
         {
+            // Run test in multithreaded environment
             var oldContext = SynchronizationContext.Current;
             try
             {
@@ -237,6 +237,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         [Fact]
         public void CallCancellationToken_WhenUsingTriggeredFunction_DoesNotTriggerCancellationToken()
         {
+            // Run test in multithreaded environment
             var oldContext = SynchronizationContext.Current;
             try
             {

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncCancellationEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncCancellationEndToEndTests.cs
@@ -108,14 +108,23 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         [Fact]
         public void WebJobsShutdown_WhenUsingHostCall_TriggersCancellationToken()
         {
-            using (WebJobsShutdownContext shutdownContext = new WebJobsShutdownContext())
-            using (JobHost host = new JobHost(_hostConfiguration))
+            var oldContext = SynchronizationContext.Current;
+            try
             {
-                _invokeInFunction = () => { shutdownContext.NotifyShutdown(); };
+                SynchronizationContext.SetSynchronizationContext(null);
+                using (WebJobsShutdownContext shutdownContext = new WebJobsShutdownContext())
+                using (JobHost host = new JobHost(_hostConfiguration))
+                {
+                    _invokeInFunction = () => { shutdownContext.NotifyShutdown(); };
 
-                Task callTask = InvokeNoAutomaticTriggerFunction(host);
+                    Task callTask = InvokeNoAutomaticTriggerFunction(host);
 
-                EvaluateNoAutomaticTriggerCancellation(callTask, expectedCancellation: true);
+                    EvaluateNoAutomaticTriggerCancellation(callTask, expectedCancellation: true);
+                }
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(oldContext);
             }
         }
 
@@ -136,15 +145,24 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         [Fact]
         public void Stop_WhenUsingHostCall_DoesNotTriggerCancellationToken()
         {
-            using (JobHost host = new JobHost(_hostConfiguration))
+            var oldContext = SynchronizationContext.Current;
+            try
             {
-                host.Start();
+                SynchronizationContext.SetSynchronizationContext(null);
+                using (JobHost host = new JobHost(_hostConfiguration))
+                {
+                    host.Start();
 
-                Task callTask = InvokeNoAutomaticTriggerFunction(host);
+                    Task callTask = InvokeNoAutomaticTriggerFunction(host);
 
-                host.Stop();
+                    host.Stop();
 
-                EvaluateNoAutomaticTriggerCancellation(callTask, expectedCancellation: false);
+                    EvaluateNoAutomaticTriggerCancellation(callTask, expectedCancellation: false);
+                }
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(oldContext);
             }
         }
 
@@ -165,13 +183,21 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         public void Dispose_WhenUsingHostCall_TriggersCancellationToken()
         {
             Task callTask;
-
-            using (JobHost host = new JobHost(_hostConfiguration))
+            var oldContext = SynchronizationContext.Current;
+            try
             {
-                callTask = InvokeNoAutomaticTriggerFunction(host);
-            }
+                SynchronizationContext.SetSynchronizationContext(null);
+                using (JobHost host = new JobHost(_hostConfiguration))
+                {
+                    callTask = InvokeNoAutomaticTriggerFunction(host);
+                }
 
-            EvaluateNoAutomaticTriggerCancellation(callTask, expectedCancellation: true);
+                EvaluateNoAutomaticTriggerCancellation(callTask, expectedCancellation: true);
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(oldContext);
+            }
         }
 
         [Fact]
@@ -188,29 +214,48 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         [Fact]
         public void CallCancellationToken_WhenUsingHostCall_TriggersCancellationToken()
         {
-            using (CancellationTokenSource tokenSource = new CancellationTokenSource())
-            using (JobHost host = new JobHost(_hostConfiguration))
+            var oldContext = SynchronizationContext.Current;
+            try
             {
-                _invokeInFunction = () => { tokenSource.Cancel(); };
+                SynchronizationContext.SetSynchronizationContext(null);
+                using (CancellationTokenSource tokenSource = new CancellationTokenSource())
+                using (JobHost host = new JobHost(_hostConfiguration))
+                {
+                    _invokeInFunction = () => { tokenSource.Cancel(); };
 
-                Task callTask = InvokeNoAutomaticTriggerFunction(host, tokenSource.Token);
+                    Task callTask = InvokeNoAutomaticTriggerFunction(host, tokenSource.Token);
 
-                EvaluateNoAutomaticTriggerCancellation(callTask, expectedCancellation: true);
+                    EvaluateNoAutomaticTriggerCancellation(callTask, expectedCancellation: true);
+                }
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(oldContext);
             }
         }
 
         [Fact]
         public void CallCancellationToken_WhenUsingTriggeredFunction_DoesNotTriggerCancellationToken()
         {
-            using (CancellationTokenSource tokenSource = new CancellationTokenSource())
-            using (JobHost host = new JobHost(_hostConfiguration))
+            var oldContext = SynchronizationContext.Current;
+            try
             {
-                _invokeInFunction = () => { tokenSource.Cancel(); };
+                SynchronizationContext.SetSynchronizationContext(null);
 
-                PrepareHostForTrigger(host, startHost: false);
-                Assert.True(host.StartAsync(tokenSource.Token).WaitUntilCompleted(DefaultTimeout));
+                using (CancellationTokenSource tokenSource = new CancellationTokenSource())
+                using (JobHost host = new JobHost(_hostConfiguration))
+                {
+                    _invokeInFunction = () => { tokenSource.Cancel(); };
 
-                EvaluateTriggeredCancellation(expectedCancellation: false);
+                    PrepareHostForTrigger(host, startHost: false);
+                    Assert.True(host.StartAsync(tokenSource.Token).WaitUntilCompleted(2 * DefaultTimeout));
+
+                    EvaluateTriggeredCancellation(expectedCancellation: false);
+                }
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(oldContext);
             }
         }
 

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncCancellationEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncCancellationEndToEndTests.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         private static EventWaitHandle _functionStarted;
         private static EventWaitHandle _functionCompleted;
         private static bool _tokenCancelled;
+        private static SynchronizationContext _oldContext;
 
         private readonly CloudStorageAccount _storageAccount;
         private readonly RandomNameResolver _resolver;
@@ -30,8 +31,10 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
         public AsyncCancellationEndToEndTests()
         {
+            // Run tests in multithreaded environment
             _resolver = new RandomNameResolver();
-
+            _oldContext = SynchronizationContext.Current;
+            SynchronizationContext.SetSynchronizationContext(null);
             _hostConfiguration = new JobHostConfiguration()
             {
                 NameResolver = _resolver,
@@ -59,6 +62,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     testQueue.DeleteAsync().Wait();
                 }
             }
+            SynchronizationContext.SetSynchronizationContext(_oldContext);
         }
 
         [NoAutomaticTrigger]


### PR DESCRIPTION
V2 version of #1657

In the binding flow, there is a point where we transition from async code => sync code => async code. In the sync => async transition, we force the async code to run synchronously by using Task.Run(() => AsyncMethod().GetAwaiter().GetResult() on the async method.

This pattern leads to thread pool contention.

Task.Run() creates a child thread, AsyncMethod() does the work that the parent thread needs, and GetAwaiter().GetResult() blocks the parent thread until the work from AsyncMethod() is completed. In low throughput scenarios, this pattern doesn't cause visible issues because there are enough threads in the thread pool to complete the work in AsyncMethod(). However, when there is a high volume of requests through this code path that blocks on GetAwaiter().GetResult(), the child threads that are spun up to do work that unblock the parents end up queued, waiting for blocked parent threads (this happens because there are a limited number of threads in the thread pool, read [2] for more details). Although work eventually completes, significant delays have led to timeouts (this fix therefore resolves #1467).

Background
There are a number of places where we are not writing our methods so that they are sync OR async all the way down (should not be a combination of both). This blog post [1] from Stephen Toub details some of the dangers of wrapping a synchronous method in an async wrapper. This blog post [2] details some of the dangers with wrapping an async method in an sync wrapper

[1] Async over sync
[2] Sync over async