### PR TITLE
Changes to ExtensionTypeProvider 

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Indexers/ExtensionTypeLocator.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Indexers/ExtensionTypeLocator.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
     {
         private readonly ITypeLocator _typeLocator;
         private IReadOnlyList<Type> _cloudBlobStreamBinderTypes;
+        private readonly static IReadOnlyList<Type> _emptyList = new List<Type>().AsReadOnly();
 
         public ExtensionTypeLocator(ITypeLocator typeLocator)
         {
@@ -22,43 +23,10 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
         }
 
         public IReadOnlyList<Type> GetCloudBlobStreamBinderTypes()
-        {
-            if (_cloudBlobStreamBinderTypes == null)
-            {
-                _cloudBlobStreamBinderTypes = GetCloudBlobStreamBinderTypes(_typeLocator.GetTypes());
-            }
-
-            return _cloudBlobStreamBinderTypes;
-        }
+            => _emptyList;
 
         // Search for any types that implement ICloudBlobStreamBinder<T>
         internal static IReadOnlyList<Type> GetCloudBlobStreamBinderTypes(IEnumerable<Type> types)
-        {
-            List<Type> cloudBlobStreamBinderTypes = new List<Type>();
-
-            foreach (Type type in types)
-            {
-                try
-                {
-                    foreach (Type interfaceType in type.GetInterfaces())
-                    {
-                        if (interfaceType.IsGenericType)
-                        {
-                            Type interfaceGenericDefinition = interfaceType.GetGenericTypeDefinition();
-
-                            if (interfaceGenericDefinition == typeof(ICloudBlobStreamBinder<>))
-                            {
-                                cloudBlobStreamBinderTypes.Add(type);
-                            }
-                        }
-                    }
-                }
-                catch
-                {
-                }
-            }
-
-            return cloudBlobStreamBinderTypes;
-        }
+            => _emptyList;
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AzureStorageEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AzureStorageEndToEndTests.cs
@@ -191,13 +191,13 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             await EndToEndTest(uploadBlobBeforeHostStart: false);
         }
 
-        [Fact]
+        [Fact(Skip = "This test relies on ICloudBlobStreamBinder<T> support, which has been removed. See https://github.com/Azure/azure-webjobs-sdk/issues/995")]
         public async Task AzureStorageEndToEndFast()
         {
             await EndToEndTest(uploadBlobBeforeHostStart: true);
         }
 
-        [Fact]
+        [Fact(Skip = "This test relies on ICloudBlobStreamBinder<T> support, which has been removed. See https://github.com/Azure/azure-webjobs-sdk/issues/995")]
         public async Task TableFilterTest()
         {
             // Reinitialize the name resolver to avoid conflicts
@@ -321,7 +321,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             await VerifyTableResultsAsync();
         }
 
-        [Fact]
+        [Fact(Skip = "This test relies on ICloudBlobStreamBinder<T> support, which has been removed. See https://github.com/Azure/azure-webjobs-sdk/issues/995")]
         public async Task BadQueueMessageE2ETests()
         {
             // This test ensures that the host does not crash on a bad message (it previously did)


### PR DESCRIPTION
Changes to ExtensionTypeProvider to avoid the use of the DefaultTypeProvider. Removal of the code path that loads ICloudBlobStreamBinder<T> implementations.

**THIS IS A TACTICAL CHANGE**. Proper fix should come after the hosting/DI changes land, and would be the removal of all deprecated interfaces (e.g. `IExtensionTypeProvider`, `ICloudBlobStreamBinder<T>`)