### PR TITLE
Fixing listener retry race condition (#1691)

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Listeners/FunctionListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Listeners/FunctionListener.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Azure.WebJobs.Host.Listeners
         private readonly FunctionDescriptor _descriptor;
         private readonly TraceWriter _trace;
         private readonly ILogger _logger;
+        private readonly SemaphoreSlim _semaphoreSlim = new SemaphoreSlim(1, 1);
         private bool _started = false;
         private bool _allowPartialHostStartup;
         private CancellationTokenSource _retryCancellationTokenSource;
@@ -55,6 +56,7 @@ namespace Microsoft.Azure.WebJobs.Host.Listeners
         {
             _listener.Dispose();
             _retryCancellationTokenSource?.Cancel();
+            _semaphoreSlim.Dispose();
         }
 
         public async Task StartAsync(CancellationToken cancellationToken)
@@ -114,6 +116,17 @@ namespace Microsoft.Azure.WebJobs.Host.Listeners
                         message = $"Listener successfully started for function '{_descriptor.ShortName}' after {attempt} retries.";
                         _trace.Info(message);
                         _logger?.LogInformation(message);
+
+                        if (cancellationToken.IsCancellationRequested)
+                        {
+                            // stop has been called while we were in the process of starting
+                            // so we need to stop this listener
+                            await StopAsync(cancellationToken);
+
+                            message = $"Listener for function '{_descriptor.ShortName}' stopped. A stop was initiated while starting.";
+                            _trace.Info(message);
+                            _logger?.LogInformation(message);
+                        }
                     }
                 }
             }
@@ -125,10 +138,20 @@ namespace Microsoft.Azure.WebJobs.Host.Listeners
             // we issue the Stop
             _retryCancellationTokenSource?.Cancel();
 
-            if (_started)
+            await _semaphoreSlim.WaitAsync();
             {
-                await _listener.StopAsync(cancellationToken);
-                _started = false;
+                try
+                {
+                    if (_started)
+                    {
+                        await _listener.StopAsync(cancellationToken);
+                        _started = false;
+                    }
+                }
+                finally
+                {
+                    _semaphoreSlim.Release();
+                }
             }
         }
     }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Listeners/FunctionListenerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Listeners/FunctionListenerTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
@@ -148,6 +149,85 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Listeners
             int retryCount = trace.Traces.Count(p => p.Message.Contains("Retrying to start listener"));
 
             Assert.Equal(prevRetryCount, retryCount);
+        }
+
+        [Fact]
+        public async Task FunctionListener_ConcurrentStartStop_ListenerIsStopped()
+        {
+            var trace = new TestTraceWriter(TraceLevel.Error);
+            Mock<IListener> badListener = new Mock<IListener>(MockBehavior.Strict);
+            var listener = new FunctionListener(badListener.Object, fd, trace, _loggerFactory, allowPartialHostStartup: true, minRetryInterval: TimeSpan.FromMilliseconds(10), maxRetryInterval: TimeSpan.FromMilliseconds(100));
+
+            int count = 0;
+            badListener.Setup(bl => bl.StartAsync(It.IsAny<CancellationToken>()))
+                .Returns(async () =>
+                {
+                    count++;
+
+                    if (count == 1)
+                    {
+                        // initiate the restart loop by falling on the first attemt
+                        throw new Exception("Listener Exploded!");
+                    }
+                    else if (count == 2)
+                    {
+                        // while we're in the retry loop simulate a concurrent stop by
+                        // invoking stop ourselves
+                        await listener.StopAsync(ct);
+                    }
+                    else
+                    {
+                        // shouldn't get to here
+                    }
+                });
+
+            bool stopCalled = false;
+            badListener.Setup(bl => bl.StopAsync(It.IsAny<CancellationToken>()))
+                .Callback(() => stopCalled = true)
+                .Returns(Task.CompletedTask);
+
+            await listener.StartAsync(ct);
+
+            await TestHelpers.Await(() =>
+            {
+                return stopCalled;
+            }, timeout: 4000, userMessage: "Listener not stopped.");
+
+            badListener.Verify(p => p.StartAsync(It.IsAny<CancellationToken>()), Times.Exactly(2));
+            badListener.Verify(p => p.StopAsync(It.IsAny<CancellationToken>()), Times.Exactly(1));
+
+            Assert.Collection(trace.Traces.Select(p => p.Message),
+                p => Assert.Equal("The listener for function 'testfunc' was unable to start.", p),
+                p => Assert.Equal("Retrying to start listener for function 'testfunc' (Attempt 1)", p),
+                p => Assert.Equal("Listener successfully started for function 'testfunc' after 1 retries.", p),
+                p => Assert.Equal("Listener for function 'testfunc' stopped. A stop was initiated while starting.", p));
+
+            // make sure the retry loop is not running
+            await Task.Delay(1000);
+            Assert.Equal(2, count);
+        }
+
+        [Fact]
+        public async Task StopAsync_MultipleConcurrentRequests_InnerListenerStoppedOnce()
+        {
+            var trace = new TestTraceWriter(TraceLevel.Error);
+            Mock<IListener> innerListener = new Mock<IListener>(MockBehavior.Strict);
+            var functionListener = new FunctionListener(innerListener.Object, fd, trace, _loggerFactory);
+
+            innerListener.Setup(bl => bl.StartAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+            innerListener.Setup(bl => bl.StopAsync(It.IsAny<CancellationToken>())).Returns(async () => await Task.Delay(100));
+
+            await functionListener.StartAsync(CancellationToken.None);
+
+            List<Task> tasks = new List<Task>();
+            for (int i = 0; i < 10; i++)
+            {
+                tasks.Add(functionListener.StopAsync(CancellationToken.None));
+            }
+
+            await Task.WhenAll(tasks);
+
+            innerListener.Verify(p => p.StopAsync(It.IsAny<CancellationToken>()), Times.Exactly(1));
         }
 
         [Fact]


### PR DESCRIPTION
Fix for https://github.com/Azure/azure-webjobs-sdk/issues/1691.