### PR TITLE
 Enable ServiceBus dependency and request collection

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/Constants/LogConstants.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/Constants/LogConstants.cs
@@ -143,5 +143,10 @@ namespace Microsoft.Azure.WebJobs.Logging
         /// Gets the name of the key used to store a metric sum.
         /// </summary>
         public const string MetricValueKey = "Value";
+
+        /// <summary>
+        /// Gets the name of the key used to store function execution time in the ApplicationInsights RequestTelemetry properties.
+        /// </summary>
+        public const string FunctionExecutionTimeKey = "FunctionExecutionTimeMs";
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Utility.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Utility.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using System.Reflection;
 using Microsoft.Azure.WebJobs.Description;
 using Microsoft.Azure.WebJobs.Host.Config;

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
@@ -65,12 +65,14 @@ namespace Microsoft.Extensions.DependencyInjection
                 excludedDomains.Add("localhost");
                 excludedDomains.Add("127.0.0.1");
 
+                var includedActivities = dependencyCollector.IncludeDiagnosticSourceActivities;
+                includedActivities.Add("Microsoft.Azure.ServiceBus");
+
                 return dependencyCollector;
             });
             services.AddSingleton<ITelemetryModule, AppServicesHeartbeatTelemetryModule>();
 
-            ServerTelemetryChannel serverChannel = new ServerTelemetryChannel();
-            services.AddSingleton<ITelemetryChannel>(serverChannel);
+            services.AddSingleton<ITelemetryChannel, ServerTelemetryChannel>();
             services.AddSingleton<TelemetryConfiguration>(provider =>
             {
                 ApplicationInsightsLoggerOptions options = provider.GetService<IOptions<ApplicationInsightsLoggerOptions>>().Value;

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
@@ -14,17 +14,17 @@
   </ItemGroup>
   
   <ItemGroup>
-  <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.6.4" />
+  <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.7.2" />
   <PackageReference Include="Microsoft.ApplicationInsights.SnapshotCollector" Version="1.3.0" />
-  <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.6.4" />
-  <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.6.4" />
+  <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.7.2" />
+  <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.7.2" />
   <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.1.0" />
   <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.0" />
   <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.6.4" />
-    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.6.4" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.7.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.7.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.0" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/WebJobs.ServiceBus.csproj
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/WebJobs.ServiceBus.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="2.0.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="3.0.2" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004" >
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage" Version="8.6.0" />

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/HttpDependencyCollectionTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/HttpDependencyCollectionTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -21,7 +22,7 @@ using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
 {
-    public class HttpDependencyCollectionTests
+    public class HttpDependencyCollectionTests : IDisposable
     {
         private const string TestArtifactPrefix = "e2etestsai";
         private const string OutputQueueNamePattern = TestArtifactPrefix + "out%rnd%";
@@ -144,7 +145,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
             Assert.Single(dependencies);
 
             DependencyTelemetry dependency = dependencies.Single();
-            ValidateDependency(
+            TelemetryValidationHelpers.ValidateHttpDependency(
                 dependency,
                 testName,
                 request.Context.Operation.Id,
@@ -323,7 +324,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
                 Assert.Equal(blobName, dependency.Properties["Blob"]);
             }
 
-            ValidateDependency(dependency, operationName, operationId, requestId, LogCategories.Bindings);
+            TelemetryValidationHelpers.ValidateHttpDependency(dependency, operationName, operationId, requestId, LogCategories.Bindings);
         }
 
 
@@ -337,26 +338,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
             Assert.Equal("Azure queue", dependency.Type);
             Assert.True(dependency.Name.EndsWith(queueName));
 
-            ValidateDependency(dependency, operationName, operationId, requestId, LogCategories.Bindings);
-        }
-
-        private void ValidateDependency(
-            DependencyTelemetry dependency,
-            string operationName,
-            string operationId,
-            string requestId,
-            string category)
-        {
-            Assert.Equal(category, dependency.Properties[LogConstants.CategoryNameKey]);
-            Assert.Equal(LogLevel.Information.ToString(), dependency.Properties[LogConstants.LogLevelKey]);
-            Assert.False(string.IsNullOrEmpty(dependency.ResultCode));
-            Assert.NotNull(dependency.Target);
-            Assert.NotNull(dependency.Data);
-            Assert.NotNull(dependency.Name);
-            Assert.NotNull(dependency.Id);
-            Assert.Equal(operationId, dependency.Context.Operation.Id);
-            Assert.Equal(operationName, dependency.Context.Operation.Name);
-            Assert.Equal(requestId, dependency.Context.Operation.ParentId);
+            TelemetryValidationHelpers.ValidateHttpDependency(dependency, operationName, operationId, requestId, LogCategories.Bindings);
         }
 
         public IHost ConfigureHost(LogLevel logLevel)

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/ServiceBusRequestAndDependencyCollectionTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/ServiceBusRequestAndDependencyCollectionTests.cs
@@ -1,0 +1,184 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.Azure.ServiceBus;
+using Microsoft.Azure.ServiceBus.Core;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Microsoft.Azure.WebJobs.Logging;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using LogLevel = Microsoft.Extensions.Logging.LogLevel;
+
+namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
+{
+    public class ServiceBusRequestAndDependencyCollectionTests : IDisposable
+    {
+        private const string _queueName = "core-test-queue1";
+        private const string _mockApplicationInsightsKey = "some_key";
+        private readonly string _endpoint;
+        private readonly string _connectionString;
+        private RandomNameResolver _resolver;
+        private readonly TestTelemetryChannel _channel = new TestTelemetryChannel();
+        private static readonly AutoResetEvent _functionWaitHandle = new AutoResetEvent(false);
+
+        public ServiceBusRequestAndDependencyCollectionTests()
+        {
+            var config = new ConfigurationBuilder()
+                .AddEnvironmentVariables()
+                .Build();
+
+            var configSection = Utility.GetExtensionConfigurationSection(config, "ServiceBus");
+            _connectionString = configSection.GetConnectionString("Primary");
+
+            var connStringBuilder = new ServiceBusConnectionStringBuilder(_connectionString);
+            _endpoint = connStringBuilder.Endpoint;
+        }
+
+        [Fact]
+        public async Task ServiceBusDepenedenciesAndRequestAreTracked()
+        {
+            using (var host = ConfigureHost())
+            {
+                await host.StartAsync();
+                await host.GetJobHost()
+                    .CallAsync(typeof(ServiceBusRequestAndDependencyCollectionTests).GetMethod(nameof(ServiceBusOut)), new {input = "message"});
+
+                _functionWaitHandle.WaitOne();
+                await Task.Delay(1000);
+
+                await host.StopAsync();
+            }
+
+            List<RequestTelemetry> requests = _channel.Telemetries.OfType<RequestTelemetry>().ToList();
+            List<DependencyTelemetry> dependencies = _channel.Telemetries.OfType<DependencyTelemetry>().ToList();
+
+            Assert.Equal(2, requests.Count);
+            Assert.Single(dependencies);
+
+            Assert.Single(requests.Where(r => r.Context.Operation.ParentId == dependencies.Single().Id));
+            var sbTriggerRequest = requests.Single(r => r.Context.Operation.ParentId == dependencies.Single().Id);
+            var manualCallRequest = requests.Single(r => r.Name == nameof(ServiceBusOut));
+            var sbOutDependency = dependencies.Single();
+
+            string operationId = manualCallRequest.Context.Operation.Id;
+            Assert.Equal(operationId, sbTriggerRequest.Context.Operation.Id);
+
+            ValidateServiceBusDependency(sbOutDependency, _endpoint, _queueName, "Send", nameof(ServiceBusOut), operationId, manualCallRequest.Id);
+            ValidateServiceBusRequest(sbTriggerRequest, _endpoint, _queueName, nameof(ServiceBusTrigger), operationId, sbOutDependency.Id);
+        }
+
+        [NoAutomaticTrigger]
+        public static void ServiceBusOut(
+            string input,
+            [ServiceBus(_queueName)] out string message,
+            TextWriter logger)
+        {
+            message = input;
+        }
+
+        public static void ServiceBusTrigger(
+            [ServiceBusTrigger(_queueName)] string message,
+            TextWriter logger)
+        {
+            logger.WriteLine($"C# script processed queue message: '{message}'");
+            _functionWaitHandle.Set();
+        }
+
+        private void ValidateServiceBusRequest(
+            RequestTelemetry request,
+            string endpoint,
+            string queueName,
+            string operationName,
+            string operationId,
+            string parentId)
+        {
+            Assert.Equal($"type:Azure Service Bus | name:{queueName} | endpoint:{endpoint}/", request.Source);
+            Assert.Null(request.Url);
+            Assert.Equal(operationName, request.Name);
+
+            Assert.True(request.Properties.ContainsKey(LogConstants.FunctionExecutionTimeKey));
+            Assert.True(double.TryParse(request.Properties[LogConstants.FunctionExecutionTimeKey], out double functionDuration));
+            Assert.True(request.Duration.TotalMilliseconds >= functionDuration);
+
+            TelemetryValidationHelpers.ValidateRequest(request, operationName, operationId, parentId, LogCategories.Results);
+        }
+
+        private void ValidateServiceBusDependency(
+            DependencyTelemetry dependency,
+            string endpoint,
+            string queueName,
+            string name,
+            string operationName,
+            string operationId,
+            string parentId)
+        {
+            Assert.Equal($"{endpoint}/ | {queueName}", dependency.Target);
+            Assert.Equal("Azure Service Bus", dependency.Type);
+            Assert.Equal(name, dependency.Name);
+            Assert.True(dependency.Success);
+            Assert.Null(dependency.Data);
+            TelemetryValidationHelpers.ValidateDependency(dependency, operationName, operationId, parentId, LogCategories.Bindings);
+        }
+
+        public IHost ConfigureHost()
+        {
+            _resolver = new RandomNameResolver();
+
+            IHost host = new HostBuilder()
+                .ConfigureDefaultTestHost<ServiceBusRequestAndDependencyCollectionTests>(b =>
+                {
+                    b.AddAzureStorage();
+                    b.AddServiceBus();
+                })
+                .ConfigureLogging(b =>
+                {
+                    b.SetMinimumLevel(LogLevel.Information);
+                    b.AddApplicationInsights(o => o.InstrumentationKey = _mockApplicationInsightsKey);
+                })
+                .Build();
+
+            TelemetryConfiguration telemteryConfiguration = host.Services.GetService<TelemetryConfiguration>();
+            telemteryConfiguration.TelemetryChannel = _channel;
+
+            return host;
+        }
+
+        public void Dispose()
+        {
+            _channel?.Dispose();
+            CleanUpEntity().GetAwaiter().GetResult();
+        }
+
+        private async Task<int> CleanUpEntity()
+        {
+            var messageReceiver = new MessageReceiver(_connectionString, _queueName, ReceiveMode.ReceiveAndDelete);
+            Message message;
+            int count = 0;
+            do
+            {
+                message = await messageReceiver.ReceiveAsync(TimeSpan.FromSeconds(3)).ConfigureAwait(false);
+                if (message != null)
+                {
+                    count++;
+                }
+                else
+                {
+                    break;
+                }
+            } while (true);
+            await messageReceiver.CloseAsync();
+            return count;
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/TelemetryValidationHelpers.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/TelemetryValidationHelpers.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.Azure.WebJobs.Logging;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
+{
+    internal class TelemetryValidationHelpers
+    {
+        public static void ValidateHttpDependency(
+            DependencyTelemetry dependency,
+            string operationName,
+            string operationId,
+            string parentId,
+            string category)
+        {
+            Assert.False(string.IsNullOrEmpty(dependency.ResultCode));
+            Assert.NotNull(dependency.Data);
+
+            ValidateDependency(dependency, operationName, operationId, parentId, category);
+        }
+
+        public static void ValidateDependency(
+            DependencyTelemetry dependency,
+            string operationName,
+            string operationId,
+            string parentId,
+            string category)
+        {
+            Assert.Equal(category, dependency.Properties[LogConstants.CategoryNameKey]);
+            Assert.Equal(LogLevel.Information.ToString(), dependency.Properties[LogConstants.LogLevelKey]);
+            Assert.NotNull(dependency.Target);
+            Assert.NotNull(dependency.Name);
+            Assert.NotNull(dependency.Id);
+            Assert.Equal(operationId, dependency.Context.Operation.Id);
+            Assert.Equal(operationName, dependency.Context.Operation.Name);
+            Assert.Equal(parentId, dependency.Context.Operation.ParentId);
+            Assert.True(dependency.Properties.ContainsKey(LogConstants.InvocationIdKey));
+        }
+
+        public static void ValidateRequest(
+            RequestTelemetry request,
+            string operationName,
+            string operationId,
+            string parentId,
+            string category)
+        {
+            Assert.Equal(category, request.Properties[LogConstants.CategoryNameKey]);
+            Assert.Equal(LogLevel.Information.ToString(), request.Properties[LogConstants.LogLevelKey]);
+            Assert.NotNull(request.Name);
+            Assert.NotNull(request.Id);
+            Assert.Equal(operationId, request.Context.Operation.Id);
+            Assert.Equal(operationName, request.Context.Operation.Name);
+            Assert.Equal(parentId, request.Context.Operation.ParentId);
+            Assert.True(request.Properties.ContainsKey(LogConstants.InvocationIdKey));
+            Assert.True(request.Properties.ContainsKey(LogConstants.TriggerReasonKey));
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/WebJobs.Host.EndToEndTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/WebJobs.Host.EndToEndTests.csproj
@@ -13,11 +13,11 @@
 
   <ItemGroup>
     <PackageReference Include="appinsights.testlogger" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="3.0.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.6.4" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.7.2" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Moq" Version="4.7.145" />

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/WebJobs.Host.FunctionalTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/WebJobs.Host.FunctionalTests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.6.4" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.7.2" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Moq" Version="4.7.145" />

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DependencyCollector;
@@ -26,7 +25,7 @@ using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
 {
-    public class ApplicationInsightsConfigurationTests : IDisposable
+    public class ApplicationInsightsConfigurationTests
     {
         [Fact]
         public void DependencyInjectionConfiguration_Configures()
@@ -337,16 +336,6 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             ruleSelector.Select(options, providerType, category, out LogLevel? minLevel, out Func<string, string, LogLevel, bool> filter);
 
             return new LoggerFilterRule(providerType.FullName, category, minLevel, filter);
-        }
-
-        public void Dispose()
-        {
-            TelemetryConfiguration.Active.Dispose();
-
-            MethodInfo setActive =
-                typeof(TelemetryConfiguration).GetMethod("set_Active", BindingFlags.Static | BindingFlags.NonPublic);
-
-            setActive.Invoke(null, new object[] { TelemetryConfiguration.CreateDefault() });
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.6.4" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.7.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />

--- a/test/Microsoft.Azure.WebJobs.Logging.FunctionalTests/WebJobs.Logging.FunctionalTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Logging.FunctionalTests/WebJobs.Logging.FunctionalTests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.6.4" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.7.2" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Moq" Version="4.7.145" />

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/WebJobs.ServiceBus.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/WebJobs.ServiceBus.UnitTests.csproj
@@ -16,11 +16,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="3.0.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.6.4" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.7.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />

--- a/test/Microsoft.Azure.Webjobs.Extensions.Storage.UnitTests/WebJobs.Extensions.Storage.UnitTests.csproj
+++ b/test/Microsoft.Azure.Webjobs.Extensions.Storage.UnitTests/WebJobs.Extensions.Storage.UnitTests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.6.4" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.7.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />


### PR DESCRIPTION
This change enables ServicBus calls tracking
ApplicaitonInsights listens to ServiceBus SDK events and tracks requests automatically, enriching them with ServiceBus specific properties such as endpoint, queue name, function called (Send/Process)

Such events are translated to telemetry so that 'Send' is tracked as dependency and 'Process' is a request. 
ServiceBus SDK also ensures that is there is a trace context in the message, it will be used.

There is a small caveat with request tracking: AppInsights SDK tracks request from SB automatically and therefore Request tracked by webjobs SDK, in this case, is not needed.
Based on the presence of Activity.Current, we can say whether someone tracks request already and avoid double-tracking.

We've had an offline conversation with @brettsam about HTTP requests, and we've decided that 'outer', 'automagical' request should be tracked: it contains specific info (such as SB message Id or queue name, or in case of HTTP request URL and response code).
'Outer' request will have a bit bigger duration than a pure function call; for now, actual function duration is added into the telemetry properties.

Request operation name still is set to function name as portal UI depends on it.

ServiceBus package was updated to the latest stable version 3.0.2 because of NullReferenceException bug in diagnostics code https://github.com/Azure/azure-service-bus-dotnet/issues/459
 
