### PR TITLE
Fix LogWriter memory leak and resiliency (webjobs V3.x)

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging/Internal/LogWriter.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging/Internal/LogWriter.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Azure.WebJobs.Logging
                 // This basically becomes a memory leak. Mitigate by enforcing a max.
                 if (_activeFuncs.Count >= MaxBufferedEntryCount || _completedFunctions.Count >= MaxBufferedEntryCount)
                 {
-                    _onException?.Invoke(new Exception($"The limit on the number of bufferable log entries was reached. A total of '{MaxBufferedEntryCount}' log entries were dropped."));
+                    _onException?.Invoke(new Exception($"The limit on the number of buffered log entries was reached. A total of '{MaxBufferedEntryCount}' log entries were dropped."));
                     _activeFuncs.Clear();
                     _completedFunctions.Clear();
                 }

--- a/src/Microsoft.Azure.WebJobs.Logging/Internal/LogWriter.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging/Internal/LogWriter.cs
@@ -250,6 +250,7 @@ namespace Microsoft.Azure.WebJobs.Logging
                     }
                 }
 
+                // https://github.com/Azure/azure-webjobs-sdk/issues/1761
                 // Just making a note while I'm in this code fixing something else. 
                 // It looks like this will drop data if there is any type of error when communicating with storage. 
                 // Other code paths drop the data after successfully writing to storage

--- a/test/Microsoft.Azure.WebJobs.Logging.FunctionalTests/LoggerTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Logging.FunctionalTests/LoggerTest.cs
@@ -804,7 +804,7 @@ namespace Microsoft.Azure.WebJobs.Logging.FunctionalTests
             if (maxBufferedEntryCount < logItemCount)
             {
                 Assert.NotEmpty(caughtExceptions);
-                Assert.StartsWith("The limit on the number of bufferable log entries was reached.", caughtExceptions[0].Message);
+                Assert.StartsWith("The limit on the number of buffered log entries was reached.", caughtExceptions[0].Message);
             }
 
             // Counts should be intact


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-functions-host/issues/2690

There's two main changes here:
1. When the background flusher hits an error, clear out the task so that it is resumed later (otherwise no more background flushes occur).
2. Set a upper limit on how many entries will be buffered so that if there are errors in flush for a long period of time (say a storage key was rolled over), there is an upper bound on how much memory will be consumed.

webjobs v2.x port is here:
https://github.com/Azure/azure-webjobs-sdk/pull/1762