### PR TITLE
Fixing Development environment options config (#1869)

### DIFF
--- a/sample/SampleHost/Program.cs
+++ b/sample/SampleHost/Program.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Microsoft.Azure.WebJobs;
 
 namespace SampleHost
 {
@@ -18,8 +17,7 @@ namespace SampleHost
                 .UseEnvironment("Development")
                 .ConfigureWebJobs(b =>
                 {
-                    b.AddDashboardLogging()
-                    .AddAzureStorageCoreServices()
+                    b.AddAzureStorageCoreServices()
                     .AddAzureStorage()
                     .AddServiceBus()
                     .AddEventHubs();

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/StorageWebJobsBuilderExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/StorageWebJobsBuilderExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Triggers;
 using Microsoft.Azure.WebJobs.Host;
@@ -16,6 +17,7 @@ using Microsoft.Azure.WebJobs.Host.Queues.Triggers;
 using Microsoft.Azure.WebJobs.Host.Tables.Config;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 using Microsoft.WindowsAzure.Storage;
 using WebJobs.Extensions.Storage;
 
@@ -61,6 +63,15 @@ namespace Microsoft.Extensions.Hosting
                 .BindOptions<QueuesOptions>();
 
             builder.Services.TryAddSingleton<IQueueProcessorFactory, DefaultQueueProcessorFactory>();
+
+            builder.Services.AddOptions<QueuesOptions>()
+                .Configure<IHostingEnvironment>((options, env) =>
+                {
+                    if (env.IsDevelopment())
+                    {
+                        options.MaxPollingInterval = TimeSpan.FromSeconds(2);
+                    }
+                });
 
             builder.AddExtension<BlobsExtensionConfigProvider>()
                 .BindOptions<BlobsOptions>();

--- a/test/Microsoft.Azure.Webjobs.Extensions.Storage.UnitTests/PublicSurfaceTests.cs
+++ b/test/Microsoft.Azure.Webjobs.Extensions.Storage.UnitTests/PublicSurfaceTests.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 "Microsoft.Azure.WebJobs.Host",
                 "Microsoft.Extensions.Configuration.Abstractions",
                 "Microsoft.Extensions.DependencyInjection.Abstractions",
+                "Microsoft.Extensions.Hosting.Abstractions",
                 "Microsoft.Extensions.Logging.Abstractions",
                 "Microsoft.Extensions.Options",
                 "Microsoft.WindowsAzure.Storage",

--- a/test/Microsoft.Azure.Webjobs.Extensions.Storage.UnitTests/Queues/StorageWebJobsBuilderExtensionsTests.cs
+++ b/test/Microsoft.Azure.Webjobs.Extensions.Storage.UnitTests/Queues/StorageWebJobsBuilderExtensionsTests.cs
@@ -14,6 +14,31 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.UnitTests.Queues
     public class StorageWebJobsBuilderExtensionsTests
     {
         [Fact]
+        public void ConfigureOptions_AppliesValuesCorrectly_Singleton()
+        {
+            string path = "AzureWebJobs:Singleton";
+            var values = new Dictionary<string, string>
+            {
+                { $"{path}:LockPeriod", "00:00:22" },
+                { $"{path}:ListenerLockPeriod", "00:00:22" },
+                { $"{path}:LockAcquisitionTimeout", "00:00:22" },
+                { $"{path}:LockAcquisitionPollingInterval", "00:00:22" },
+                { $"{path}:ListenerLockRecoveryPollingInterval", "00:00:22" }
+            };
+
+            SingletonOptions options = TestHelpers.GetConfiguredOptions<SingletonOptions>(b =>
+            {
+                b.AddAzureStorage();
+            }, values);
+
+            Assert.Equal(TimeSpan.FromSeconds(22), options.LockPeriod);
+            Assert.Equal(TimeSpan.FromSeconds(22), options.ListenerLockPeriod);
+            Assert.Equal(TimeSpan.FromSeconds(22), options.LockAcquisitionTimeout);
+            Assert.Equal(TimeSpan.FromSeconds(22), options.ListenerLockRecoveryPollingInterval);
+            Assert.Equal(TimeSpan.FromSeconds(22), options.ListenerLockRecoveryPollingInterval);
+        }
+
+        [Fact]
         public void ConfigureOptions_AppliesValuesCorrectly_Queues()
         {
             string extensionPath = "AzureWebJobs:Extensions:Queues";


### PR DESCRIPTION
Addresses https://github.com/Azure/azure-webjobs-sdk/issues/1869

Without these changes the development mode experience isn't very good. E.g. by default:

- after a short period of time the queue polling interval exponentially backs off to 1 minute
- the queue polling interval affects blob trigger as well
- timers can experience issues because the default listener lock period is 1 minute, meaning if you kill the local host and restart it, it might take up to a minute for it to acquire the lease