### PR TITLE
Logging loader exception details when calls to GetTypes in DefaultTypeLocator throws a ReflectionTypeLoadException

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Indexers/DefaultTypeLocator.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Indexers/DefaultTypeLocator.cs
@@ -122,10 +122,16 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
             catch (ReflectionTypeLoadException ex)
             {
                 _log.WriteLine("Warning: Only got partial types from assembly: {0}", assembly.FullName);
+                _log.WriteLine($"The following loader failures occured when trying to load the assembly:");
+                string loaderFailuresMessage = string.Join(Environment.NewLine, ex.LoaderExceptions.Select(e => $"   - {e.Message}"));
+                _log.WriteLine(loaderFailuresMessage);
+
+                _log.WriteLine("This can occur if the assemblies listed above are missing, outdated or mismatched.");
+
                 _log.WriteLine("Exception message: {0}", ex.ToString());
 
                 // In case of a type load exception, at least get the types that did succeed in loading
-                types = ex.Types;
+                types = ex.Types.Where(t => t != null).ToArray();
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Resolves #1722
This improves the experience and allows proper identification of the root cause of issues #1681 #1715 and the issues listed in #1722

#### Logged message before the change:
```
Warning: Only got partial types from assembly: ClassLibrary1, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
Exception message: System.Reflection.ReflectionTypeLoadException: Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
   at System.Reflection.RuntimeModule.GetTypes(RuntimeModule module)
   at System.Reflection.Assembly.GetTypes()
   at Microsoft.Azure.WebJobs.Host.Indexers.DefaultTypeLocator.FindTypes(Assembly assembly, IEnumerable`1 extensionAssemblies) in C:\projects\azure-webjobs-sdk-rqm4t\src\Microsoft.Azure.WebJobs.Host\Indexers\DefaultTypeLocator.cs:line 120
```

#### After the changes:
```
Warning: Only got partial types from assembly: ClassLibrary1, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
The following loader failures occured when trying to load the assembly:
   - Could not load file or assembly 'ClassLibrary2, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null'. The system cannot find the file specified.
This can occur if the assemblies listed above are missing, outdated or mismatched.
Exception message: System.Reflection.ReflectionTypeLoadException: Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
   at System.Reflection.RuntimeModule.GetTypes(RuntimeModule module)
   at System.Reflection.Assembly.GetTypes()
   at Microsoft.Azure.WebJobs.Host.Indexers.DefaultTypeLocator.FindTypes(Assembly assembly, IEnumerable`1 extensionAssemblies) in C:\projects\azure-webjobs-sdk-rqm4t\src\Microsoft.Azure.WebJobs.Host\Indexers\DefaultTypeLocator.cs:line 120

```