### PR TITLE
ServiceBus MessageReceiver/MessageSender bindings (#1743)

### DIFF
--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/MessageSenderArgumentBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/MessageSenderArgumentBindingProvider.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.ServiceBus.Core;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+
+namespace Microsoft.Azure.WebJobs.ServiceBus.Bindings
+{
+    internal class MessageSenderArgumentBindingProvider : IQueueArgumentBindingProvider
+    {
+        public IArgumentBinding<ServiceBusEntity> TryCreate(ParameterInfo parameter)
+        {
+            if (parameter.ParameterType != typeof(MessageSender))
+            {
+                return null;
+            }
+
+            return new MessageSenderArgumentBinding();
+        }
+
+        internal class MessageSenderArgumentBinding : IArgumentBinding<ServiceBusEntity>
+        {
+            public Type ValueType
+            {
+                get { return typeof(MessageSender); }
+            }
+
+            public Task<IValueProvider> BindAsync(ServiceBusEntity value, ValueBindingContext context)
+            {
+                if (context == null)
+                {
+                    throw new ArgumentNullException("context");
+                }
+
+                IValueProvider provider = new MessageSenderValueBinder(value.MessageSender);
+
+                return Task.FromResult(provider);
+            }
+
+            private class MessageSenderValueBinder : IValueBinder
+            {
+                private readonly MessageSender _messageSender;
+
+                public MessageSenderValueBinder(MessageSender messageSender)
+                {
+                    _messageSender = messageSender;
+                }
+
+                public BindStepOrder StepOrder
+                {
+                    get { return BindStepOrder.Enqueue; }
+                }
+
+                public Type Type
+                {
+                    get { return typeof(MessageSender); }
+                }
+
+                public Task<object> GetValueAsync()
+                {
+                    return Task.FromResult<object>(_messageSender);
+                }
+
+                public string ToInvokeString()
+                {
+                    return _messageSender.Path;
+                }
+
+                public Task SetValueAsync(object value, CancellationToken cancellationToken)
+                {
+                    return Task.CompletedTask;
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/ServiceBusAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/ServiceBusAttributeBindingProvider.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Bindings
     {
         private static readonly IQueueArgumentBindingProvider InnerProvider =
             new CompositeArgumentBindingProvider(
+                new MessageSenderArgumentBindingProvider(),
                 new MessageArgumentBindingProvider(),
                 new StringArgumentBindingProvider(),
                 new ByteArrayArgumentBindingProvider(),
@@ -67,7 +68,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Bindings
 
             ServiceBusAccount account = new ServiceBusAccount(_config, attribute);
 
-            IBinding binding = new ServiceBusBinding(parameter.Name, argumentBinding, account, path, attribute);
+            IBinding binding = new ServiceBusBinding(parameter.Name, argumentBinding, account, _config, path, attribute);
             return Task.FromResult<IBinding>(binding);
         }
 

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/StringToServiceBusEntityConverter.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Bindings/StringToServiceBusEntityConverter.cs
@@ -13,12 +13,14 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Bindings
         private readonly ServiceBusAccount _account;
         private readonly IBindableServiceBusPath _defaultPath;
         private readonly EntityType _entityType;
+        private readonly MessagingProvider _messagingProvider;
 
-        public StringToServiceBusEntityConverter(ServiceBusAccount account, IBindableServiceBusPath defaultPath, EntityType entityType)
+        public StringToServiceBusEntityConverter(ServiceBusAccount account, IBindableServiceBusPath defaultPath, EntityType entityType, MessagingProvider messagingProvider)
         {
             _account = account;
             _defaultPath = defaultPath;
             _entityType = entityType;
+            _messagingProvider = messagingProvider;
         }
 
         public Task<ServiceBusEntity> ConvertAsync(string input, CancellationToken cancellationToken)
@@ -36,7 +38,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Bindings
             }
 
             cancellationToken.ThrowIfCancellationRequested();
-            var messageSender = new MessageSender(_account.ConnectionString, queueOrTopicName);
+            var messageSender = _messagingProvider.CreateMessageSender(queueOrTopicName, _account.ConnectionString);
 
             var entity = new ServiceBusEntity
             {

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Listeners/ServiceBusListener.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Listeners/ServiceBusListener.cs
@@ -35,6 +35,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
             _messageProcessor = config.MessagingProvider.CreateMessageProcessor(entityPath, _serviceBusAccount.ConnectionString);
         }
 
+        internal MessageReceiver Receiver => _receiver;
+
         public Task StartAsync(CancellationToken cancellationToken)
         {
             ThrowIfDisposed();

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Bindings/ServiceBusTriggerBindingTests.cs
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/Bindings/ServiceBusTriggerBindingTests.cs
@@ -8,6 +8,7 @@ using System.Text;
 using Microsoft.Azure.WebJobs.ServiceBus.Triggers;
 using Microsoft.Azure.ServiceBus;
 using Xunit;
+using Microsoft.Azure.ServiceBus.Core;
 
 namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Bindings
 {
@@ -18,9 +19,10 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Bindings
         {
             IReadOnlyDictionary<string, Type> argumentContract = null;
             var bindingDataContract = ServiceBusTriggerBinding.CreateBindingDataContract(argumentContract);
-            Assert.Equal(12, bindingDataContract.Count);
+            Assert.Equal(14, bindingDataContract.Count);
             Assert.Equal(bindingDataContract["DeliveryCount"], typeof(int));
             Assert.Equal(bindingDataContract["DeadLetterSource"], typeof(string));
+            Assert.Equal(bindingDataContract["LockToken"], typeof(string));
             Assert.Equal(bindingDataContract["ExpiresAtUtc"], typeof(DateTime));
             Assert.Equal(bindingDataContract["EnqueuedTimeUtc"], typeof(DateTime));
             Assert.Equal(bindingDataContract["MessageId"], typeof(string));
@@ -31,6 +33,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Bindings
             Assert.Equal(bindingDataContract["Label"], typeof(string));
             Assert.Equal(bindingDataContract["CorrelationId"], typeof(string));
             Assert.Equal(bindingDataContract["UserProperties"], typeof(IDictionary<string, object>));
+            Assert.Equal(bindingDataContract["MessageReceiver"], typeof(MessageReceiver));
 
             // verify that argument binding values override built ins
             argumentContract = new Dictionary<string, Type>
@@ -39,7 +42,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Bindings
                 { "NewProperty", typeof(decimal) }
             };
             bindingDataContract = ServiceBusTriggerBinding.CreateBindingDataContract(argumentContract);
-            Assert.Equal(13, bindingDataContract.Count);
+            Assert.Equal(15, bindingDataContract.Count);
             Assert.Equal(bindingDataContract["DeliveryCount"], typeof(string));
             Assert.Equal(bindingDataContract["NewProperty"], typeof(decimal));
         }
@@ -47,22 +50,29 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Bindings
         [Fact]
         public void CreateBindingData_ReturnsExpectedValue()
         {
-            Message message = new Message(Encoding.UTF8.GetBytes("Test Message"));
-            message.ReplyTo = "test-queue";
-            message.To = "test";
-            message.ContentType = "application/json";
-            message.Label = "test label";
-            message.CorrelationId = Guid.NewGuid().ToString();
+            Message message = new Message(Encoding.UTF8.GetBytes("Test Message"))
+            {
+                ReplyTo = "test-queue",
+                To = "test",
+                ContentType = "application/json",
+                Label = "test label",
+                CorrelationId = Guid.NewGuid().ToString(),
+            };
+
             IReadOnlyDictionary<string, object> valueBindingData = null;
-            var bindingData = ServiceBusTriggerBinding.CreateBindingData(message, valueBindingData);
-            Assert.Equal(7, bindingData.Count);
+            var config = new ServiceBusConfiguration();
+            var messageReceiver = new MessageReceiver(config.ConnectionString, "test");
+            var bindingData = ServiceBusTriggerBinding.CreateBindingData(message, messageReceiver, valueBindingData);
+            Assert.Equal(9, bindingData.Count);
             Assert.Equal(message.ReplyTo, bindingData["ReplyTo"]);
+            Assert.Equal(string.Empty, bindingData["lockToken"]);
             Assert.Equal(message.To, bindingData["To"]);
             Assert.Equal(message.MessageId, bindingData["MessageId"]);
             Assert.Equal(message.ContentType, bindingData["ContentType"]);
             Assert.Equal(message.Label, bindingData["Label"]);
             Assert.Equal(message.CorrelationId, bindingData["CorrelationId"]);
             Assert.Same(message.UserProperties, bindingData["UserProperties"]);
+            Assert.Same(messageReceiver, bindingData["MessageReceiver"]);
 
             // verify that value binding data overrides built ins
             valueBindingData = new Dictionary<string, object>
@@ -70,8 +80,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Bindings
                 { "ReplyTo",  "override" },
                 { "NewProperty", 123 }
             };
-            bindingData = ServiceBusTriggerBinding.CreateBindingData(message, valueBindingData);
-            Assert.Equal(8, bindingData.Count);
+            bindingData = ServiceBusTriggerBinding.CreateBindingData(message, messageReceiver, valueBindingData);
+            Assert.Equal(10, bindingData.Count);
             Assert.Equal("override", bindingData["ReplyTo"]);
             Assert.Equal(123, bindingData["NewProperty"]);
         }

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/MessagingProviderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/MessagingProviderTests.cs
@@ -1,17 +1,14 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-using System.Threading.Tasks;
 using Xunit;
-using Microsoft.Azure.ServiceBus.Core;
 
 namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests
 {
     public class MessagingProviderTests
     {
         [Fact]
-        public void CreateMessageProcessor_ReturnsExpectedReceiver()
+        public void CreateMessageReceiver_ReturnsExpectedReceiver()
         {
             string defaultConnection = "Endpoint=sb://default.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abc123=";
             var config = new ServiceBusConfiguration
@@ -22,9 +19,28 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests
             var receiver = provider.CreateMessageReceiver("entityPath", defaultConnection);
             Assert.Equal("entityPath", receiver.Path);
 
+            var receiver2 = provider.CreateMessageReceiver("entityPath", defaultConnection);
+            Assert.Same(receiver, receiver2);
+
             config.PrefetchCount = 100;
             receiver = provider.CreateMessageReceiver("entityPath1", defaultConnection);
             Assert.Equal(100, receiver.PrefetchCount);
+        }
+
+        [Fact]
+        public void CreateMessageSender_ReturnsExpectedSender()
+        {
+            string defaultConnection = "Endpoint=sb://default.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abc123=";
+            var config = new ServiceBusConfiguration
+            {
+                ConnectionString = defaultConnection
+            };
+            var provider = new MessagingProvider(config);
+            var sender = provider.CreateMessageSender("entityPath", defaultConnection);
+            Assert.Equal("entityPath", sender.Path);
+
+            var sender2 = provider.CreateMessageSender("entityPath", defaultConnection);
+            Assert.Same(sender, sender2);
         }
     }
 }


### PR DESCRIPTION
Addresses https://github.com/Azure/azure-webjobs-sdk/issues/1743

Adding:

- new ServiceBusAttribute binding for MessageSender. This allows a user to bind to a sender if they want to do the sending themselves. Similar to the Azure Storage CloudQueue binding, and other bindings that allow you to bind to a service client
- new binding data direct bind capability for lockToken and triggering MessageReceiver. Using these two values, a function can perform direct operations on the message (e.g. renew lease, abandon, etc.)

The end to end test shows example functions using these new bindings.