### PR TITLE
Add QuickPulse Api Key to AppInsights settings and apply it

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
@@ -13,5 +13,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
         public SamplingPercentageEstimatorSettings SamplingSettings { get; set; }
 
         public SnapshotCollectorConfiguration SnapshotConfiguration { get; set; }
+
+        public string QuickPulseAuthenticationApiKey { get; set; }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
@@ -109,6 +109,26 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
         }
 
         [Fact]
+        public void DependencyInjectionConfiguration_ConfiguresQuickPulseAuthApiKey()
+        {
+            using (var host = new HostBuilder()
+                .ConfigureLogging(b =>
+                {
+                    b.AddApplicationInsights(o =>
+                    {
+                        o.InstrumentationKey = "some key";
+                        o.QuickPulseAuthenticationApiKey = "some auth key";
+                    });
+                })
+                .Build())
+            {
+                var modules = host.Services.GetServices<ITelemetryModule>().ToList();
+                var quickPulseTelemetryModule = modules.OfType<QuickPulseTelemetryModule>().Single();
+                Assert.Equal("some auth key", quickPulseTelemetryModule.AuthenticationApiKey);
+            }
+        }
+
+        [Fact]
         public void DependencyInjectionConfiguration_NoFilterConfiguresSampling()
         {
             var samplingSettings = new SamplingPercentageEstimatorSettings { MaxTelemetryItemsPerSecond = 1 };


### PR DESCRIPTION
See https://github.com/Azure/azure-webjobs-sdk/issues/1349

This change allows configuring QuickPulse AuthentificationApiKey to secure livestream channel: https://docs.microsoft.com/en-us/azure/application-insights/app-insights-live-stream#secure-the-control-channel