### PR TITLE
fixing QuickPulse test; minor code cleanup

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerProvider.cs
@@ -15,12 +15,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
 
         public ApplicationInsightsLoggerProvider(TelemetryClient client)
         {
-            if (client == null)
-            {
-                throw new ArgumentNullException(nameof(client));
-            }
-
-            _client = client;
+            _client = client ?? throw new ArgumentNullException(nameof(client));
         }
 
         public ILogger CreateLogger(string categoryName) => new ApplicationInsightsLogger(_client, categoryName);

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/FilteringTelemetryProcessor.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/FilteringTelemetryProcessor.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
 {
     internal class FilteringTelemetryProcessor : ITelemetryProcessor
     {
-        private Func<string, LogLevel, bool> _filter;
+        private readonly Func<string, LogLevel, bool> _filter;
         private ITelemetryProcessor _next;
 
         public FilteringTelemetryProcessor(Func<string, LogLevel, bool> filter, ITelemetryProcessor next)
@@ -33,12 +33,9 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
         {
             bool enabled = true;
 
-            ISupportProperties telemetry = item as ISupportProperties;
-
-            if (telemetry != null && _filter != null)
+            if (item is ISupportProperties telemetry && _filter != null)
             {
-                string categoryName = null;
-                if (!telemetry.Properties.TryGetValue(LogConstants.CategoryNameKey, out categoryName))
+                if (!telemetry.Properties.TryGetValue(LogConstants.CategoryNameKey, out string categoryName))
                 {
                     // If no category is specified, it will be filtered by the default filter
                     categoryName = string.Empty;
@@ -55,10 +52,8 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                 }
 
                 // Extract the log level and apply the filter
-                string logLevelString = null;
-                LogLevel logLevel;
-                if (telemetry.Properties.TryGetValue(LogConstants.LogLevelKey, out logLevelString) &&
-                    Enum.TryParse(logLevelString, out logLevel))
+                if (telemetry.Properties.TryGetValue(LogConstants.LogLevelKey, out string logLevelString) &&
+                    Enum.TryParse(logLevelString, out LogLevel logLevel))
                 {
                     enabled = _filter(categoryName, logLevel);
                 }

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobsTelemetryInitializer.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobsTelemetryInitializer.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
         private const string ComputerNameKey = "COMPUTERNAME";
         private const string WebSiteInstanceIdKey = "WEBSITE_INSTANCE_ID";
 
-        private static string _roleInstanceName = GetRoleInstanceName();
+        private static readonly string _roleInstanceName = GetRoleInstanceName();
 
         public void Initialize(ITelemetry telemetry)
         {


### PR DESCRIPTION
Fixes an issue where the QuickPulseModule was not initialized yet we were starting our test scenario. Now we'll wait until we've gotten the initial ping and first empty sample before continuing.

Also did some minor unrelated code cleanup wherever I was seeing Intellisense messages.