### PR TITLE
Show missing referenced assembly in error message

### DIFF
--- a/src/Dashboard/Dashboard.csproj
+++ b/src/Dashboard/Dashboard.csproj
@@ -487,7 +487,6 @@
     <AssemblyOriginatorKeyFile>..\Common\PublicKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
   <Target Name="MvcBuildViews" AfterTargets="AfterBuild" Condition="'$(MvcBuildViews)'=='true'">
     <AspNetCompiler VirtualPath="temp" PhysicalPath="$(WebProjectOutputDir)" />

--- a/src/Microsoft.Azure.WebJobs.Host/Indexers/DefaultTypeLocator.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Indexers/DefaultTypeLocator.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
                 return false;
             }
 
-            AssemblyName[] referencedAssemblyNames = assembly.GetReferencedAssemblies();  
+            AssemblyName[] referencedAssemblyNames = assembly.GetReferencedAssemblies();
             foreach (var referencedAssemblyName in referencedAssemblyNames)
             {
                 if (String.Equals(referencedAssemblyName.Name, WebJobsAssemblyName, StringComparison.OrdinalIgnoreCase))
@@ -121,8 +121,25 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
             }
             catch (ReflectionTypeLoadException ex)
             {
+                var sb = new System.Text.StringBuilder();
+                var exceptionList = ex.LoaderExceptions;
+                if (exceptionList != null)
+                {
+                    string lastMessage = null;
+                    foreach (var exceptionItem in exceptionList)
+                    {
+                        if (exceptionItem.Message != lastMessage)
+                        {
+                            sb.AppendLine(exceptionItem.Message);
+                        }
+                        lastMessage = exceptionItem.Message;
+                    }
+                }
+
+                var message = sb.Length > 0 ? sb.ToString() : ex.ToString();
+
                 _log.WriteLine("Warning: Only got partial types from assembly: {0}", assembly.FullName);
-                _log.WriteLine("Exception message: {0}", ex.ToString());
+                _log.WriteLine("Exception message: {0}", message);
 
                 // In case of a type load exception, at least get the types that did succeed in loading
                 types = ex.Types;


### PR DESCRIPTION
On the error message displayed it does not say why the loaded assembly did not load completely. I am adding on the error message the name of the missing referenced assemblies.