### PR TITLE
Fixing UseEventHub namespace issue

### DIFF
--- a/sample/SampleHost/Program.cs
+++ b/sample/SampleHost/Program.cs
@@ -4,7 +4,6 @@
 using System;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Logging;
-using Microsoft.Azure.WebJobs.ServiceBus;
 using Microsoft.Extensions.Logging;
 
 namespace SampleHost

--- a/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/EventHubJobHostConfigurationExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/EventHubJobHostConfigurationExtensions.cs
@@ -4,8 +4,9 @@
 using System;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Config;
+using Microsoft.Azure.WebJobs.ServiceBus;
 
-namespace Microsoft.Azure.WebJobs.ServiceBus
+namespace Microsoft.Azure.WebJobs
 {
     /// <summary>
     /// Extension for registering an event hub configuration with the JobHostConfiguration.


### PR DESCRIPTION
For proper discoverability, all extension registration methods are supposed to be in the root Microsoft.Azure.WebJobs so they are discoverable in a vanilla console host immediately after adding the extension package. All the other extensions follow this pattern, but we missed this on EH.