### PR TITLE
improving TestTraceWriter

### DIFF
--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncChainEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncChainEndToEndTests.cs
@@ -210,12 +210,12 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
                 await host.StopAsync();
 
-                bool hasError = string.Join(Environment.NewLine, trace.Traces.Where(p => p.Message.Contains("Error"))).Any();
+                bool hasError = string.Join(Environment.NewLine, trace.GetTraces().Where(p => p.Message.Contains("Error"))).Any();
                 Assert.False(hasError);
 
-                Assert.NotNull(trace.Traces.SingleOrDefault(p => p.Message.Contains("User TraceWriter log")));
-                Assert.NotNull(trace.Traces.SingleOrDefault(p => p.Message.Contains("User TextWriter log (TestParam)")));
-                Assert.NotNull(trace.Traces.SingleOrDefault(p => p.Message.Contains("Another User TextWriter log")));
+                Assert.NotNull(trace.GetTraces().SingleOrDefault(p => p.Message.Contains("User TraceWriter log")));
+                Assert.NotNull(trace.GetTraces().SingleOrDefault(p => p.Message.Contains("User TextWriter log (TestParam)")));
+                Assert.NotNull(trace.GetTraces().SingleOrDefault(p => p.Message.Contains("Another User TextWriter log")));
                 ValidateTraceProperties(trace);
 
                 string[] consoleOutputLines = consoleOutput.ToString().Trim().Split(new string[] { Environment.NewLine }, StringSplitOptions.None);
@@ -340,7 +340,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
         private void ValidateTraceProperties(TestTraceWriter trace)
         {
-            foreach (var traceEvent in trace.Traces)
+            foreach (var traceEvent in trace.GetTraces())
             {
                 var message = traceEvent.Message;
                 var startedOrEndedMessage = message.StartsWith("Executing ") || message.StartsWith("Executed ");
@@ -395,7 +395,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
             // Validate TraceWriter
             // We expect 3 error messages total
-            TraceEvent[] traceErrors = trace.Traces.Where(p => p.Level == TraceLevel.Error).ToArray();
+            TraceEvent[] traceErrors = trace.GetTraces().Where(p => p.Level == TraceLevel.Error).ToArray();
             Assert.Equal(3, traceErrors.Length);
 
             // Ensure that all errors include the same exception, with function
@@ -505,7 +505,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
             // Validate TraceWriter
             // We expect 3 error messages total
-            TraceEvent[] traceErrors = trace.Traces.Where(p => p.Level == TraceLevel.Error).ToArray();
+            TraceEvent[] traceErrors = trace.GetTraces().Where(p => p.Level == TraceLevel.Error).ToArray();
             Assert.Equal(3, traceErrors.Length);
             Assert.StartsWith(expectedExceptionMessage, traceErrors[0].Message);
             Assert.StartsWith(expectedResultMessage, traceErrors[1].Message);
@@ -532,7 +532,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             await host.CallAsync(methodInfo);
 
             // Validate TraceWriter
-            TraceEvent[] traceErrors = trace.Traces.Where(p => p.Level == TraceLevel.Error).ToArray();
+            TraceEvent[] traceErrors = trace.GetTraces().Where(p => p.Level == TraceLevel.Error).ToArray();
             Assert.Equal(0, traceErrors.Length);
 
             // Validate Logger
@@ -562,9 +562,9 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     await Task.Delay(3000);
 
                     // expect no function output
-                    TraceEvent[] traces = trace.Traces.ToArray();
-                    string failureMessage = $"{Environment.NewLine}{string.Join(Environment.NewLine, trace.Traces)}";
-                    Assert.True(traces.Length == 4, $"Expected 4 traces. Actual {traces.Length}.{failureMessage}");
+                    var traces = trace.GetTraces();
+                    string failureMessage = $"{Environment.NewLine}{string.Join(Environment.NewLine, traces)}";
+                    Assert.True(traces.Count == 4, $"Expected 4 traces. Actual {traces.Count}.{failureMessage}");
                     Assert.False(traces.Any(p => p.Message.Contains("test message")), $"Did not expect to see 'test message' in a trace.{failureMessage}");
                 }
             }
@@ -597,8 +597,8 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     await Task.Delay(3000);
 
                     // expect normal logs to be written (TraceLevel override is ignored)
-                    TraceEvent[] traces = trace.Traces.ToArray();
-                    Assert.Equal(9, traces.Length);
+                    var traces = trace.GetTraces();
+                    Assert.Equal(9, traces.Count);
 
                     string output = string.Join("\r\n", traces.Select(p => p.Message));
                     Assert.Contains("Executing 'AsyncChainEndToEndTests.QueueTrigger_TraceLevelOverride' (Reason='New queue message detected", output);

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AzureStorageEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AzureStorageEndToEndTests.cs
@@ -412,7 +412,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             Assert.Equal(0, _badMessage2Calls);
 
             // make sure the exception is being properly logged
-            var errors = tracer.Traces.Where(t => t.Level == TraceLevel.Error);
+            var errors = tracer.GetTraces().Where(t => t.Level == TraceLevel.Error);
             Assert.True(errors.All(t => t.Exception.InnerException.InnerException is FormatException));
 
             // Validate Logger

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ServiceBusEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ServiceBusEndToEndTests.cs
@@ -180,8 +180,8 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
                 // in addition to verifying that our custom processor was called, we're also
                 // verifying here that extensions can log to the TraceWriter
-                Assert.Equal(4, trace.Traces.Count(p => p.Message.Contains("Custom processor Begin called!")));
-                Assert.Equal(4, trace.Traces.Count(p => p.Message.Contains("Custom processor End called!")));
+                Assert.Equal(4, trace.GetTraces().Count(p => p.Message.Contains("Custom processor Begin called!")));
+                Assert.Equal(4, trace.GetTraces().Count(p => p.Message.Contains("Custom processor End called!")));
             }
             finally
             {

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/DispatchQueueTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/DispatchQueueTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
                 ThrowsAsync(new Exception(error));
 
             await _sharedQueue.InitializeAsync(CancellationToken.None);
-            Assert.Empty(_trace.Traces);
+            Assert.Empty(_trace.GetTraces());
 
 
             // listenercontext should return inMemoryDispatchQueueHandler when there's no storage account
@@ -99,8 +99,8 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
 
             var dispatchQueue = context.GetDispatchQueue(messageHandlerMock.Object);
             // make sure initialization error is traced
-            Assert.Equal(error, _trace.Traces[0].Exception.Message);
-            Assert.Equal(SharedQueueHandler.InitErrorMessage, _trace.Traces[0].Message);
+            Assert.Equal(error, _trace.GetTraces()[0].Exception.Message);
+            Assert.Equal(SharedQueueHandler.InitErrorMessage, _trace.GetTraces()[0].Message);
             Assert.IsType<InMemoryDispatchQueueHandler>(dispatchQueue);
 
             await dispatchQueue.EnqueueAsync(JObject.Parse("{}"), CancellationToken.None);

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/ILoggerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/ILoggerTests.cs
@@ -55,10 +55,10 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
                 host.Call(method);
             }
 
-            Assert.Equal(6, _trace.Traces.Count);
+            Assert.Equal(6, _trace.GetTraces().Count);
             // The fourth and fifth traces are from our function
-            var infoLog = _trace.Traces[3];
-            var errorLog = _trace.Traces[4];
+            var infoLog = _trace.GetTraces()[3];
+            var errorLog = _trace.GetTraces()[4];
 
             Assert.Equal("This should go to the ILogger", infoLog.Message);
             Assert.Null(infoLog.Exception);

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/TestTraceWriter.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/TestTraceWriter.cs
@@ -1,26 +1,55 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Linq;
 
 namespace Microsoft.Azure.WebJobs.Host.TestCommon
 {
     public class TestTraceWriter : TraceWriter
     {
-        public Collection<TraceEvent> Traces = new Collection<TraceEvent>();
-        private object _syncLock = new object();
+        private Collection<TraceEvent> _traces = new Collection<TraceEvent>();
+        private object _syncObject = new object();
 
         public TestTraceWriter(TraceLevel level) : base(level)
         {
         }
 
+        public bool Flushed { get; private set; }
+
+        // Don't allow direct access to the underlying _traces as they can be modified
+        // while callers are enumerating, resulted in a 'Collection was modified' exception.
+        public IList<TraceEvent> GetTraces()
+        {
+            lock (_syncObject)
+            {
+                return _traces.ToList();
+            }
+        }
+
+        public void ClearTraces()
+        {
+            lock (_syncObject)
+            {
+                _traces.Clear();
+            }
+        }
+
         public override void Trace(TraceEvent traceEvent)
         {
-            lock (_syncLock)
+            lock (_syncObject)
             {
-                Traces.Add(traceEvent);
+                _traces.Add(traceEvent);
             }
+        }
+
+        public override void Flush()
+        {
+            Flushed = true;
+
+            base.Flush();
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Bindings/TraceWriter/TextWriterTraceAdapterTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Bindings/TraceWriter/TextWriterTraceAdapterTests.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Bindings
 
             await Task.WhenAll(tasks);
 
-            Assert.Equal(1000, trace.Traces.Count);
+            Assert.Equal(1000, trace.GetTraces().Count);
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/CompositeTraceWriterTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/CompositeTraceWriterTests.cs
@@ -107,18 +107,18 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             var traceWriter = new CompositeTraceWriter(traceWriters, textWriter);
 
             traceWriter.Info("Test");
-            Assert.Equal(1, t1.Traces.Count);
-            Assert.Equal(1, t2.Traces.Count);
+            Assert.Equal(1, t1.GetTraces().Count);
+            Assert.Equal(1, t2.GetTraces().Count);
             Assert.Equal(1, textWriter.ToString().Split(new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries).Length);
 
             var t3 = new TestTraceWriter(TraceLevel.Verbose);
             traceWriters.Add(t3);
 
             traceWriter.Info("Test");
-            Assert.Equal(2, t1.Traces.Count);
-            Assert.Equal(2, t2.Traces.Count);
+            Assert.Equal(2, t1.GetTraces().Count);
+            Assert.Equal(2, t2.GetTraces().Count);
             Assert.Equal(2, textWriter.ToString().Split(new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries).Length);
-            Assert.Equal(0, t3.Traces.Count);
+            Assert.Equal(0, t3.GetTraces().Count);
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/FunctionExecutorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/FunctionExecutorTests.cs
@@ -336,7 +336,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             string message = string.Format("Timeout value of 00:01:00 exceeded by function 'Functions.MethodLevel' (Id: 'b2d1dd72-80e2-412b-a22e-3b4558f378b4'). {0}", expectedMessage);
 
             // verify TraceWriter
-            TraceEvent trace = _traceWriter.Traces[0];
+            TraceEvent trace = _traceWriter.GetTraces()[0];
             Assert.Equal(TraceLevel.Error, trace.Level);
             Assert.Equal(TraceSource.Execution, trace.Source);
             Assert.Equal(message, trace.Message);

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/FunctionInstanceTraceWriterTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/FunctionInstanceTraceWriterTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
 
             var instanceWriter = new FunctionInstanceTraceWriter(instance, hostInstanceId, writer, functionTraceLevel);
             instanceWriter.Info("Test Info");
-            var traceEvent = writer.Traces.Single();
+            var traceEvent = writer.GetTraces().Single();
 
             Assert.Equal(4, traceEvent.Properties.Count);
             Assert.Equal(instance.Id, traceEvent.Properties["MS_FunctionInvocationId"]);

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Indexers/FunctionIndexerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Indexers/FunctionIndexerTests.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Indexers
             string expectedMessage = "Function 'ReturnAsyncVoid' is async but does not return a Task. Your function may not run correctly.";
 
             // Validate TraceWriter
-            var traceWarning = traceWriter.Traces.First(p => p.Level == TraceLevel.Warning);
+            var traceWarning = traceWriter.GetTraces().First(p => p.Level == TraceLevel.Warning);
             Assert.Equal(expectedMessage, traceWarning.Message);
 
             // Validate Logger

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostTests.cs
@@ -491,23 +491,23 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             Assert.Equal("BindingErrorsProgram.Invalid", fex.MethodName);
 
             // verify that the binding error was logged
-            Assert.Equal(6, traceWriter.Traces.Count);
-            TraceEvent traceEvent = traceWriter.Traces[0];
+            Assert.Equal(6, traceWriter.GetTraces().Count);
+            TraceEvent traceEvent = traceWriter.GetTraces()[0];
             Assert.Equal("Error indexing method 'BindingErrorsProgram.Invalid'", traceEvent.Message);
             Assert.Equal(TraceLevel.Error, traceEvent.Level);
             Assert.Same(fex, traceEvent.Exception);
             Assert.Equal("Invalid container name: invalid$=+1", traceEvent.Exception.InnerException.Message);
-            traceEvent = traceWriter.Traces[1];
+            traceEvent = traceWriter.GetTraces()[1];
             Assert.Equal("Function 'BindingErrorsProgram.Invalid' failed indexing and will be disabled.", traceEvent.Message);
             Assert.Equal(TraceLevel.Warning, traceEvent.Level);
 
             // verify that the valid function was still indexed
-            traceEvent = traceWriter.Traces[2];
+            traceEvent = traceWriter.GetTraces()[2];
             Assert.True(traceEvent.Message.Contains("Found the following functions"));
             Assert.True(traceEvent.Message.Contains("BindingErrorsProgram.Valid"));
 
             // verify that the job host was started successfully
-            traceEvent = traceWriter.Traces[5];
+            traceEvent = traceWriter.GetTraces()[5];
             Assert.Equal("Job host started", traceEvent.Message);
 
             host.Stop();

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Listeners/HostListenerFactoryTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Listeners/HostListenerFactoryTests.cs
@@ -64,10 +64,10 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Listeners
             string expectedMessage = $"Function '{descriptor.ShortName}' is disabled";
 
             // Validate TraceWriter
-            Assert.Equal(1, traceWriter.Traces.Count);
-            Assert.Equal(TraceLevel.Info, traceWriter.Traces[0].Level);
-            Assert.Equal(TraceSource.Host, traceWriter.Traces[0].Source);
-            Assert.Equal(expectedMessage, traceWriter.Traces[0].Message);
+            Assert.Equal(1, traceWriter.GetTraces().Count);
+            Assert.Equal(TraceLevel.Info, traceWriter.GetTraces()[0].Level);
+            Assert.Equal(TraceSource.Host, traceWriter.GetTraces()[0].Source);
+            Assert.Equal(expectedMessage, traceWriter.GetTraces()[0].Message);
 
             // Validate Logger
             var logMessage = loggerProvider.CreatedLoggers.Single().GetLogMessages().Single();

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/TraceWriterFunctionInstanceLoggerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/TraceWriterFunctionInstanceLoggerTests.cs
@@ -39,8 +39,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
 
             await _logger.LogFunctionStartedAsync(message, CancellationToken.None);
 
-            Assert.Equal(1, _traceWriter.Traces.Count);
-            TraceEvent traceEvent = _traceWriter.Traces[0];
+            Assert.Equal(1, _traceWriter.GetTraces().Count);
+            TraceEvent traceEvent = _traceWriter.GetTraces()[0];
             Assert.Equal(TraceLevel.Info, traceEvent.Level);
             Assert.Equal(Host.TraceSource.Execution, traceEvent.Source);
             Assert.Equal(string.Format("Executing 'TestJob' (Reason='TestReason', Id={0})", message.FunctionInstanceId), traceEvent.Message);
@@ -78,9 +78,9 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             await _logger.LogFunctionCompletedAsync(successMessage, CancellationToken.None);
             await _logger.LogFunctionCompletedAsync(failureMessage, CancellationToken.None);
 
-            Assert.Equal(3, _traceWriter.Traces.Count);
+            Assert.Equal(3, _traceWriter.GetTraces().Count);
 
-            TraceEvent traceEvent = _traceWriter.Traces[0];
+            TraceEvent traceEvent = _traceWriter.GetTraces()[0];
             Assert.Equal(TraceLevel.Info, traceEvent.Level);
             Assert.Equal(Host.TraceSource.Execution, traceEvent.Source);
             Assert.Equal(string.Format("Executed 'TestJob' (Succeeded, Id={0})", successMessage.FunctionInstanceId), traceEvent.Message);
@@ -88,7 +88,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             Assert.Equal(successMessage.FunctionInstanceId, traceEvent.Properties["MS_FunctionInvocationId"]);
             Assert.Same(successMessage.Function, traceEvent.Properties["MS_FunctionDescriptor"]);
 
-            traceEvent = _traceWriter.Traces[1];
+            traceEvent = _traceWriter.GetTraces()[1];
             Assert.Equal(TraceLevel.Error, traceEvent.Level);
             Assert.Equal(Host.TraceSource.Execution, traceEvent.Source);
             Assert.Equal(string.Format("Executed 'TestJob' (Failed, Id={0})", failureMessage.FunctionInstanceId), traceEvent.Message);
@@ -97,7 +97,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             Assert.Equal(failureMessage.FunctionInstanceId, traceEvent.Properties["MS_FunctionInvocationId"]);
             Assert.Same(failureMessage.Function, traceEvent.Properties["MS_FunctionDescriptor"]);
 
-            traceEvent = _traceWriter.Traces[2];
+            traceEvent = _traceWriter.GetTraces()[2];
             Assert.Equal(TraceLevel.Error, traceEvent.Level);
             Assert.Equal(Host.TraceSource.Host, traceEvent.Source);
             Assert.Equal("  Function had errors. See Azure WebJobs SDK dashboard for details. Instance ID is '8d71c9e3-e809-4cfb-bb78-48ae25c7d26d'", traceEvent.Message);

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Singleton/SingletonManagerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Singleton/SingletonManagerTests.cs
@@ -205,8 +205,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Singleton
             await _singletonManager.ReleaseLockAsync(lockHandle, cancellationToken);
 
             // verify the traces
-            Assert.Equal(1, _trace.Traces.Count(p => p.ToString().Contains("Verbose Singleton lock acquired (testid)")));
-            Assert.Equal(1, _trace.Traces.Count(p => p.ToString().Contains("Verbose Singleton lock released (testid)")));
+            Assert.Equal(1, _trace.GetTraces().Count(p => p.ToString().Contains("Verbose Singleton lock acquired (testid)")));
+            Assert.Equal(1, _trace.GetTraces().Count(p => p.ToString().Contains("Verbose Singleton lock released (testid)")));
 
             // verify the logger
             TestLogger logger = _loggerProvider.CreatedLoggers.Single() as TestLogger;

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Config/EventHubConfigurationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Config/EventHubConfigurationTests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Config
             handler.Method.Invoke(handler.Target, new object[] { null, args });
 
             string expectedMessage = "EventProcessorHost error (Action=Testing)";
-            var trace = traceWriter.Traces.Last();
+            var trace = traceWriter.GetTraces().Last();
             Assert.Equal(expectedMessage, trace.Message);
             Assert.Same(ex, trace.Exception);
 

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Config/ServiceBusExtensionConfigTests.cs
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Config/ServiceBusExtensionConfigTests.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Config
             handler.Method.Invoke(handler.Target, new object[] { null, args });
 
             string expectedMessage = "MessageReceiver error (Action=Testing)";
-            var trace = traceWriter.Traces.Last();
+            var trace = traceWriter.GetTraces().Last();
             Assert.Equal(expectedMessage, trace.Message);
             Assert.Same(ex, trace.Exception);
 

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/UtilityTests.cs
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/UtilityTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests
             Utility.LogExceptionReceivedEvent(e, "Test", _traceWriter, _loggerFactory);
 
             var expectedMessage = $"Test error (Action=Complete)";
-            var traceEvent = _traceWriter.Traces.Single();
+            var traceEvent = _traceWriter.GetTraces().Single();
             Assert.Equal(TraceLevel.Error, traceEvent.Level);
             Assert.Same(ex, traceEvent.Exception);
             Assert.Equal(expectedMessage, traceEvent.Message);
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests
             Utility.LogExceptionReceivedEvent(e, "Test", _traceWriter, _loggerFactory);
 
             var expectedMessage = $"Test error (Action=Connect)";
-            var traceEvent = _traceWriter.Traces.Single();
+            var traceEvent = _traceWriter.GetTraces().Single();
             Assert.Equal(TraceLevel.Verbose, traceEvent.Level);
             Assert.Equal($"{expectedMessage} : {ex.ToString()}", traceEvent.Message);
             Assert.Same(ex, traceEvent.Exception);
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests
             Utility.LogExceptionReceivedEvent(e, "Test", _traceWriter, _loggerFactory);
 
             var expectedMessage = $"Test error (Action=Receive)";
-            var traceEvent = _traceWriter.Traces.Single();
+            var traceEvent = _traceWriter.GetTraces().Single();
             Assert.Equal(TraceLevel.Verbose, traceEvent.Level);
             Assert.Equal($"{expectedMessage} : {ex.ToString()}", traceEvent.Message);
             Assert.Same(ex, traceEvent.Exception);
@@ -96,7 +96,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests
             Utility.LogExceptionReceivedEvent(e, "Test", _traceWriter, _loggerFactory);
 
             var expectedMessage = $"Test error (Action=Unknown)";
-            var traceEvent = _traceWriter.Traces.Single();
+            var traceEvent = _traceWriter.GetTraces().Single();
             Assert.Equal(TraceLevel.Error, traceEvent.Level);
             Assert.Same(ex, traceEvent.Exception);
             Assert.Equal(expectedMessage, traceEvent.Message);


### PR DESCRIPTION
`TestTraceWriter` had similar issues to `TestLogger` -- it'd occasionally throw when enumerating and adding from different threads simultaneously. Example: https://ci.appveyor.com/project/appsvc/azure-webjobs-sdk-rqm4t/build/11349/tests

This pulls the changes made a while back to `TestTraceWriter` in `azure-functions-host`: https://github.com/Azure/azure-functions-host/blob/ba9c1fdb921ac75ef7320da3cb2cdc5fb8e7fbde/test/WebJobs.Script.Tests.Shared/TestTraceWriter.cs