### PR TITLE
Enable Application Insights heartbeats

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
@@ -15,6 +15,7 @@
   
   <ItemGroup>
   <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.6.4" />
+  <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.6.4" />
   <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.6.4" />
   <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.1.0" />
   <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.0" />

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
@@ -10,6 +10,7 @@ using Microsoft.ApplicationInsights.DependencyCollector;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.Extensibility.Implementation;
 using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse;
+using Microsoft.ApplicationInsights.WindowsServer;
 using Microsoft.ApplicationInsights.WindowsServer.Channel.Implementation;
 using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
 using Microsoft.Azure.WebJobs.Logging.ApplicationInsights;
@@ -44,9 +45,10 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                 var modules = host.Services.GetServices<ITelemetryModule>().ToList();
 
                 // Verify Modules
-                Assert.Equal(2, modules.Count);
+                Assert.Equal(3, modules.Count);
                 Assert.Single(modules.OfType<DependencyTrackingTelemetryModule>());
                 Assert.Single(modules.OfType<QuickPulseTelemetryModule>());
+                Assert.Single(modules.OfType<AppServicesHeartbeatTelemetryModule>());
                 Assert.Same(config.TelemetryChannel, host.Services.GetServices<ITelemetryChannel>().Single());
                 // Verify client
                 var client = host.Services.GetService<TelemetryClient>();
@@ -126,9 +128,10 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                 var modules = host.Services.GetServices<ITelemetryModule>().ToList();
 
                 // Verify Modules
-                Assert.Equal(2, modules.Count);
+                Assert.Equal(3, modules.Count);
                 Assert.Single(modules.OfType<DependencyTrackingTelemetryModule>());
                 Assert.Single(modules.OfType<QuickPulseTelemetryModule>());
+                Assert.Single(modules.OfType<AppServicesHeartbeatTelemetryModule>());
                 Assert.NotSame(config.TelemetryChannel, host.Services.GetServices<ITelemetryChannel>().Single());
                 // Verify client
                 var client = host.Services.GetService<TelemetryClient>();


### PR DESCRIPTION
This change adds ApplicaitonInsights heartbeats.

Heartbeat is a simple custom event, sent to customer ApplicationInsights resource every 15 minutes with infrastructure information such as OS,  runtime version, and app-service details: service name, stamp, owner and host.

this information 
1. allows navigating from Application Map directly to Function/App Service resource 
2. measure application insights usage

/cc @fabiocav  @brettsam