### PR TITLE
removing e2e test race condition

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,7 @@ branches:
   - master
   - next
 image: Visual Studio 2017
+max_jobs: 1
 install:
 - ps: |
     $env:CommitHash = "$env:APPVEYOR_REPO_COMMIT"

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncChainEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncChainEndToEndTests.cs
@@ -431,15 +431,14 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         }
 
         [NoAutomaticTrigger]
-        public static async Task WriteStartDataMessageToQueue(
-            [Queue(Queue1Name)] ICollector<string> queueMessages,
-            [Blob(ContainerName + "/" + NonWebJobsBlobName, FileAccess.Write)] Stream nonSdkBlob,
-            CancellationToken token)
+        public static void WriteStartDataMessageToQueue(
+            [Queue(Queue1Name)] out string queueMessage,
+            [Blob(ContainerName + "/" + NonWebJobsBlobName, FileAccess.Write)] Stream nonSdkBlob)
         {
-            queueMessages.Add(" works");
+            queueMessage = " works";
 
             byte[] messageBytes = Encoding.UTF8.GetBytes("async");
-            await nonSdkBlob.WriteAsync(messageBytes, 0, messageBytes.Length);
+            nonSdkBlob.Write(messageBytes, 0, messageBytes.Length);
         }
 
         [NoAutomaticTrigger]
@@ -499,6 +498,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             CloudBlobClient blobClient = _storageAccount.CreateCloudBlobClient();
             CloudBlobContainer container = blobClient.GetContainerReference(_resolver.ResolveInString(ContainerName));
             CloudBlockBlob blob = container.GetBlockBlobReference(NonWebJobsBlobName);
+
             string blobContent = await blob.DownloadTextAsync();
 
             trace.Info("User TraceWriter log 1");


### PR DESCRIPTION
In the `AsyncChain...` e2e tests, there are two tests in the chain that go:

1. Add message to queue and write blob.
2. Trigger off of queue message inserted in 1 and read blob from 1.

Because the queue message was inserted first, there was a chance that the next function started before the blob write had completed. That function could throw a 404 on the missing blob and then re-run successfully. For most of the e2e tests, this was fine as they only cared whether the full chain of functions completed successfully. However, the `AggregatorOnly` test was looking at the aggregation events. It'd see that failed-and-retried function and fail because it was unexpected.

Branch `v2.x` has this same problem. Will be following up there as well.