### PR TITLE
improving TestLogger against race conditions

### DIFF
--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/ILoggerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/ILoggerTests.cs
@@ -31,20 +31,21 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
             }
 
             // Six loggers are the startup, singleton, results, function and function.user
-            Assert.Equal(5, _loggerProvider.CreatedLoggers.Count);
+            Assert.Equal(5, _loggerProvider.CreatedLoggers.Count());
 
             var functionLogger = _loggerProvider.CreatedLoggers.Where(l => l.Category == LogCategories.CreateFunctionUserCategory(functionName)).Single();
             var resultsLogger = _loggerProvider.CreatedLoggers.Where(l => l.Category == LogCategories.Results).Single();
 
-            Assert.Equal(2, functionLogger.LogMessages.Count);
-            var infoMessage = functionLogger.LogMessages[0];
-            var errorMessage = functionLogger.LogMessages[1];
+            var messages = functionLogger.GetLogMessages();
+            Assert.Equal(2, messages.Count);
+            var infoMessage = messages[0];
+            var errorMessage = messages[1];
 
             // These get the {OriginalFormat} property as well as the 2 from structured log properties
             Assert.Equal(3, infoMessage.State.Count());
             Assert.Equal(3, errorMessage.State.Count());
 
-            Assert.Equal(1, resultsLogger.LogMessages.Count);
+            Assert.Equal(1, resultsLogger.GetLogMessages().Count);
 
             // TODO: beef these verifications up
         }
@@ -60,11 +61,12 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
             }
 
             // Five loggers are the startup, singleton, results, function and function.user
-            Assert.Equal(5, _loggerProvider.CreatedLoggers.Count);
+            Assert.Equal(5, _loggerProvider.CreatedLoggers.Count());
             var functionLogger = _loggerProvider.CreatedLoggers.Where(l => l.Category == LogCategories.CreateFunctionUserCategory(functionName)).Single();
-            Assert.Equal(2, functionLogger.LogMessages.Count);
-            var infoMessage = functionLogger.LogMessages[0];
-            var errorMessage = functionLogger.LogMessages[1];
+            var messages = functionLogger.GetLogMessages();
+            Assert.Equal(2, messages.Count);
+            var infoMessage = messages[0];
+            var errorMessage = messages[1];
 
             // These get the {OriginalFormat} only
             Assert.Single(infoMessage.State);

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/LogMessage.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/LogMessage.cs
@@ -10,11 +10,19 @@ namespace Microsoft.Azure.WebJobs.Host.TestCommon
     public class LogMessage
     {
         public LogLevel Level { get; set; }
+
         public EventId EventId { get; set; }
+
         public IEnumerable<KeyValuePair<string, object>> State { get; set; }
+
         public Exception Exception { get; set; }
+
         public string FormattedMessage { get; set; }
 
         public string Category { get; set; }
+
+        public DateTime Timestamp { get; set; }
+
+        public override string ToString() => $"[{Timestamp.ToString("HH:mm:ss.fff")}] [{Category}] {FormattedMessage} {Exception}";
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/TestLoggerProvider.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/TestLoggerProvider.cs
@@ -14,24 +14,37 @@ namespace Microsoft.Azure.WebJobs.Host.TestCommon
         private readonly Func<string, LogLevel, bool> _filter;
         private readonly Action<LogMessage> _logAction;
 
-        public IList<TestLogger> CreatedLoggers = new List<TestLogger>();
-
         public TestLoggerProvider(Func<string, LogLevel, bool> filter = null, Action<LogMessage> logAction = null)
         {
             _filter = filter ?? new LogCategoryFilter().Filter;
             _logAction = logAction;
         }
 
+        private Dictionary<string, TestLogger> LoggerCache { get; } = new Dictionary<string, TestLogger>();
+
+        public IEnumerable<TestLogger> CreatedLoggers => LoggerCache.Values;
+
         public ILogger CreateLogger(string categoryName)
         {
-            var logger = new TestLogger(categoryName, _filter, _logAction);
-            CreatedLoggers.Add(logger);
+            if (!LoggerCache.TryGetValue(categoryName, out TestLogger logger))
+            {
+                logger = new TestLogger(categoryName, _filter, _logAction);
+                LoggerCache.Add(categoryName, logger);
+            }
+
             return logger;
         }
 
-        public IEnumerable<LogMessage> GetAllLogMessages()
+        public IEnumerable<LogMessage> GetAllLogMessages() => CreatedLoggers.SelectMany(l => l.GetLogMessages()).OrderBy(p => p.Timestamp);
+
+        public string GetLogString() => string.Join(Environment.NewLine, GetAllLogMessages());
+
+        public void ClearAllLogMessages()
         {
-            return CreatedLoggers.SelectMany(l => l.LogMessages);
+            foreach (TestLogger logger in CreatedLoggers)
+            {
+                logger.ClearLogMessages();
+            }
         }
 
         public void Dispose()

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/FunctionExecutorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/FunctionExecutorTests.cs
@@ -333,7 +333,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             string message = string.Format("Timeout value of 00:01:00 exceeded by function 'Functions.MethodLevel' (Id: 'b2d1dd72-80e2-412b-a22e-3b4558f378b4'). {0}", expectedMessage);
 
             // verify ILogger
-            LogMessage log = logger.LogMessages.Single();
+            LogMessage log = logger.GetLogMessages().Single();
             Assert.Equal(LogLevel.Error, log.Level);
             Assert.Equal(message, log.FormattedMessage);
         }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Filters/FunctionFilterTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Filters/FunctionFilterTests.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             var logger = loggerProvider.CreatedLoggers.Single(p => p.Category == LogCategories.CreateFunctionCategory(nameof(MyProg3.Method2)));
 
             // strip out the 4 messages written by the executor ("Executing", FunctionStartedEvent, "Executed", FunctionCompletedEvent)
-            string logResult = string.Join("|", logger.LogMessages
+            string logResult = string.Join("|", logger.GetLogMessages()
                 .Where(p => p.EventId.Id == 0 && !p.FormattedMessage.StartsWith("Execut"))
                 .Select(p => p.FormattedMessage));
 

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Indexers/FunctionIndexerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Indexers/FunctionIndexerTests.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Indexers
 
             // Validate Logger
             var logger = loggerProvider.CreatedLoggers.Single(l => l.Category == Logging.LogCategories.Startup);
-            var loggerWarning = logger.LogMessages.Single();
+            var loggerWarning = logger.GetLogMessages().Single();
             Assert.Equal(LogLevel.Warning, loggerWarning.Level);
             Assert.Equal(expectedMessage, loggerWarning.FormattedMessage);
         }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostTests.cs
@@ -479,22 +479,23 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             Assert.Equal("BindingErrorsProgram.Invalid", fex.MethodName);
 
             // verify that the binding error was logged
-            Assert.Equal(5, errorLogger.LogMessages.Count);
-            LogMessage logMessage = errorLogger.LogMessages.ElementAt(0);
+            var messages = errorLogger.GetLogMessages();
+            Assert.Equal(5, messages.Count);
+            LogMessage logMessage = messages.ElementAt(0);
             Assert.Equal("Error indexing method 'BindingErrorsProgram.Invalid'", logMessage.FormattedMessage);
             Assert.Same(fex, logMessage.Exception);
             Assert.Equal("Invalid container name: invalid$=+1", logMessage.Exception.InnerException.Message);
-            logMessage = errorLogger.LogMessages.ElementAt(1);
+            logMessage = messages.ElementAt(1);
             Assert.Equal("Function 'BindingErrorsProgram.Invalid' failed indexing and will be disabled.", logMessage.FormattedMessage);
             Assert.Equal(Extensions.Logging.LogLevel.Warning, logMessage.Level);
 
             // verify that the valid function was still indexed
-            logMessage = errorLogger.LogMessages.ElementAt(2);
+            logMessage = messages.ElementAt(2);
             Assert.True(logMessage.FormattedMessage.Contains("Found the following functions"));
             Assert.True(logMessage.FormattedMessage.Contains("BindingErrorsProgram.Valid"));
 
             // verify that the job host was started successfully
-            logMessage = errorLogger.LogMessages.ElementAt(4);
+            logMessage = messages.ElementAt(4);
             Assert.Equal("Job host started", logMessage.FormattedMessage);
 
             host.Stop();

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Listeners/FunctionListenerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Listeners/FunctionListenerTests.cs
@@ -92,7 +92,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Listeners
         public async Task FunctionListener_BackgroundRetriesStopped_WhenListenerCancelled()
         {
             await RetryStopTestHelper(
-                (listener) => {
+                (listener) =>
+                {
                     listener.Cancel();
                     return Task.CompletedTask;
                 });
@@ -102,7 +103,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Listeners
         public async Task FunctionListener_BackgroundRetriesStopped_WhenListenerDisposed()
         {
             await RetryStopTestHelper(
-                (listener) => {
+                (listener) =>
+                {
                     listener.Dispose();
                     return Task.CompletedTask;
                 });
@@ -184,7 +186,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Listeners
             await TestHelpers.Await(() =>
             {
                 return Task.FromResult(stopCalled);
-            }, timeout: 4000, userMessage: "Listener not stopped.");
+            }, timeout: 4000, userMessageCallback: () => "Listener not stopped.");
 
             badListener.Verify(p => p.StartAsync(It.IsAny<CancellationToken>()), Times.Exactly(2));
             badListener.Verify(p => p.StopAsync(It.IsAny<CancellationToken>()), Times.Exactly(1));
@@ -233,7 +235,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Listeners
             var e = await Assert.ThrowsAsync<FunctionListenerException>(async () => await listener.StartAsync(ct));
 
             // Validate Logger
-            var loggerEx = _loggerProvider.CreatedLoggers.Single().LogMessages.Single().Exception as FunctionException;
+            var loggerEx = _loggerProvider.CreatedLoggers.Single().GetLogMessages().Single().Exception as FunctionException;
             Assert.Equal("testfunc", loggerEx.MethodName);
             Assert.False(loggerEx.Handled);
 
@@ -257,7 +259,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Listeners
             string expectedMessage = "The listener for function 'testfunc' was unable to start.";
 
             // Validate Logger
-            var logMessage = handlingLoggerProvider.CreatedLoggers.Single().LogMessages.Single();
+            var logMessage = handlingLoggerProvider.CreatedLoggers.Single().GetLogMessages().Single();
             Assert.Equal(expectedMessage, logMessage.FormattedMessage);
             var loggerEx = logMessage.Exception as FunctionException;
             Assert.Equal("testfunc", loggerEx.MethodName);
@@ -301,7 +303,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Listeners
             await listener.StartAsync(ct);
             await listener.StopAsync(ct);
 
-            Assert.Empty(_loggerProvider.CreatedLoggers.Single().LogMessages);
+            Assert.Empty(_loggerProvider.CreatedLoggers.Single().GetLogMessages());
 
             goodListener.VerifyAll();
         }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Listeners/HostListenerFactoryTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Listeners/HostListenerFactoryTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Listeners
             string expectedMessage = $"Function '{descriptor.ShortName}' is disabled";
 
             // Validate Logger
-            var logMessage = loggerProvider.CreatedLoggers.Single().LogMessages.Single();
+            var logMessage = loggerProvider.CreatedLoggers.Single().GetLogMessages().Single();
             Assert.Equal(LogLevel.Information, logMessage.Level);
             Assert.Equal(Logging.LogCategories.Startup, logMessage.Category);
             Assert.Equal(expectedMessage, logMessage.FormattedMessage);

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Singleton/SingletonManagerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Singleton/SingletonManagerTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Singleton
                 return null;
             }
             return (SingletonLockHandle)handle.InnerLock;
-    }
+        }
     }
 
     public class SingletonManagerTests
@@ -204,9 +204,10 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Singleton
             // verify the logger
             TestLogger logger = _loggerProvider.CreatedLoggers.Single() as TestLogger;
             Assert.Equal(LogCategories.Singleton, logger.Category);
-            Assert.Equal(2, logger.LogMessages.Count);
-            Assert.NotNull(logger.LogMessages.Single(m => m.Level == Extensions.Logging.LogLevel.Debug && m.FormattedMessage == "Singleton lock acquired (testid)"));
-            Assert.NotNull(logger.LogMessages.Single(m => m.Level == Extensions.Logging.LogLevel.Debug && m.FormattedMessage == "Singleton lock released (testid)"));
+            var messages = logger.GetLogMessages();
+            Assert.Equal(2, messages.Count);
+            Assert.NotNull(messages.Single(m => m.Level == Extensions.Logging.LogLevel.Debug && m.FormattedMessage == "Singleton lock acquired (testid)"));
+            Assert.NotNull(messages.Single(m => m.Level == Extensions.Logging.LogLevel.Debug && m.FormattedMessage == "Singleton lock released (testid)"));
 
             renewCount = 0;
             await Task.Delay(1000);


### PR DESCRIPTION
This fixes some flakiness while reading from log collections while they may still be getting populated by the host. We've fixed this in other branches and must have missed it here.