### PR TITLE
Fixing IConfiguration environment variable caching

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/ConfigurationUtility.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/ConfigurationUtility.cs
@@ -2,8 +2,9 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Globalization;
+using System.Linq;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.EnvironmentVariables;
 
 namespace Microsoft.Azure.WebJobs.Host
 {
@@ -32,7 +33,6 @@ namespace Microsoft.Azure.WebJobs.Host
         public static void SetConfigurationFactory(Func<IConfiguration> configurationRootFactory)
         {
             _configurationFactory = configurationRootFactory;
-            Reset();
         }
 
         public static bool IsSettingEnabled(string settingName)
@@ -53,15 +53,10 @@ namespace Microsoft.Azure.WebJobs.Host
         private static IConfigurationRoot BuildConfiguration()
         {
             var configurationBuilder = new ConfigurationBuilder()
-                .AddJsonFile("appsettings.json", optional: true)
-                .AddEnvironmentVariables();
+                .AddJsonFile("appsettings.json", optional: true);
+            configurationBuilder.Sources.Add(new WebJobsEnvironmentVariablesConfigurationSource());
 
             return configurationBuilder.Build();
-        }
-
-        internal static void Reset()
-        {
-            _configuration = new Lazy<IConfiguration>(_configurationFactory);
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/WebJobsEnvironmentVariablesConfigurationSource.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/WebJobsEnvironmentVariablesConfigurationSource.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.EnvironmentVariables;
+
+namespace Microsoft.Azure.WebJobs.Host
+{
+    /// <summary>
+    /// This source exists to replace the default <see cref="EnvironmentVariablesConfigurationSource"/> to allow
+    /// us to override caching behavior.
+    /// </summary>
+    internal class WebJobsEnvironmentVariablesConfigurationSource : IConfigurationSource
+    {
+        public IConfigurationProvider Build(IConfigurationBuilder builder)
+        {
+            return new WebHostEnvironmentVariablesProvider();
+        }
+
+        private class WebHostEnvironmentVariablesProvider : EnvironmentVariablesConfigurationProvider
+        {
+            public WebHostEnvironmentVariablesProvider() : base()
+            {
+            }
+
+            public override bool TryGet(string key, out string value)
+            {
+                return
+                    (value = Environment.GetEnvironmentVariable(key)) != null ||
+                    (value = Environment.GetEnvironmentVariable(NormalizeKey(key))) != null;
+            }
+
+            public override void Set(string key, string value)
+            {
+                Environment.SetEnvironmentVariable(key, value);
+            }
+        }
+
+        private static string NormalizeKey(string key)
+        {
+            // For hierarchical config values specified in environment variables, 
+            // a colon(:) may not work on all platforms. Double underscore(__) is
+            // supported by all platforms.
+            return key.Replace(ConfigurationPath.KeyDelimiter, "__");
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/EnvVarHolder.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/EnvVarHolder.cs
@@ -11,8 +11,6 @@ namespace Microsoft.Azure.WebJobs
     {
         public static IDisposable Set(string name, string value)
         {
-            ConfigurationUtility.Reset();
-
             string prevStorage = Environment.GetEnvironmentVariable(name);
 
             Environment.SetEnvironmentVariable(name, value);
@@ -32,7 +30,6 @@ namespace Microsoft.Azure.WebJobs
             public void Dispose()
             {
                 Environment.SetEnvironmentVariable(_name, _value);
-                ConfigurationUtility.Reset();
             }
         }
     }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/ConfigurationUtilityTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/ConfigurationUtilityTests.cs
@@ -11,8 +11,6 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         [Fact]
         public void GetSettingFromConfigOrEnvironment_NotFound_ReturnsEmpty()
         {
-            ConfigurationUtility.Reset();
-
             string value = ConfigurationUtility.GetSetting("DNE");
             Assert.Equal(null, value);
         }
@@ -20,8 +18,6 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         [Fact]
         public void GetSettingFromConfigOrEnvironment_NameNull_ReturnsEmpty()
         {
-            ConfigurationUtility.Reset();
-
             string value = ConfigurationUtility.GetSetting(null);
             Assert.Equal(null, value);
         }
@@ -29,8 +25,6 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         [Fact]
         public void GetSettingFromConfigOrEnvironment_ConfigSetting_NoEnvironmentSetting()
         {
-            ConfigurationUtility.Reset();
-
             string value = ConfigurationUtility.GetSetting("DisableSetting0");
             Assert.Equal("0", value);
         }
@@ -38,8 +32,6 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         [Fact]
         public void GetSettingFromConfigOrEnvironment_EnvironmentSetting_NoConfigSetting()
         {
-            ConfigurationUtility.Reset();
-
             Environment.SetEnvironmentVariable("EnvironmentSetting", "1");
 
             string value = ConfigurationUtility.GetSetting("EnvironmentSetting");
@@ -51,14 +43,39 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         [Fact]
         public void GetSettingFromConfigOrEnvironment_ConfigAndEnvironment_EnvironmentWins()
         {
-            ConfigurationUtility.Reset();
-
             Environment.SetEnvironmentVariable("DisableSetting0", "1");
 
             string value = ConfigurationUtility.GetSetting("DisableSetting0");
             Assert.Equal("1", value);
 
             Environment.SetEnvironmentVariable("DisableSetting0", null);
+        }
+
+        [Theory]
+        [InlineData("Foo__Bar__Baz", "Foo__Bar__Baz")]
+        [InlineData("Foo__Bar__Baz", "foo__bar__baz")]
+        [InlineData("Foo__Bar__Baz", "Foo:Bar:Baz")]
+        [InlineData("Foo__Bar__Baz", "foo:bar:baz")]
+        [InlineData("Foo:Bar:Baz", "Foo:Bar:Baz")]
+        [InlineData("Foo:Bar:Baz", "foo:bar:baz")]
+        [InlineData("Foo_Bar_Baz", "Foo_Bar_Baz")]
+        [InlineData("Foo_Bar_Baz", "foo_bar_baz")]
+        [InlineData("FooBarBaz", "FooBarBaz")]
+        [InlineData("FooBarBaz", "foobarbaz")]
+        public void GetSetting_NormalizesKeys(string key, string lookup)
+        {
+            try
+            {
+                string value = Guid.NewGuid().ToString();
+                Environment.SetEnvironmentVariable(key, value);
+
+                string result = ConfigurationUtility.GetSetting(lookup);
+                Assert.Equal(value, result);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(key, null);
+            }
         }
 
         [Theory]
@@ -72,7 +89,6 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         public void IsSettingEnabled_ReturnsExpected(string settingValue, bool expectedResult)
         {
             // Arrange
-            ConfigurationUtility.Reset();
             string settingName = "SettingEnabledTest";
             Environment.SetEnvironmentVariable(settingName, settingValue);            
 

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/DefaultStorageAccountProviderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/DefaultStorageAccountProviderTests.cs
@@ -22,8 +22,6 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
         [Fact]
         public void ConnectionStringProvider_NoDashboardConnectionString_Throws()
         {
-            ConfigurationUtility.Reset();
-
             const string DashboardConnectionEnvironmentVariable = "AzureWebJobsDashboard";
             string previousConnectionString = Environment.GetEnvironmentVariable(DashboardConnectionEnvironmentVariable);
 

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Listeners/HostListenerFactoryTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Listeners/HostListenerFactoryTests.cs
@@ -37,8 +37,6 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Listeners
         [InlineData(typeof(Functions2), "DisabledAtClassLevel")]
         public async Task CreateAsync_SkipsDisabledFunctions(Type jobType, string methodName)
         {
-            ConfigurationUtility.Reset();
-
             Environment.SetEnvironmentVariable("EnvironmentSettingTrue", "True");
 
             Mock<IFunctionDefinition> mockFunctionDefinition = new Mock<IFunctionDefinition>();
@@ -107,7 +105,6 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Listeners
         [InlineData("Disable_TestJob_Blah", false)]
         public void IsDisabledBySetting_BindsSettingName(string settingName, bool disabled)
         {
-            ConfigurationUtility.Reset();
             Environment.SetEnvironmentVariable("Disable_Functions1.TestJob_TestValue", "1");
             Environment.SetEnvironmentVariable("Disable_TestJob_TestValue", "1");
             Environment.SetEnvironmentVariable("Disable_TestJob", "False");


### PR DESCRIPTION
Addresses https://github.com/Azure/azure-webjobs-sdk/issues/1689

Applying same fix that we did for Azure Functions in https://github.com/Azure/azure-functions-host/commit/29397abfc80b2850164cf2c3da4ec380f4ede607. There are Azure Functions tests/scenarios currently disabled due to this bug (e.g. [this test](https://github.com/Azure/azure-functions-host/blob/ef311c8c4a46e6494e0b6b4af359586bb1295667/test/WebJobs.Script.Tests/Binding/CoreExtensionsScriptBindingProviderTests.cs#L17)).

Eventually just like in Functions the static config that ConfigurationUtility is doing will go away - this is a stepping stone to get things working consistently up and down the stack.