### PR TITLE
Improving/unifying ServiceBus/EventHub error handling

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/TypeUtility.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/TypeUtility.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Globalization;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Config/ServiceBusExtensionConfig.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Config/ServiceBusExtensionConfig.cs
@@ -62,14 +62,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Config
             // host level.
             Config.MessageOptions.ExceptionReceived += (s, e) =>
             {
-                if (!e.Exception.IsWrappedExceptionTransient())
-                {
-                    string message = $"MessageReceiver error (Action={e.Action})";
-                    var logger = context.Config.LoggerFactory?.CreateLogger(LogCategories.Executor);
-                    logger?.LogError(0, e.Exception, message);
-
-                    context.Trace.Error(message, e.Exception);
-                }
+                Utility.LogExceptionReceivedEvent(e, "MessageReceiver", context.Trace, context.Config.LoggerFactory);
             };
 
             // get the services we need to construct our binding providers

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubConfiguration.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubConfiguration.cs
@@ -465,14 +465,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
             // host level.
             _options.ExceptionReceived += (s, e) =>
             {
-                if (!e.Exception.IsWrappedExceptionTransient())
-                {
-                    string message = $"EventProcessorHost error (Action={e.Action})";
-                    var logger = context.Config.LoggerFactory?.CreateLogger(LogCategories.Executor);
-                    logger?.LogError(0, e.Exception, message);
-
-                    context.Trace.Error(message, e.Exception);
-                }
+                Utility.LogExceptionReceivedEvent(e, "EventProcessorHost", context.Trace, context.Config.LoggerFactory);
             };
         }
 

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Utility.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Utility.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Diagnostics;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs.Logging;
+using Microsoft.Extensions.Logging;
+using Microsoft.ServiceBus.Messaging;
+
+namespace Microsoft.Azure.WebJobs.ServiceBus
+{
+    internal static class Utility
+    {
+        public static void LogExceptionReceivedEvent(ExceptionReceivedEventArgs e, string source, TraceWriter traceWriter, ILoggerFactory loggerFactory = null)
+        {
+            var logger = loggerFactory?.CreateLogger(LogCategories.Executor);
+            string message = $"{source} error (Action={e.Action})";
+
+            var mex = e.Exception as MessagingException;
+            if (mex == null || !mex.IsTransient)
+            {
+                // any non-transient exceptions or unknown exception types
+                // we want to log as errors
+                logger?.LogError(0, e.Exception, message);
+                traceWriter.Error(message, e.Exception);
+            }
+            else
+            {
+                // transient messaging errors we log as verbose so we have a record
+                // of them, but we don't treat them as actual errors
+                logger?.LogDebug(0, e.Exception, message);
+                var evt = new TraceEvent(TraceLevel.Verbose, $"{message} : {e.Exception.ToString()}", exception: e.Exception);
+                traceWriter.Trace(evt);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/WebJobs.ServiceBus.csproj
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/WebJobs.ServiceBus.csproj
@@ -278,6 +278,7 @@
     <Compile Include="Listeners\ServiceBusCausalityHelper.cs" />
     <Compile Include="Triggers\ServiceBusTriggerAttributeBindingProvider.cs" />
     <Compile Include="Triggers\ServiceBusTriggerBinding.cs" />
+    <Compile Include="Utility.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Azure.WebJobs.Host\WebJobs.Host.csproj">

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/UtilityTests.cs
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/UtilityTests.cs
@@ -1,0 +1,91 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Microsoft.Azure.WebJobs.Logging;
+using Microsoft.Extensions.Logging;
+using Microsoft.ServiceBus.Messaging;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests
+{
+    public class UtilityTests
+    {
+        private readonly ILoggerFactory _loggerFactory;
+        private readonly TestLoggerProvider _loggerProvider;
+        private readonly TestTraceWriter _traceWriter;
+
+        public UtilityTests()
+        {
+            _loggerFactory = new LoggerFactory();
+            var filter = new LogCategoryFilter();
+            filter.DefaultLevel = LogLevel.Debug;
+            _loggerProvider = new TestLoggerProvider(filter.Filter);
+            _loggerFactory.AddProvider(_loggerProvider);
+
+            _traceWriter = new TestTraceWriter(TraceLevel.Verbose);
+        }
+
+        [Fact]
+        public void LogExceptionReceivedEvent_NonTransientEvent_LoggedAsError()
+        {
+            var ex = new MessageLockLostException("Lost the lock");
+            Assert.False(ex.IsTransient);
+            ExceptionReceivedEventArgs e = new ExceptionReceivedEventArgs(ex, "Complete");
+            Utility.LogExceptionReceivedEvent(e, "Test", _traceWriter, _loggerFactory);
+
+            var expectedMessage = $"Test error (Action=Complete)";
+            var traceEvent = _traceWriter.Traces.Single();
+            Assert.Equal(TraceLevel.Error, traceEvent.Level);
+            Assert.Same(ex, traceEvent.Exception);
+            Assert.Equal(expectedMessage, traceEvent.Message);
+
+            var logMessage = _loggerProvider.GetAllLogMessages().Single();
+            Assert.Equal(LogLevel.Error, logMessage.Level);
+            Assert.Same(ex, logMessage.Exception);
+            Assert.Equal(expectedMessage, logMessage.FormattedMessage);
+        }
+
+        [Fact]
+        public void LogExceptionReceivedEvent_TransientEvent_LoggedAsVerbose()
+        {
+            var ex = new MessagingCommunicationException("Test Path");
+            Assert.True(ex.IsTransient);
+            ExceptionReceivedEventArgs e = new ExceptionReceivedEventArgs(ex, "Connect");
+            Utility.LogExceptionReceivedEvent(e, "Test", _traceWriter, _loggerFactory);
+
+            var expectedMessage = $"Test error (Action=Connect)";
+            var traceEvent = _traceWriter.Traces.Single();
+            Assert.Equal(TraceLevel.Verbose, traceEvent.Level);
+            Assert.Equal($"{expectedMessage} : {ex.ToString()}", traceEvent.Message);
+            Assert.Same(ex, traceEvent.Exception);
+
+            var logMessage = _loggerProvider.GetAllLogMessages().Single();
+            Assert.Equal(LogLevel.Debug, logMessage.Level);
+            Assert.Same(ex, logMessage.Exception);
+            Assert.Equal(expectedMessage, logMessage.FormattedMessage);
+        }
+
+        [Fact]
+        public void LogExceptionReceivedEvent_NonMessagingException_LoggedAsError()
+        {
+            var ex = new MissingMethodException("What method??");
+            ExceptionReceivedEventArgs e = new ExceptionReceivedEventArgs(ex, "Unknown");
+            Utility.LogExceptionReceivedEvent(e, "Test", _traceWriter, _loggerFactory);
+
+            var expectedMessage = $"Test error (Action=Unknown)";
+            var traceEvent = _traceWriter.Traces.Single();
+            Assert.Equal(TraceLevel.Error, traceEvent.Level);
+            Assert.Same(ex, traceEvent.Exception);
+            Assert.Equal(expectedMessage, traceEvent.Message);
+
+            var logMessage = _loggerProvider.GetAllLogMessages().Single();
+            Assert.Equal(LogLevel.Error, logMessage.Level);
+            Assert.Same(ex, logMessage.Exception);
+            Assert.Equal(expectedMessage, logMessage.FormattedMessage);
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/WebJobs.ServiceBus.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/WebJobs.ServiceBus.UnitTests.csproj
@@ -218,6 +218,7 @@
     <Compile Include="ServiceBusTriggerAttributeTests.cs" />
     <Compile Include="Triggers\ServiceBusSubscriptionListenerFactoryTests.cs" />
     <Compile Include="Triggers\ServiceBusTriggerBindingIntegrationTests.cs" />
+    <Compile Include="UtilityTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\src\Common\PublicKey.snk">


### PR DESCRIPTION
Paul was working a customer scenario where the exception that was happening in the background was thrown very early during EventHub listener startup, and the exception type wasn't triggering my existing "is not transient" logic so wasn't getting logged.

Updating the code so it logs ALL exceptions, treating non-transient exceptions or unknown exceptions as true errors, but others that it can't classify it logs as Debug/Verbose so we have some record of it.

I'll make the corresponding changes in the dev branch as well.