### PR TITLE
Throw exception without losing stack trace

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionExecutor.cs
@@ -1181,7 +1181,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
                     // If a post-filter throws, capture that 
                     if (exception != null)
                     {
-                        throw exception;
+                        ExceptionDispatchInfo.Capture(exception).Throw();
                     }
                 }
             }


### PR DESCRIPTION
When using a FunctionInvocationFilterAttribute, exceptions are not keeping their stack trace due to this "thow exception".