### PR TITLE
display malformatted blob identifier in error message

### DIFF
--- a/src/Dashboard/Data/BlobPath.cs
+++ b/src/Dashboard/Data/BlobPath.cs
@@ -47,7 +47,7 @@ namespace Dashboard.Data
 
             if (!TryParse(value, out path))
             {
-                throw new FormatException($"Blob identifiers must be in the format 'container/blob', but given '{value}'.");
+                throw new FormatException($"Invalid blob path specified: '{value}'. Blob identifiers must be in the format 'container/blob'.");
             }
 
             return path;

--- a/src/Dashboard/Data/BlobPath.cs
+++ b/src/Dashboard/Data/BlobPath.cs
@@ -47,7 +47,7 @@ namespace Dashboard.Data
 
             if (!TryParse(value, out path))
             {
-                throw new FormatException("Blob identifiers must be in the format 'container/blob'.");
+                throw new FormatException($"Blob identifiers must be in the format 'container/blob', but given '{value}'.");
             }
 
             return path;

--- a/src/Microsoft.Azure.WebJobs.Host/Blobs/BlobPath.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Blobs/BlobPath.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs
 
             if (!TryParse(value, isContainerBinding, out possiblePath))
             {
-                errorMessage = $"Blob identifiers must be in the format 'container/blob', but given '{value}'.";
+                errorMessage = $"Invalid blob path specified : '{value}'. Blob identifiers must be in the format 'container/blob'.";
                 path = null;
                 return false;
             }

--- a/src/Microsoft.Azure.WebJobs.Host/Blobs/BlobPath.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Blobs/BlobPath.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs
 
             if (!TryParse(value, isContainerBinding, out possiblePath))
             {
-                errorMessage = "Blob identifiers must be in the format 'container/blob'.";
+                errorMessage = $"Blob identifiers must be in the format 'container/blob', but given '{value}'.";
                 path = null;
                 return false;
             }


### PR DESCRIPTION
sample output:
```
2018-04-24T00:11:55.485 [Info] Function started (Id=273d9086-6de0-4589-ac4c-3b69b468e5d8)
2018-04-24T00:11:55.813 [Error] Exception while executing function: Functions.BlobTriggerJS1. Microsoft.Azure.WebJobs.Host: Exception binding parameter 'myBlob'. Microsoft.Azure.WebJobs.Host: Blob identifiers must be in the format 'container/blob', but given ' '.
2018-04-24T00:11:55.864 [Error] Function completed (Failure, Id=273d9086-6de0-4589-ac4c-3b69b468e5d8, Duration=377ms)
2018-04-24T00:12:15.185 [Info] Function started (Id=bf63af68-8779-4b88-b69b-2a9b62f436df)
2018-04-24T00:12:15.232 [Error] Exception while executing function: Functions.BlobTriggerJS1. Microsoft.Azure.WebJobs.Host: Exception binding parameter 'myBlob'. Microsoft.Azure.WebJobs.Host: Blob identifiers must be in the format 'container/blob', but given 'goodbye world'.
2018-04-24T00:12:15.279 [Error] Function completed (Failure, Id=bf63af68-8779-4b88-b69b-2a9b62f436df, Duration=92ms)
```