### PR TITLE
ExtensionAttribute pattern refinements (#3186)

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/EventHubExtensionConfigProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/EventHubExtensionConfigProvider.cs
@@ -17,7 +17,7 @@ using Newtonsoft.Json;
 namespace Microsoft.Azure.WebJobs.EventHubs
 {
     [Extension("EventHubs")]
-    public class EventHubExtensionConfigProvider : IExtensionConfigProvider
+    internal class EventHubExtensionConfigProvider : IExtensionConfigProvider
     {
         private readonly EventHubConfiguration _options;
         private readonly ILoggerFactory _loggerFactory;

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/AzureStorageWebJobsStartup.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/AzureStorageWebJobsStartup.cs
@@ -5,11 +5,11 @@ using Microsoft.Azure.WebJobs.Extensions.Storage;
 using Microsoft.Azure.WebJobs.Hosting;
 using Microsoft.Extensions.Hosting;
 
-[assembly: WebJobsStartup(typeof(StorageWebJobsStartup))]
+[assembly: WebJobsStartup(typeof(AzureStorageWebJobsStartup))]
 
 namespace Microsoft.Azure.WebJobs.Extensions.Storage
 {
-    public class StorageWebJobsStartup : IWebJobsStartup
+    public class AzureStorageWebJobsStartup : IWebJobsStartup
     {
         public void Configure(IWebJobsBuilder builder)
         {

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Config/BlobsExtensionConfigProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Config/BlobsExtensionConfigProvider.cs
@@ -18,7 +18,7 @@ using Microsoft.WindowsAzure.Storage.Blob;
 
 namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
 {
-    [Extension("AzureBlobs")]
+    [Extension("AzureStorageBlobs", "Blobs")]
     internal class BlobsExtensionConfigProvider : IExtensionConfigProvider,
         IAsyncConverter<BlobAttribute, CloudBlobContainer>,
         IAsyncConverter<BlobAttribute, CloudBlobDirectory>,
@@ -285,13 +285,13 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
             }
         }
 
-        private async Task<CloudBlobClient> GetClientAsync(
+        private Task<CloudBlobClient> GetClientAsync(
          BlobAttribute blobAttribute,
          CancellationToken cancellationToken)
         {
             var account = _accountProvider.Get(blobAttribute.Connection, _nameResolver);
             var client = account.CreateCloudBlobClient();
-            return client;
+            return Task.FromResult(client);
         }
 
         private async Task<CloudBlobContainer> GetContainerAsync(

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Queues/Config/QueuesExtensionConfigProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Queues/Config/QueuesExtensionConfigProvider.cs
@@ -16,7 +16,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Host.Queues.Config
 {
-    [Extension("AzureQueues")]
+    [Extension("AzureStorageQueues", "Queues")]
     internal class QueuesExtensionConfigProvider : IExtensionConfigProvider
     {
         private readonly IContextGetter<IMessageEnqueuedWatcher> _contextGetter;
@@ -192,7 +192,7 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Config
                 return new QueueAsyncCollector(queue, _messageEnqueuedWatcherGetter.Value);
             }
 
-            internal async Task<CloudQueue> GetQueueAsync(QueueAttribute attrResolved)
+            internal Task<CloudQueue> GetQueueAsync(QueueAttribute attrResolved)
             {
                 // var account = await _accountProvider.GetStorageAccountAsync(attrResolved, CancellationToken.None);
                 var account = _accountProvider.Get(attrResolved.Connection);
@@ -201,7 +201,8 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Config
                 string queueName = attrResolved.QueueName.ToLowerInvariant();
                 QueueClient.ValidateQueueName(queueName);
 
-                return client.GetQueueReference(queueName);
+                var queue = client.GetQueueReference(queueName);
+                return Task.FromResult(queue);
             }
 
             internal CloudQueue GetQueue(QueueAttribute attrResolved)

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Tables/Config/TablesExtensionConfigProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Tables/Config/TablesExtensionConfigProvider.cs
@@ -15,8 +15,8 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Host.Tables.Config
 {
-    [Extension("AzureTables")]
-    public class TablesExtensionConfigProvider : IExtensionConfigProvider
+    [Extension("AzureStorageTables", "Tables")]
+    internal class TablesExtensionConfigProvider : IExtensionConfigProvider
     {
         private StorageAccountProvider _accountProvider;
         private readonly INameResolver _nameResolver;

--- a/src/Microsoft.Azure.WebJobs.Host/Hosting/IWebJobsStartup.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Hosting/IWebJobsStartup.cs
@@ -1,14 +1,20 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using Microsoft.Extensions.Hosting;
-
 namespace Microsoft.Azure.WebJobs.Hosting
 {
+    /// <summary>
+    /// Interface defining a startup configuration action that should be performed
+    /// as part of host startup.
+    /// </summary>
     public interface IWebJobsStartup
     {
+        /// <summary>
+        /// Performs the startup configuration action. The host will call this
+        /// method at the right time during host initialization.
+        /// </summary>
+        /// <param name="builder">The <see cref="IWebJobsBuilder"/> that can be used to
+        /// configure the host.</param>
         void Configure(IWebJobsBuilder builder);
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsStartupAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsStartupAttribute.cs
@@ -5,10 +5,20 @@ using System;
 
 namespace Microsoft.Azure.WebJobs.Hosting
 {
+    /// <summary>
+    /// Attribute used to declare <see cref="IWebJobsStartup"/> Types that should be registered and invoked
+    /// as part of host startup.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Assembly, Inherited = false, AllowMultiple = true)]
     public class WebJobsStartupAttribute : Attribute
     {
-        public WebJobsStartupAttribute(Type startupType)
+        /// <summary>
+        /// Constructs a new instance.
+        /// </summary>
+        /// <param name="startupType">The Type of the <see cref="IWebJobsStartup"/> class to register.</param>
+        /// <param name="name">The friendly human readable name for the startup action. If null, the name will be
+        /// defaulted based on naming convention.</param>
+        public WebJobsStartupAttribute(Type startupType, string name = null)
         {
             if (startupType == null)
             {
@@ -20,9 +30,33 @@ namespace Microsoft.Azure.WebJobs.Hosting
                 throw new ArgumentException($@"""{startupType}"" does not implement {typeof(IWebJobsStartup)}.", nameof(startupType));
             }
 
+            if (string.IsNullOrEmpty(name))
+            {
+                // for a startup class named 'CustomConfigWebJobsStartup' or 'CustomConfigStartup',
+                // default to a name 'CustomConfig'
+                name = startupType.Name;
+                int idx = name.IndexOf("WebJobsStartup");
+                if (idx < 0)
+                {
+                    idx = name.IndexOf("Startup");
+                }
+                if (idx > 0)
+                {
+                    name = name.Substring(0, idx);
+                }
+            }
             WebJobsStartupType = startupType;
+            Name = name;
         }
 
+        /// <summary>
+        /// Gets the Type of the <see cref="IWebJobsStartup"/> class to register.
+        /// </summary>
         public Type WebJobsStartupType { get; }
+
+        /// <summary>
+        /// Gets the friendly human readable name for the startup action.
+        /// </summary>
+        public string Name { get;  }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Config/ServiceBusExtensionConfigProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Config/ServiceBusExtensionConfigProvider.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Config
     /// Extension configuration provider used to register ServiceBus triggers and binders
     /// </summary>
     [Extension("ServiceBus")]
-    public class ServiceBusExtensionConfigProvider : IExtensionConfigProvider
+    internal class ServiceBusExtensionConfigProvider : IExtensionConfigProvider
     {
         private readonly INameResolver _nameResolver;
         private readonly IConnectionStringProvider _connectionStringProvider;

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Config/ServiceBusHostBuilderExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Config/ServiceBusHostBuilderExtensions.cs
@@ -17,10 +17,10 @@ namespace Microsoft.Extensions.Hosting
             builder.AddExtension<ServiceBusExtensionConfigProvider>();
 
             builder.Services.AddOptions<ServiceBusOptions>()
-                            .Configure<IConnectionStringProvider>((o, p) =>
-                            {
-                                o.ConnectionString = p.GetConnectionString(ConnectionStringNames.ServiceBus);
-                            });
+                .Configure<IConnectionStringProvider>((o, p) =>
+                {
+                    o.ConnectionString = p.GetConnectionString(ConnectionStringNames.ServiceBus);
+                });
 
             builder.Services.TryAddSingleton<MessagingProvider>();
 

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/Triggers/MessageValueProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/Triggers/MessageValueProvider.cs
@@ -3,12 +3,10 @@
 
 using System;
 using System.Globalization;
-using System.IO;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.ServiceBus;
+using Microsoft.Azure.WebJobs.Host.Bindings;
 
 namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
 {
@@ -67,14 +65,15 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
             }
         }
 
-        private static async Task<string> GetBase64StringAsync(Message clonedMessage,
+        private static Task<string> GetBase64StringAsync(Message clonedMessage,
             CancellationToken cancellationToken)
         {
             if (clonedMessage.Body == null)
             {
-                return null;
+                return Task.FromResult((string)null);
             }
-            return Convert.ToBase64String(clonedMessage.Body);
+            string converted = Convert.ToBase64String(clonedMessage.Body);
+            return Task.FromResult(converted);
         }
 
         private static Task<string> GetDescriptionAsync(Message clonedMessage)
@@ -85,14 +84,15 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
             return Task.FromResult(description);
         }
 
-        private static async Task<string> GetTextAsync(Message clonedMessage,
+        private static Task<string> GetTextAsync(Message clonedMessage,
             CancellationToken cancellationToken)
         {
             if (clonedMessage.Body == null)
             {
-                return null;
+                return Task.FromResult((string)null);
             }
-            return StrictEncodings.Utf8.GetString(clonedMessage.Body);
+            string s = StrictEncodings.Utf8.GetString(clonedMessage.Body);
+            return Task.FromResult(s);
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs/ExtensionAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs/ExtensionAttribute.cs
@@ -6,19 +6,25 @@ using System;
 namespace Microsoft.Azure.WebJobs.Description
 {
     /// <summary>
-    /// Attribute applied to the <see cref="IExtensionConfigProvider"/> implementation for an extension.
+    /// Attribute used to mark types belonging to a single logical extension.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, Inherited = false)]
     public sealed class ExtensionAttribute : Attribute
     {
-        public ExtensionAttribute(string name)
+        public ExtensionAttribute(string name, string configurationSection = null)
         {
             Name = name;
+            ConfigurationSection = configurationSection ?? name;
         }
 
         /// <summary>
-        /// Gets the friendly name of the extension.
+        /// Gets the friendly human readable name of the extension.
         /// </summary>
         public string Name { get;  }
+
+        /// <summary>
+        /// Gets the configuration section name for this extension.
+        /// </summary>
+        public string ConfigurationSection { get; }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.EventHubs.UnitTests/PublicSurfaceTests.cs
+++ b/test/Microsoft.Azure.WebJobs.EventHubs.UnitTests/PublicSurfaceTests.cs
@@ -18,7 +18,6 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 "EventHubAttribute",
                 "EventHubTriggerAttribute",
                 "EventHubConfiguration",
-                "EventHubExtensionConfigProvider",
                 "EventHubWebJobsBuilderExtensions",
                 "EventHubsWebJobsStartup"
             };

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Hosting/WebJobsStartupTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Hosting/WebJobsStartupTests.cs
@@ -14,14 +14,27 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Hosting
     public class WebJobsStartupTests
     {
         [Fact]
+        public void WebJobsStartupAttribute_Constructor_InitializesAlias()
+        {
+            var attribute = new WebJobsStartupAttribute(typeof(FooStartup));
+            Assert.Equal("Foo", attribute.Name);
+
+            attribute = new WebJobsStartupAttribute(typeof(FooWebJobsStartup));
+            Assert.Equal("Foo", attribute.Name);
+
+            attribute = new WebJobsStartupAttribute(typeof(FooWebJobsStartup), "Bar");
+            Assert.Equal("Bar", attribute.Name);
+        }
+
+        [Fact]
         public void GenericUseWebJobsStartup_CallsStartupMethods()
         {
             using (new StartupScope())
             {
                 var builder = new HostBuilder()
-                    .ConfigureWebJobs(webJobeBuilder =>
+                    .ConfigureWebJobs(webJobsBuilder =>
                     {
-                        webJobeBuilder.UseWebJobsStartup<TestStartup>();
+                        webJobsBuilder.UseWebJobsStartup<TestStartup>();
                     });
 
                 IHost host = builder.Build();
@@ -40,9 +53,9 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Hosting
             using (new StartupScope())
             {
                 var builder = new HostBuilder()
-                    .ConfigureWebJobs(webJobeBuilder =>
+                    .ConfigureWebJobs(webJobsBuilder =>
                     {
-                        webJobeBuilder.UseWebJobsStartup(typeof(TestStartup));
+                        webJobsBuilder.UseWebJobsStartup(typeof(TestStartup));
                     });
 
 
@@ -111,6 +124,22 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Hosting
             public void Configure(IWebJobsBuilder builder)
             {
                 builder.Services.AddSingleton<TestExternalService>();
+            }
+        }
+
+        public class FooStartup : IWebJobsStartup
+        {
+            public void Configure(IWebJobsBuilder builder)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public class FooWebJobsStartup : IWebJobsStartup
+        {
+            public void Configure(IWebJobsBuilder builder)
+            {
+                throw new NotImplementedException();
             }
         }
 

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/PublicSurfaceTests.cs
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/PublicSurfaceTests.cs
@@ -21,7 +21,6 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 "ServiceBusAccountAttribute",
                 "ServiceBusAttribute",
                 "ServiceBusTriggerAttribute",
-                "ServiceBusExtensionConfigProvider",
                 "ServiceBusHostBuilderExtensions",
                 "ServiceBusOptions",
                 "ServiceBusWebJobsStartup"

--- a/test/Microsoft.Azure.Webjobs.Extensions.Storage.UnitTests/PublicSurfaceTests.cs
+++ b/test/Microsoft.Azure.Webjobs.Extensions.Storage.UnitTests/PublicSurfaceTests.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using Microsoft.Azure.WebJobs.Host.TestCommon;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Host.UnitTests
@@ -66,11 +64,10 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 "StorageHostBuilderExtensions",
                 "TableAttribute",
                 "TableEntityParameterDescriptor",
-                "TablesExtensionConfigProvider",
                 "TableParameterDescriptor",
                 "StorageAccount",
                 "StorageAccountProvider",
-                "StorageWebJobsStartup"
+                "AzureStorageWebJobsStartup"
             };
 
             TestHelpers.AssertPublicTypes(expected, assembly);

--- a/test/Microsoft.Azure.Webjobs.Extensions.Storage.UnitTests/Queues/QueueListenerTests.cs
+++ b/test/Microsoft.Azure.Webjobs.Extensions.Storage.UnitTests/Queues/QueueListenerTests.cs
@@ -377,6 +377,5 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Queues
                 Task.WaitAll(tasks.ToArray());
             }
         }
-
     }
 }


### PR DESCRIPTION
We didn't really want IExtensionConfigProviders to have to be public just for tooling discovery. This actually was problematic in a couple cases (Blobs/Queues) where these couldn't be made public due to the fact that the ctors for the config providers referenced non-public types injected via DI. That will be a general problem for people wishing to leverage DI for their config providers.

So instead I'd like to move to the pattern where it's the WebJobsStartup class for an extension that is annotated. The runtime already discovers these and runs them to register extensions, so these really do define the extensions that are installed at runtime. So for the tooling issue https://github.com/Azure/azure-functions-host/issues/3186 I'll update the tooling to instead search for WebJobsStartup types and those will be added to extensions.json. The runtime already treats these as startup types.

The startup class maps to the set of extensions that will be registered by a startup class. E.g., the AzureStorage extension includes Blobs/Tables/Queues each which as an implementation detail has its own IExtensionConfigProvider. However the unit of registration is AddAzureStorage corresponding to the startup class. Similarly for the "core" extensions in the extensions repo (Files/Timers). [ExtensionsWebJobsStartup](https://github.com/Azure/azure-webjobs-sdk-extensions/blob/dev/src/WebJobs.Extensions/Extensions/ExtensionsWebJobsStartup.cs) registers both Timers and Files. I'll likely give this extension an name like "Core" or something, or perhaps we split it out into a couple startup classes, TBD.