### PR TITLE
Add ApplicationIdProvider to support multi-instrumentation key scenarios

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
@@ -111,8 +111,8 @@ namespace Microsoft.Extensions.DependencyInjection
                         new ServerTelemetryChannel(),
                         provider.GetServices<ITelemetryInitializer>(),
                         provider.GetServices<ITelemetryModule>(),
-                        appIdProvider,
-                        new ApplicationInsightsApplicationIdProvider());
+                        new ApplicationInsightsApplicationIdProvider(),
+                        filterOptions);
                 }
                 return config;
             });

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
@@ -10,6 +10,7 @@ using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DependencyCollector;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.Extensibility.Implementation;
+using Microsoft.ApplicationInsights.Extensibility.Implementation.ApplicationId;
 using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse;
 using Microsoft.ApplicationInsights.SnapshotCollector;
 using Microsoft.ApplicationInsights.WindowsServer;
@@ -50,6 +51,9 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<ITelemetryInitializer, WebJobsTelemetryInitializer>();
             services.AddSingleton<ITelemetryInitializer, WebJobsSanitizingInitializer>();
             services.AddSingleton<ITelemetryModule, QuickPulseTelemetryModule>();
+
+            services.AddSingleton<IApplicationIdProvider, ApplicationInsightsApplicationIdProvider>();
+
             services.AddSingleton<ITelemetryModule, DependencyTrackingTelemetryModule>(provider =>
             {
                 var dependencyCollector = new DependencyTrackingTelemetryModule();
@@ -79,6 +83,9 @@ namespace Microsoft.Extensions.DependencyInjection
 
                 ITelemetryChannel channel = provider.GetService<ITelemetryChannel>();
                 TelemetryConfiguration config = TelemetryConfiguration.CreateDefault();
+
+                IApplicationIdProvider appIdProvider = provider.GetService<IApplicationIdProvider>();
+
                 SetupTelemetryConfiguration(
                     config,
                     options.InstrumentationKey,
@@ -87,6 +94,7 @@ namespace Microsoft.Extensions.DependencyInjection
                     channel,
                     provider.GetServices<ITelemetryInitializer>(),
                     provider.GetServices<ITelemetryModule>(),
+                    appIdProvider,
                     filterOptions);
 
                 // Function users have no access to TelemetryConfiguration from host DI container,
@@ -103,7 +111,8 @@ namespace Microsoft.Extensions.DependencyInjection
                         new ServerTelemetryChannel(),
                         provider.GetServices<ITelemetryInitializer>(),
                         provider.GetServices<ITelemetryModule>(),
-                        filterOptions);
+                        appIdProvider,
+                        new ApplicationInsightsApplicationIdProvider());
                 }
                 return config;
             });
@@ -160,6 +169,7 @@ namespace Microsoft.Extensions.DependencyInjection
             ITelemetryChannel channel,
             IEnumerable<ITelemetryInitializer> telemetryInitializers,
             IEnumerable<ITelemetryModule> telemetryModules,
+            IApplicationIdProvider applicationIdProvider,
             LoggerFilterOptions filterOptions)
         {
             if (instrumentationKey != null)
@@ -217,6 +227,8 @@ namespace Microsoft.Extensions.DependencyInjection
                     module.Initialize(configuration);
                 }
             }
+
+            configuration.ApplicationIdProvider = applicationIdProvider;
         }
         internal static string GetAssemblyFileVersion(Assembly assembly)
         {

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
@@ -10,6 +10,7 @@ using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DependencyCollector;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.Extensibility.Implementation;
+using Microsoft.ApplicationInsights.Extensibility.Implementation.ApplicationId;
 using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse;
 using Microsoft.ApplicationInsights.SnapshotCollector;
 using Microsoft.ApplicationInsights.WindowsServer;
@@ -76,6 +77,10 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                 Assert.IsType<QuickPulseTelemetryProcessor>(config.TelemetryProcessors[0]);
                 Assert.IsType<FilteringTelemetryProcessor>(config.TelemetryProcessors[1]);
                 Assert.Empty(config.TelemetryProcessors.OfType<AdaptiveSamplingTelemetryProcessor>());
+
+                // Verify ApplicationIdProvider
+                Assert.NotNull(config.ApplicationIdProvider);
+                Assert.IsType<ApplicationInsightsApplicationIdProvider>(config.ApplicationIdProvider);
             }
         }
 
@@ -199,6 +204,10 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                 Assert.IsType<QuickPulseTelemetryProcessor>(config.TelemetryProcessors[0]);
                 Assert.IsType<FilteringTelemetryProcessor>(config.TelemetryProcessors[1]);
                 Assert.Empty(config.TelemetryProcessors.OfType<AdaptiveSamplingTelemetryProcessor>());
+
+                // Verify ApplicationIdProvider
+                Assert.NotNull(config.ApplicationIdProvider);
+                Assert.IsType<ApplicationInsightsApplicationIdProvider>(config.ApplicationIdProvider);
             }
         }
 


### PR DESCRIPTION
ApplicationInsights can show AppMap and end-to-end trace viewer in case when different sub-components report to different ApplicationInsights resources.
This feature is available now HTTP only and we are working on extending support for other protocols.

This change enables multiple instrumentation key feature. 

/cc  @brettsam @fabiocav 