### PR TITLE
adding Logging.FunctionalTests to build

### DIFF
--- a/WebJobs.proj
+++ b/WebJobs.proj
@@ -189,6 +189,7 @@
         <UnitTestProjects Include="test\Microsoft.Azure.WebJobs.Host.UnitTests\WebJobs.Host.UnitTests.csproj"/>
         <UnitTestProjects Include="test\Microsoft.Azure.WebJobs.Host.FunctionalTests\WebJobs.Host.FunctionalTests.csproj"/>
         <UnitTestProjects Include="test\Microsoft.Azure.WebJobs.ServiceBus.UnitTests\WebJobs.ServiceBus.UnitTests.csproj"/>
+        <UnitTestProjects Include="test\Microsoft.Azure.WebJobs.Logging.FunctionalTests\WebJobs.Logging.FunctionalTests.csproj"/>
         <UnitTestProjects Include="test\Dashboard.UnitTests\Dashboard.UnitTests.csproj"/>
     </ItemGroup>
 
@@ -208,6 +209,7 @@
         <TestBinaries Include="test\Microsoft.Azure.WebJobs.ServiceBus.UnitTests\WebJobs.ServiceBus.UnitTests.csproj"/>
         <TestBinaries Include="test\Dashboard.UnitTests\Dashboard.UnitTests.csproj"/>
         <TestBinaries Include="test\Microsoft.Azure.WebJobs.Host.EndToEndTests\WebJobs.Host.EndToEndTests.csproj"/>
+        <TestBinaries Include="test\Microsoft.Azure.WebJobs.Logging.FunctionalTests\WebJobs.Logging.FunctionalTests.csproj"/>
     </ItemGroup>
 
     <MSBuild Projects="@(TestBinaries)"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,11 @@ build_script:
 - cmd: IF "%APPVEYOR_REPO_TAG_NAME%"=="" SET PackageSuffixCmd=/p:PackageSuffix=-%APPVEYOR_BUILD_NUMBER%
 - cmd: msbuild "WebJobs.proj" /verbosity:minimal /t:GetBitsToSign;BuildTestBinaries /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /p:Configuration=Release;Platform=AnyCPU /p:BuildNumber=%APPVEYOR_BUILD_NUMBER% /p:CommitHash=%APPVEYOR_REPO_COMMIT% %PackageSuffixCmd%    
 test_script:
-- cmd: "vstest.console /logger:Appveyor /TestAdapterPath:bin test/Microsoft.Azure.WebJobs.Host.UnitTests/bin/Release/Microsoft.Azure.WebJobs.Host.UnitTests.dll test/Microsoft.Azure.WebJobs.Host.FunctionalTests/bin/Release/Microsoft.Azure.WebJobs.Host.FunctionalTests.dll test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/bin/Release/Microsoft.Azure.WebJobs.ServiceBus.UnitTests.dll test/Dashboard.UnitTests/bin/Release/Dashboard.UnitTests.dll \n\nvstest.console /logger:Appveyor /TestAdapterPath:bin test/Microsoft.Azure.WebJobs.Host.EndToEndTests/bin/Release/Microsoft.Azure.WebJobs.Host.EndToEndTests.dll"
+- cmd: "vstest.console /logger:Appveyor /TestAdapterPath:bin test/Microsoft.Azure.WebJobs.Host.UnitTests/bin/Release/Microsoft.Azure.WebJobs.Host.UnitTests.dll"
+- cmd: "vstest.console /logger:Appveyor /TestAdapterPath:bin test/Microsoft.Azure.WebJobs.Host.FunctionalTests/bin/Release/Microsoft.Azure.WebJobs.Host.FunctionalTests.dll"
+- cmd: "vstest.console /logger:Appveyor /TestAdapterPath:bin test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/bin/Release/Microsoft.Azure.WebJobs.ServiceBus.UnitTests.dll"
+- cmd: "vstest.console /logger:Appveyor /TestAdapterPath:bin test/Dashboard.UnitTests/bin/Release/Dashboard.UnitTests.dll"
+- cmd: "vstest.console /logger:Appveyor /TestAdapterPath:bin test/Microsoft.Azure.WebJobs.Logging.FunctionalTests/bin/Release/Microsoft.Azure.WebJobs.Logging.FunctionalTests.dll"
+- cmd: "vstest.console /logger:Appveyor /TestAdapterPath:bin test/Microsoft.Azure.WebJobs.Host.EndToEndTests/bin/Release/Microsoft.Azure.WebJobs.Host.EndToEndTests.dll"   
 on_finish:
-- ps: .\tools\PollSigningResults.ps1 
+- ps: .\tools\PollSigningResults.ps1

--- a/test/Microsoft.Azure.WebJobs.Logging.FunctionalTests/LoggerTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Logging.FunctionalTests/LoggerTest.cs
@@ -754,11 +754,11 @@ namespace Microsoft.Azure.WebJobs.Logging.FunctionalTests
             };
 
             await writer.AddAsync(item1);
-            await TestHelpers.Await(() => caughtExceptions.Count == 1, timeout: 5000, pollingInterval: 100, userMessage: $"Expected caughtExceptions == 1; Actual: {caughtExceptions.Count}");
+            await TestHelpers.Await(() => caughtExceptions.Count == 1, timeout: 5000, pollingInterval: 100, userMessageCallback: () => $"Expected caughtExceptions == 1; Actual: {caughtExceptions.Count}");
 
             // Without fixes to the error handling in the background flusher task, this second condition would never be met because no further flushes would occur after the first exception.
             await writer.AddAsync(item2);
-            await TestHelpers.Await(() => caughtExceptions.Count == 2, timeout: 5000, pollingInterval: 100, userMessage: $"Expected caughtExceptions == 2; Actual: {caughtExceptions.Count}");
+            await TestHelpers.Await(() => caughtExceptions.Count == 2, timeout: 5000, pollingInterval: 100, userMessageCallback: () => $"Expected caughtExceptions == 2; Actual: {caughtExceptions.Count}");
 
             Assert.Same(exToThrow1, caughtExceptions[0]);
             Assert.Same(exToThrow2, caughtExceptions[1]);

--- a/test/Microsoft.Azure.WebJobs.Logging.FunctionalTests/Properties/AssemblyInfo.cs
+++ b/test/Microsoft.Azure.WebJobs.Logging.FunctionalTests/Properties/AssemblyInfo.cs
@@ -1,36 +1,9 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("Microsoft.Azure.WebJobs.Logging.FunctionalTests")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Microsoft.Azure.WebJobs.Logging.FunctionalTests")]
-[assembly: AssemblyCopyright("Copyright ©  2016")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
+using System.Reflection;
+using Xunit;
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("c8eaae01-e8cf-4131-9d4b-f0fdf00da4be")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly)]

--- a/test/Microsoft.Azure.WebJobs.Logging.FunctionalTests/WebJobs.Logging.FunctionalTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Logging.FunctionalTests/WebJobs.Logging.FunctionalTests.csproj
@@ -115,6 +115,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\Common\CommonAssemblyInfo.cs">
+      <Link>Properties\CommonAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="FunctionIdTests.cs" />
     <Compile Include="ProjectionTests.cs" />
     <Compile Include="InstanceCountLoggerBaseTests.cs" />
@@ -134,6 +137,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\..\src\Common\PublicKey.snk">
+      <Link>Properties\PublicKey.snk</Link>
+    </None>
     <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>

--- a/tools/SkipStrongNames.xml
+++ b/tools/SkipStrongNames.xml
@@ -17,4 +17,5 @@
   <assembly name="Microsoft.Azure.WebJobs.Host.UnitTests"/>
   <assembly name="Microsoft.Azure.WebJobs.ServiceBus.UnitTests"/>
   <assembly name="Microsoft.Azure.WebJobs.Storage.IntegrationTests"/>
+  <assembly name="Microsoft.Azure.WebJobs.Logging.FunctionalTests"/>
 </assemblies>


### PR DESCRIPTION
After a bunch of debugging, I enabled fusion logs on the Appveyor VM and saw that we weren't skipping strong name validation on this assembly. Tracked it back to the SkipStrongNames.xml file. Now all should be building and running.