### PR TITLE
Populate SystemProperties on binding data

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Extensions/SystemPropertiesCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Extensions/SystemPropertiesCollectionExtensions.cs
@@ -11,7 +11,13 @@ namespace Microsoft.Azure.WebJobs.EventHubs
     {
         internal static IDictionary<string, object> ToDictionary(this SystemPropertiesCollection collection)
         {
-            return JObject.FromObject(collection).ToObject<IDictionary<string, object>>();
+            return new Dictionary<string, object>()
+            {
+                { "SequenceNumber", collection.SequenceNumber},
+                { "Offset", collection.Offset },
+                { "PartitionKey", collection.PartitionKey },
+                { "EnqueuedTimeUtc", collection.EnqueuedTimeUtc }
+            };
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.EventHubs.UnitTests/EventHubTests.cs
+++ b/test/Microsoft.Azure.WebJobs.EventHubs.UnitTests/EventHubTests.cs
@@ -88,9 +88,12 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             Assert.Equal(evt.SystemProperties.SequenceNumber, bindingData["SequenceNumber"]);
             Assert.Equal(evt.SystemProperties.EnqueuedTimeUtc, bindingData["EnqueuedTimeUtc"]);
             Assert.Same(evt.Properties, bindingData["Properties"]);
-            var bindingDataSysProps = bindingData["SystemProperties"] as IDictionary<string, object>;
+            IDictionary<string, object> bindingDataSysProps = bindingData["SystemProperties"] as Dictionary<string, object>;
             Assert.NotNull(bindingDataSysProps);
-            Assert.True(CompareSystemProperties(bindingDataSysProps, sysProps));
+            Assert.Equal(bindingDataSysProps["PartitionKey"], bindingData["PartitionKey"]);
+            Assert.Equal(bindingDataSysProps["Offset"], bindingData["Offset"]);
+            Assert.Equal(bindingDataSysProps["SequenceNumber"], bindingData["SequenceNumber"]);
+            Assert.Equal(bindingDataSysProps["EnqueuedTimeUtc"], bindingData["EnqueuedTimeUtc"]);
         }
 
         private static IDictionary<string, object> GetSystemProperties(string partitionKey = "TestKey")
@@ -102,12 +105,6 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             sysProps["x-opt-enqueued-time"] = DateTime.MinValue;
             sysProps["x-opt-sequence-number"] = testSequence;
             return sysProps;
-        }
-
-        private static bool CompareSystemProperties(IDictionary<string, object> actualProperties, IDictionary<string, object> expectedProperties)
-        {
-           return actualProperties.Keys.Count == expectedProperties.Keys.Count &&
-                   actualProperties.Keys.All(k => expectedProperties.ContainsKey(k) && object.Equals(actualProperties[k], expectedProperties[k]));
         }
 
         [Fact]


### PR DESCRIPTION
Populate SystemProperties on binding data with same property names as used in [EventData SystemPropertiesCollection](https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.eventhubs.eventdata.systempropertiescollection?view=azure-dotnet)
Implementation of SystemPropertiesCollection in Microsoft.Azure.Eventhubs changed from v 1.0.3 to 2.1.0.

Here is the reference to SystemPropertiesCollection from .Net reflector

```
public sealed class SystemPropertiesCollection : Dictionary<string, object>
        {
            internal SystemPropertiesCollection()
            {
            }
            
            public long SequenceNumber
            {
                get
                {
                    object obj2;
                    if (base.TryGetValue("x-opt-sequence-number", ref obj2))
                    {
                        return (long) obj2;
                    }
                    object[] args = new object[] { "x-opt-sequence-number" };
                    throw new ArgumentException(Resources.MissingSystemProperty.FormatForUser(args));
                }
            }
            
            public DateTime EnqueuedTimeUtc
            {
                get
                {
                    object obj2;
                    if (base.TryGetValue("x-opt-enqueued-time", ref obj2))
                    {
                        return (DateTime) obj2;
                    }
                    object[] args = new object[] { "x-opt-enqueued-time" };
                    throw new ArgumentException(Resources.MissingSystemProperty.FormatForUser(args));
                }
            }
            
            public string Offset
            {
                get
                {
                    object obj2;
                    if (base.TryGetValue("x-opt-offset", ref obj2))
                    {
                        return (string) obj2;
                    }
                    object[] args = new object[] { "x-opt-offset" };
                    throw new ArgumentException(Resources.MissingSystemProperty.FormatForUser(args));
                }
            }
            
            public string PartitionKey
            {
                get
                {
                    object obj2;
                    if (base.TryGetValue("x-opt-partition-key", ref obj2))
                    {
                        return (string) obj2;
                    }
                    return null;
                }
            }
        }
```