### PR TITLE
Fix EventHub configuration (#1857)

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Config/EventHubWebJobsBuilderExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Config/EventHubWebJobsBuilderExtensions.cs
@@ -1,10 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.Azure.EventHubs.Processor;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.EventHubs;
-using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Extensions.Hosting
 {
@@ -12,10 +13,35 @@ namespace Microsoft.Extensions.Hosting
     {
         public static IWebJobsBuilder AddEventHubs(this IWebJobsBuilder builder)
         {
-            builder.AddExtension<EventHubExtensionConfigProvider>()
-                .BindOptions<EventProcessorOptions>();
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
 
-            builder.Services.TryAddSingleton<EventHubConfiguration>();
+            builder.AddEventHubs(p => {});
+
+            return builder;
+        }
+
+        public static IWebJobsBuilder AddEventHubs(this IWebJobsBuilder builder, Action<EventHubOptions> configure)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            builder.AddExtension<EventHubExtensionConfigProvider>()
+                .BindOptions<EventHubOptions>();
+
+            builder.Services.Configure<EventHubOptions>(options =>
+            {
+                configure(options);
+            });
 
             return builder;
         }

--- a/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Listeners/EventHubListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Listeners/EventHubListener.cs
@@ -19,18 +19,16 @@ namespace Microsoft.Azure.WebJobs.EventHubs
         private readonly ITriggeredFunctionExecutor _executor;
         private readonly EventProcessorHost _eventProcessorHost;
         private readonly bool _singleDispatch;
-        private readonly EventProcessorOptions _options;
-        private readonly EventHubConfiguration _config;
+        private readonly EventHubOptions _options;
         private readonly ILogger _logger;
         private bool _started;
 
-        public EventHubListener(ITriggeredFunctionExecutor executor, EventProcessorHost eventProcessorHost, bool singleDispatch, EventHubConfiguration config, ILogger logger)
+        public EventHubListener(ITriggeredFunctionExecutor executor, EventProcessorHost eventProcessorHost, bool singleDispatch, EventHubOptions options, ILogger logger)
         {
             _executor = executor;
             _eventProcessorHost = eventProcessorHost;
             _singleDispatch = singleDispatch;
-            _options = config.GetOptions();
-            _config = config;
+            _options = options;
             _logger = logger;
         }
 
@@ -45,7 +43,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
 
         public async Task StartAsync(CancellationToken cancellationToken)
         {
-            await _eventProcessorHost.RegisterEventProcessorFactoryAsync(this, _options);
+            await _eventProcessorHost.RegisterEventProcessorFactoryAsync(this, _options.EventProcessorOptions);
             _started = true;
         }
 
@@ -60,7 +58,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
 
         IEventProcessor IEventProcessorFactory.CreateEventProcessor(PartitionContext context)
         {
-            return new EventProcessor(_config, _executor, _logger, _singleDispatch);
+            return new EventProcessor(_options, _executor, _logger, _singleDispatch);
         }
 
         /// <summary>
@@ -84,12 +82,12 @@ namespace Microsoft.Azure.WebJobs.EventHubs
             private int _batchCounter = 0;
             private bool _disposed = false;
 
-            public EventProcessor(EventHubConfiguration config, ITriggeredFunctionExecutor executor, ILogger logger, bool singleDispatch, ICheckpointer checkpointer = null)
+            public EventProcessor(EventHubOptions options, ITriggeredFunctionExecutor executor, ILogger logger, bool singleDispatch, ICheckpointer checkpointer = null)
             {
                 _checkpointer = checkpointer ?? this;
                 _executor = executor;
                 _singleDispatch = singleDispatch;
-                _batchCheckpointFrequency = config.BatchCheckpointFrequency;
+                _batchCheckpointFrequency = options.BatchCheckpointFrequency;
                 _logger = logger;
             }
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Triggers/EventHubTriggerAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Triggers/EventHubTriggerAttributeBindingProvider.cs
@@ -11,6 +11,8 @@ using Microsoft.Azure.WebJobs.Host.Triggers;
 using Microsoft.Azure.EventHubs;
 using Microsoft.Extensions.Logging;
 using Microsoft.Azure.WebJobs.Logging;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.WebJobs.EventHubs
 {
@@ -18,18 +20,21 @@ namespace Microsoft.Azure.WebJobs.EventHubs
     {
         private readonly INameResolver _nameResolver;
         private readonly ILogger _logger;
-        private readonly EventHubConfiguration _eventHubConfig;
+        private readonly IConfiguration _config;
+        private readonly IOptions<EventHubOptions> _options;
         private readonly IConverterManager _converterManager;
 
         public EventHubTriggerAttributeBindingProvider(
+            IConfiguration configuration,
             INameResolver nameResolver,
             IConverterManager converterManager,
-            EventHubConfiguration eventHubConfig,
+            IOptions<EventHubOptions> options,
             ILoggerFactory loggerFactory)
         {
+            _config = configuration;
             _nameResolver = nameResolver;
             _converterManager = converterManager;
-            _eventHubConfig = eventHubConfig;
+            _options = options;
             _logger = loggerFactory?.CreateLogger(LogCategories.CreateTriggerCategory("EventHub"));
         }
 
@@ -56,15 +61,15 @@ namespace Microsoft.Azure.WebJobs.EventHubs
 
             if (!string.IsNullOrWhiteSpace(attribute.Connection))
             {
-                _eventHubConfig.AddReceiver(resolvedEventHubName, _nameResolver.Resolve(attribute.Connection));
+                _options.Value.AddReceiver(resolvedEventHubName, _nameResolver.Resolve(attribute.Connection));
             }
             
-            var eventHostListener = _eventHubConfig.GetEventProcessorHost(resolvedEventHubName, resolvedConsumerGroup);
+            var eventHostListener = _options.Value.GetEventProcessorHost(_config, resolvedEventHubName, resolvedConsumerGroup);
 
             Func<ListenerFactoryContext, bool, Task<IListener>> createListener =
              (factoryContext, singleDispatch) =>
              {
-                 IListener listener = new EventHubListener(factoryContext.Executor, eventHostListener, singleDispatch, _eventHubConfig, _logger);
+                 IListener listener = new EventHubListener(factoryContext.Executor, eventHostListener, singleDispatch, _options.Value, _logger);
                  return Task.FromResult(listener);
              };
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/Config/ServiceBusWebJobsBuilderExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/Config/ServiceBusWebJobsBuilderExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.ServiceBus;
 using Microsoft.Azure.WebJobs.ServiceBus.Config;
@@ -14,6 +15,28 @@ namespace Microsoft.Extensions.Hosting
     {
         public static IWebJobsBuilder AddServiceBus(this IWebJobsBuilder builder)
         {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            builder.AddServiceBus(p => { });
+
+            return builder;
+        }
+
+        public static IWebJobsBuilder AddServiceBus(this IWebJobsBuilder builder, Action<ServiceBusOptions> configure)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
             builder.AddExtension<ServiceBusExtensionConfigProvider>()
                 .ConfigureOptions<ServiceBusOptions>((config, path, options) =>
                 {
@@ -21,6 +44,8 @@ namespace Microsoft.Extensions.Hosting
 
                     IConfigurationSection section = config.GetSection(path);
                     section.Bind(options);
+
+                    configure(options);
                 });
 
             builder.Services.TryAddSingleton<MessagingProvider>();

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/StorageWebJobsBuilderExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/StorageWebJobsBuilderExtensions.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Extensions.Hosting
 {
     public static class StorageWebJobsBuilderExtensions
     {
-        public static IWebJobsBuilder AddAzureStorage(this IWebJobsBuilder builder)
+        public static IWebJobsBuilder AddAzureStorage(this IWebJobsBuilder builder, Action<QueuesOptions> configureQueues = null, Action<BlobsOptions> configureBlobs = null)
         {
             // add webjobs to user agent for all storage calls
             OperationContext.GlobalSendingRequest += (sender, e) =>
@@ -61,6 +61,10 @@ namespace Microsoft.Extensions.Hosting
 
             builder.AddExtension<QueuesExtensionConfigProvider>()
                 .BindOptions<QueuesOptions>();
+            if (configureQueues != null)
+            {
+                builder.Services.Configure<QueuesOptions>(configureQueues);
+            }
 
             builder.Services.TryAddSingleton<IQueueProcessorFactory, DefaultQueueProcessorFactory>();
 
@@ -75,6 +79,10 @@ namespace Microsoft.Extensions.Hosting
 
             builder.AddExtension<BlobsExtensionConfigProvider>()
                 .BindOptions<BlobsOptions>();
+            if (configureBlobs != null)
+            {
+                builder.Services.Configure<BlobsOptions>(configureBlobs);
+            }
 
             return builder;
         }

--- a/src/Microsoft.Azure.WebJobs.Host.Storage/RuntimeStorageWebJobsBuilderExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host.Storage/RuntimeStorageWebJobsBuilderExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Extensions.Hosting
     public static class RuntimeStorageWebJobsBuilderExtensions
     {
         // WebJobs v1 Classic logging. Needed for dashboard.         
-        // $$$ Update title? 
+        [Obsolete("Dashboard is being deprecated. Use AppInsights.")]
         public static IWebJobsBuilder AddDashboardLogging(this IWebJobsBuilder builder)
         {
             builder.Services.AddDashboardLogging();

--- a/src/Microsoft.Azure.WebJobs.Host.Storage/StorageServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host.Storage/StorageServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Threading;
 using Microsoft.Azure.WebJobs.Host.Loggers;
 using Microsoft.Extensions.DependencyInjection;
@@ -10,7 +11,8 @@ using WebJobs.Host.Storage.Logging;
 namespace Microsoft.Extensions.Hosting
 {
     public static class StorageServiceCollectionExtensions
-    {  
+    {
+        [Obsolete("Dashboard is being deprecated. Use AppInsights.")]
         public static IServiceCollection AddDashboardLogging(this IServiceCollection services)
         {
             services.TryAddSingleton<LoggerProviderFactory>();

--- a/src/Microsoft.Azure.WebJobs/BindingAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs/BindingAttribute.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Azure.WebJobs.Description
         /// from a function.
         /// </summary>
         /// $$$ Review this
+        [Obsolete("Will be redesigned in a future release.")]
         public bool TriggerHandlesReturnValue { get; set; }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.EventHubs.UnitTests/EventHubListenerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.EventHubs.UnitTests/EventHubListenerTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
         {
             var partitionContext = EventHubTests.GetPartitionContext();
             var checkpoints = 0;
-            var config = new EventHubConfiguration
+            var options = new EventHubOptions
             {
                 BatchCheckpointFrequency = batchCheckpointFrequency
             };
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             var loggerMock = new Mock<ILogger>(MockBehavior.Strict);
             var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
             executor.Setup(p => p.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>())).ReturnsAsync(new FunctionResult(true));
-            var eventProcessor = new EventHubListener.EventProcessor(config, executor.Object, loggerMock.Object, true, checkpointer.Object);
+            var eventProcessor = new EventHubListener.EventProcessor(options, executor.Object, loggerMock.Object, true, checkpointer.Object);
 
             for (int i = 0; i < 100; i++)
             {
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
         public async Task ProcessEvents_MultipleDispatch_CheckpointsCorrectly(int batchCheckpointFrequency, int expected)
         {
             var partitionContext = EventHubTests.GetPartitionContext();
-            var config = new EventHubConfiguration
+            var options = new EventHubOptions
             {
                 BatchCheckpointFrequency = batchCheckpointFrequency
             };
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             var loggerMock = new Mock<ILogger>(MockBehavior.Strict);
             var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
             executor.Setup(p => p.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>())).ReturnsAsync(new FunctionResult(true));
-            var eventProcessor = new EventHubListener.EventProcessor(config, executor.Object, loggerMock.Object, false, checkpointer.Object);
+            var eventProcessor = new EventHubListener.EventProcessor(options, executor.Object, loggerMock.Object, false, checkpointer.Object);
 
             for (int i = 0; i < 100; i++)
             {
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
         public async Task ProcessEvents_Failure_Checkpoints()
         {
             var partitionContext = EventHubTests.GetPartitionContext();
-            var config = new EventHubConfiguration();
+            var options = new EventHubOptions();
             var checkpointer = new Mock<EventHubListener.ICheckpointer>(MockBehavior.Strict);
             checkpointer.Setup(p => p.CheckpointAsync(partitionContext)).Returns(Task.CompletedTask);
 
@@ -107,7 +107,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
                 return result;
             });
             var loggerMock = new Mock<ILogger>(MockBehavior.Strict);
-            var eventProcessor = new EventHubListener.EventProcessor(config, executor.Object, loggerMock.Object, true, checkpointer.Object);
+            var eventProcessor = new EventHubListener.EventProcessor(options, executor.Object, loggerMock.Object, true, checkpointer.Object);
 
             await eventProcessor.ProcessEventsAsync(partitionContext, events);
 
@@ -118,11 +118,11 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
         public async Task CloseAsync_Shutdown_DoesNotCheckpoint()
         {
             var partitionContext = EventHubTests.GetPartitionContext();
-            var config = new EventHubConfiguration();
+            var options = new EventHubOptions();
             var checkpointer = new Mock<EventHubListener.ICheckpointer>(MockBehavior.Strict);
             var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
             var loggerMock = new Mock<ILogger>(MockBehavior.Strict);
-            var eventProcessor = new EventHubListener.EventProcessor(config, executor.Object, loggerMock.Object, true, checkpointer.Object);
+            var eventProcessor = new EventHubListener.EventProcessor(options, executor.Object, loggerMock.Object, true, checkpointer.Object);
 
             await eventProcessor.CloseAsync(partitionContext, CloseReason.Shutdown);
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.EventHubs.UnitTests/PublicSurfaceTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.EventHubs.UnitTests/PublicSurfaceTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             {
                 "EventHubAttribute",
                 "EventHubTriggerAttribute",
-                "EventHubConfiguration",
+                "EventHubOptions",
                 "EventHubWebJobsBuilderExtensions",
                 "EventHubsWebJobsStartup"
             };

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/EventHubEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/EventHubEndToEndTests.cs
@@ -143,17 +143,10 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     .ConfigureDefaultTestHost<EventHubTestJobs>(b =>
                     {
                         b.AddAzureStorage()
-                        .AddEventHubs();
-                    })
-                    .ConfigureServices(services =>
-                    {
-                        services.AddSingleton<EventHubConfiguration>(serviceProvider =>
+                        .AddEventHubs(options =>
                         {
-                            var configuration = serviceProvider.GetRequiredService<IConfiguration>();
-                            var eventHubConfig = new EventHubConfiguration(configuration);
-                            eventHubConfig.AddSender(TestHubName, connection);
-                            eventHubConfig.AddReceiver(TestHubName, connection);
-                            return eventHubConfig;
+                            options.AddSender(TestHubName, connection);
+                            options.AddReceiver(TestHubName, connection);
                         });
                     })
                     .Build();


### PR DESCRIPTION
Addresses https://github.com/Azure/azure-webjobs-sdk/issues/1857.

Not only is EventHub config currently broken (the documented setting BatchCheckpointFrequency is currently ignored if configured), but it also didn't follow the options pattern all the other extensions follow. This PR fixes all that.

Also in this PR:

- added some missing options config overloads for ServiceBus/AzureStorage extensions
- marked some more interfaces/members obsolete in prep for GA