### PR TITLE
Fixing MessageProcessor AutoComplete handling

### DIFF
--- a/src/Microsoft.Azure.WebJobs.ServiceBus/MessageProcessor.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/MessageProcessor.cs
@@ -52,30 +52,33 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         /// <summary>
         /// This method completes processing of the specified message, after the job function has been invoked.
         /// </summary>
+        /// <remarks>
+        /// The message is completed by the ServiceBus SDK based on how the <see cref="OnMessageOptions.AutoComplete"/> option
+        /// is configured. E.g. if <see cref="OnMessageOptions.AutoComplete"/> is false, it is up to the job function to complete
+        /// the message.
+        /// </remarks>
         /// <param name="message">The message to complete processing for.</param>
         /// <param name="result">The <see cref="FunctionResult"/> from the job invocation.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use</param>
         /// <returns>A <see cref="Task"/> that will complete the message processing.</returns>
-        public virtual async Task CompleteProcessingMessageAsync(BrokeredMessage message, FunctionResult result, CancellationToken cancellationToken)
+        public virtual Task CompleteProcessingMessageAsync(BrokeredMessage message, FunctionResult result, CancellationToken cancellationToken)
         {
-            if (result.Succeeded)
+            if (result == null)
             {
-                if (!MessageOptions.AutoComplete)
-                {
-                    // AutoComplete is true by default, but if set to false
-                    // we need to complete the message
-                    cancellationToken.ThrowIfCancellationRequested();
-                    await message.CompleteAsync();
-                }
+                throw new ArgumentNullException(nameof(result));
             }
-            else
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!result.Succeeded)
             {
                 // if the invocation failed, we must propagate the
                 // exception back to SB so it can handle message state
                 // correctly
-                cancellationToken.ThrowIfCancellationRequested();
                 throw result.Exception;
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/MessageProcessorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/MessageProcessorTests.cs
@@ -13,28 +13,6 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests
     public class MessageProcessorTests
     {
         [Fact]
-        public async Task CompleteProcessingMessageAsync_Success_CompletesMessage_WhenAutoCompleteFalse()
-        {
-            OnMessageOptions options = new OnMessageOptions
-            {
-                AutoComplete = false
-            };
-            MessageProcessor processor = new MessageProcessor(options);
-
-            BrokeredMessage message = new BrokeredMessage();
-            FunctionResult result = new FunctionResult(true);
-            var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
-            {
-                await processor.CompleteProcessingMessageAsync(message, result, CancellationToken.None);
-            });
-
-            // The service bus APIs aren't unit testable, so in this test suite
-            // we rely on exception stacks to verify APIs are called as expected.
-            // this verifies that we initiated the completion
-            Assert.True(ex.ToString().Contains("Microsoft.ServiceBus.Messaging.BrokeredMessage.BeginComplete"));
-        }
-
-        [Fact]
         public async Task CompleteProcessingMessageAsync_Failure_PropagatesException()
         {
             OnMessageOptions options = new OnMessageOptions


### PR DESCRIPTION
Related to Functions issue https://github.com/Azure/azure-functions-host/issues/2066 where users need the ability to control completion behavior for successful function invocations. In part of the discussion of that issue, it was pointed out that even when OnMessageOptions.AutoComplete is set to false, we still call complete! This logic was added a long time ago (in this [commit](https://github.com/Azure/azure-webjobs-sdk/commit/e52196e2661f3acc18b6069cc6f34d5eac2b98bb#diff-cea788c59d9a8fcd71c41c3b06ce6a23)) and I don't think it is correct. When you set AutoComplete to false, you're saying that in the absence of an exception, you want to control the message state yourself (e.g. call Complete/DeadLetter/etc.).

The default for AutoComplete is true, so this change will only affect people who have changed the default. Technically it is a breaking change, but given that this won't affect default users, and the behavior when set to false doesn't make any sense, I'm comfortable making the change in a minor version release as a bug fix. Note that for Azure Functions users, since we don't currently allow you to configure AutoComplete, it isn't breaking there.

Will make the same change in dev.