### PR TITLE
Suppress warning CS1998: This async method lacks 'await'

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Bindings/BlobExtensionConfig.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Bindings/BlobExtensionConfig.cs
@@ -198,13 +198,13 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
             }
         }
 
-        private async Task<CloudBlobClient> GetClientAsync(
+        private Task<CloudBlobClient> GetClientAsync(
          BlobAttribute blobAttribute,
          CancellationToken cancellationToken)
         {
             var account = _accountProvider.Get(blobAttribute.Connection, _nameResolver);
             var client = account.CreateCloudBlobClient();
-            return client;
+            return Task.FromResult(client);
         }
 
         private async Task<CloudBlobContainer> GetContainerAsync(

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Triggers/BlobTriggerAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Triggers/BlobTriggerAttributeBindingProvider.cs
@@ -114,14 +114,14 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Triggers
             _loggerFactory = loggerFactory;
         }
 
-        public async Task<ITriggerBinding> TryCreateAsync(TriggerBindingProviderContext context)
+        public Task<ITriggerBinding> TryCreateAsync(TriggerBindingProviderContext context)
         {
             ParameterInfo parameter = context.Parameter;
             var blobTriggerAttribute = TypeUtility.GetResolvedAttribute<BlobTriggerAttribute>(context.Parameter);
 
             if (blobTriggerAttribute == null)
             {
-                return null;
+                return Task.FromResult<ITriggerBinding>(null);
             }
 
             string resolvedCombinedPath = Resolve(blobTriggerAttribute.BlobPath);
@@ -137,7 +137,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Triggers
                 _hostIdProvider, _queueOptions, _blobsOptions, _exceptionHandler, _blobWrittenWatcherSetter,
                 _messageEnqueuedWatcherSetter, _sharedContextProvider, _singletonManager, _loggerFactory);
 
-            return binding;
+            return Task.FromResult(binding);
         }
 
         private string Resolve(string queueName)

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/CloudStorageAccount/CloudStorageAccountBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/CloudStorageAccount/CloudStorageAccountBindingProvider.cs
@@ -19,19 +19,19 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings.StorageAccount
             _accountProvider = accountProvider ?? throw new ArgumentNullException("accountProvider");
         }
 
-        public async Task<IBinding> TryCreateAsync(BindingProviderContext context)
+        public Task<IBinding> TryCreateAsync(BindingProviderContext context)
         {
             ParameterInfo parameter = context.Parameter;
 
             if (parameter.ParameterType != typeof(CloudStorageAccount))
             {
-                return null;
+                return Task.FromResult<IBinding>(null);
             }
 
             var accountAttribute = TypeUtility.GetHierarchicalAttributeOrNull<StorageAccountAttribute>(parameter);
             var account = _accountProvider.Get(accountAttribute?.Account);
 
-            return new CloudStorageAccountBinding(parameter.Name, account.SdkObject);
+            return Task.FromResult<IBinding>(new CloudStorageAccountBinding(parameter.Name, account.SdkObject));
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Queues/Bindings/QueueBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Queues/Bindings/QueueBindingProvider.cs
@@ -192,7 +192,7 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Bindings
                 return new QueueAsyncCollector(queue, _messageEnqueuedWatcherGetter.Value);
             }
 
-            internal async Task<CloudQueue> GetQueueAsync(QueueAttribute attrResolved)
+            internal Task<CloudQueue> GetQueueAsync(QueueAttribute attrResolved)
             {
                 // var account = await _accountProvider.GetStorageAccountAsync(attrResolved, CancellationToken.None);
                 var account = _accountProvider.Get(attrResolved.Connection);
@@ -201,7 +201,7 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Bindings
                 string queueName = attrResolved.QueueName.ToLowerInvariant();
                 QueueClient.ValidateQueueName(queueName);
 
-                return client.GetQueueReference(queueName);
+                return Task.FromResult(client.GetQueueReference(queueName));
             }
 
             internal CloudQueue GetQueue(QueueAttribute attrResolved)

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Queues/Triggers/QueueTriggerAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Queues/Triggers/QueueTriggerAttributeBindingProvider.cs
@@ -45,14 +45,14 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Triggers
             _loggerFactory = loggerFactory;
         }
 
-        public async Task<ITriggerBinding> TryCreateAsync(TriggerBindingProviderContext context)
+        public Task<ITriggerBinding> TryCreateAsync(TriggerBindingProviderContext context)
         {
             ParameterInfo parameter = context.Parameter;
             var queueTrigger = TypeUtility.GetResolvedAttribute<QueueTriggerAttribute>(context.Parameter);
 
             if (queueTrigger == null)
             {
-                return null;
+                return Task.FromResult<ITriggerBinding>(null);
             }
 
             string queueName = Resolve(queueTrigger.QueueName);
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Triggers
             ITriggerBinding binding = new QueueTriggerBinding(parameter.Name, queue, argumentBinding,
                 _queueOptions, _exceptionHandler, _messageEnqueuedWatcherSetter,
                 _loggerFactory);
-            return binding;
+            return Task.FromResult(binding);
         }
 
         private static string NormalizeAndValidate(string queueName)

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Triggers/MessageValueProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Triggers/MessageValueProvider.cs
@@ -67,14 +67,14 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
             }
         }
 
-        private static async Task<string> GetBase64StringAsync(Message clonedMessage,
+        private static Task<string> GetBase64StringAsync(Message clonedMessage,
             CancellationToken cancellationToken)
         {
             if (clonedMessage.Body == null)
             {
-                return null;
+                return Task.FromResult<string>(null);
             }
-            return Convert.ToBase64String(clonedMessage.Body);
+            return Task.FromResult(Convert.ToBase64String(clonedMessage.Body));
         }
 
         private static Task<string> GetDescriptionAsync(Message clonedMessage)
@@ -85,14 +85,14 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
             return Task.FromResult(description);
         }
 
-        private static async Task<string> GetTextAsync(Message clonedMessage,
+        private static Task<string> GetTextAsync(Message clonedMessage,
             CancellationToken cancellationToken)
         {
             if (clonedMessage.Body == null)
             {
-                return null;
+                return Task.FromResult<string>(null);
             }
-            return StrictEncodings.Utf8.GetString(clonedMessage.Body);
+            return Task.FromResult(StrictEncodings.Utf8.GetString(clonedMessage.Body));
         }
     }
 }


### PR DESCRIPTION
Hi,

I've seen a lot of warnings when you compile the solution related with async/await stuffs "Suppress warning CS1998: This async method lacks 'await'"

If you have nothing to await why not just return Task.FromResult?

Regards!