### PR TITLE
Updating build file to ease local package publishing

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -1,7 +1,13 @@
 ﻿param (
-  [string]$packageSuffix = "0"
+  [string]$packageSuffix = "0",
+  [bool]$isLocal = $false,
+  [string]$outputDirectory = "..\..\buildoutput"
 )
 
+if ($isLocal){
+  $packageSuffix = "dev" + [datetime]::UtcNow.Ticks.ToString()
+  Write-Host "Local build - setting package suffixes to $packageSuffix" -ForegroundColor Yellow
+}
 dotnet --version
 
 dotnet build Webjobs.sln -v q
@@ -20,7 +26,7 @@ $projects =
 
 foreach ($project in $projects)
 {
-  $cmd = "pack", "$project", "-o", "..\..\buildoutput", "--no-build"
+  $cmd = "pack", "$project", "-o", $outputDirectory, "--no-build"
   
   if ($packageSuffix -ne "0")
   {


### PR DESCRIPTION
Small update to allow passing output directory and local publishing (adds build timestamp) flag to the build process. This makes the process of populating a local package source a little easier.