### PR TITLE
Adding support for [ConnectionString] attribute on binding attribute properties

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/EventHubAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/EventHubAttribute.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.WebJobs
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.ReturnValue)]
     [Binding]
-    public sealed class EventHubAttribute : Attribute, IConnectionProvider
+    public sealed class EventHubAttribute : Attribute
     {
         /// <summary>
         /// Initialize a new instance of the <see cref="EventHubAttribute"/>
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.WebJobs
         /// <param name="eventHubName">Name of the event hub as resolved against the <see cref="EventHubConfiguration"/> </param>
         public EventHubAttribute(string eventHubName)
         {
-            this.EventHubName = eventHubName;
+            EventHubName = eventHubName;
         }
 
         /// <summary>
@@ -29,9 +29,9 @@ namespace Microsoft.Azure.WebJobs
         public string EventHubName { get; private set; }
 
         /// <summary>
-        /// Gets or sets the optional app setting name that contains the Event Hub connection string. If missing, tries to use a registered event hub sender.
+        /// Gets or sets the optional connection string name that contains the Event Hub connection string. If missing, tries to use a registered event hub sender.
         /// </summary>
-        [AppSetting]
+        [ConnectionString]
         public string Connection { get; set; }
-    }    
+    }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/EventHubTriggerAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/EventHubTriggerAttribute.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.WebJobs
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter)]
     [Binding]
-    public sealed class EventHubTriggerAttribute : Attribute, IConnectionProvider
+    public sealed class EventHubTriggerAttribute : Attribute
     {
         /// <summary>
         /// Create an instance of this attribute.
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.WebJobs
         /// <param name="eventHubName">Event hub to listen on for messages. </param>
         public EventHubTriggerAttribute(string eventHubName)
         {
-            this.EventHubName = eventHubName;
+            EventHubName = eventHubName;
         }
 
         /// <summary>
@@ -35,7 +35,6 @@ namespace Microsoft.Azure.WebJobs
         /// <summary>
         /// Gets or sets the optional app setting name that contains the Event Hub connection string. If missing, tries to use a registered event hub receiver.
         /// </summary>
-        [AppSetting]
         public string Connection { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Triggers/EventHubTriggerAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Triggers/EventHubTriggerAttributeBindingProvider.cs
@@ -4,14 +4,14 @@
 using System;
 using System.Reflection;
 using System.Threading.Tasks;
+using Microsoft.Azure.EventHubs;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Azure.WebJobs.Host.Triggers;
-using Microsoft.Azure.EventHubs;
-using Microsoft.Extensions.Logging;
 using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.WebJobs.EventHubs
@@ -61,9 +61,10 @@ namespace Microsoft.Azure.WebJobs.EventHubs
 
             if (!string.IsNullOrWhiteSpace(attribute.Connection))
             {
-                _options.Value.AddReceiver(resolvedEventHubName, _nameResolver.Resolve(attribute.Connection));
+                var connectionString = _config.GetConnectionStringOrSetting(attribute.Connection);
+                _options.Value.AddReceiver(resolvedEventHubName, connectionString);
             }
-            
+
             var eventHostListener = _options.Value.GetEventProcessorHost(_config, resolvedEventHubName, resolvedConsumerGroup);
 
             Func<ListenerFactoryContext, bool, Task<IListener>> createListener =
@@ -74,7 +75,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
              };
 
             ITriggerBinding binding = BindingFactory.GetTriggerBinding(new EventHubTriggerBindingStrategy(), parameter, _converterManager, createListener);
-            return Task.FromResult<ITriggerBinding>(binding);         
+            return Task.FromResult<ITriggerBinding>(binding);
         }
     } // end class
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingProviders/AsyncCollectorBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingProviders/AsyncCollectorBindingProvider.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Protocols;
+using Microsoft.Extensions.Configuration;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Host.Bindings
@@ -18,18 +19,21 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
     internal class AsyncCollectorBindingProvider<TAttribute, TType> : FluentBindingProvider<TAttribute>, IBindingProvider, IBindingRuleProvider
         where TAttribute : Attribute
     {
+        private readonly IConfiguration _configuration;
         private readonly INameResolver _nameResolver;
         private readonly IConverterManager _converterManager;
         private readonly PatternMatcher _patternMatcher;
 
         public AsyncCollectorBindingProvider(
-           INameResolver nameResolver,
-           IConverterManager converterManager,
-           PatternMatcher patternMatcher)
+            IConfiguration configuration,
+            INameResolver nameResolver,
+            IConverterManager converterManager,
+            PatternMatcher patternMatcher)
         {
-            this._nameResolver = nameResolver;
-            this._converterManager = converterManager;
-            this._patternMatcher = patternMatcher;
+            _configuration = configuration;
+            _nameResolver = nameResolver;
+            _converterManager = converterManager;
+            _patternMatcher = patternMatcher;
         }
 
         // Describe different flavors of IAsyncCollector<T> bindings. 
@@ -320,7 +324,7 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
                     };
                 }
 
-                var cloner = new AttributeCloner<TAttribute>(attributeSource, context.BindingDataContract, parent._nameResolver);
+                var cloner = new AttributeCloner<TAttribute>(attributeSource, context.BindingDataContract, parent._configuration, parent._nameResolver);
                 return new ExactBinding<TMessage>(cloner, param, mode, buildFromAttribute, converter);
             }
 

--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingProviders/BindToInputBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingProviders/BindToInputBindingProvider.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Protocols;
+using Microsoft.Extensions.Configuration;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Host.Bindings
@@ -17,18 +18,21 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
     internal class BindToInputBindingProvider<TAttribute, TType> : FluentBindingProvider<TAttribute>, IBindingProvider, IBindingRuleProvider
         where TAttribute : Attribute
     {
+        private readonly IConfiguration _configuration;
         private readonly INameResolver _nameResolver;
         private readonly IConverterManager _converterManager;
         private readonly PatternMatcher _patternMatcher;
 
         public BindToInputBindingProvider(
+            IConfiguration configuration,
             INameResolver nameResolver,
             IConverterManager converterManager,
             PatternMatcher patternMatcher)
         {
-            this._nameResolver = nameResolver;
-            this._converterManager = converterManager;
-            this._patternMatcher = patternMatcher;
+            _configuration = configuration;
+            _nameResolver = nameResolver;
+            _converterManager = converterManager;
+            _patternMatcher = patternMatcher;
         }
 
         public Task<IBinding> TryCreateAsync(BindingProviderContext context)
@@ -145,7 +149,7 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
                 var userType = parameter.ParameterType;
                 var attributeSource = TypeUtility.GetResolvedAttribute<TAttribute>(parameter);
 
-                var cloner = new AttributeCloner<TAttribute>(attributeSource, context.BindingDataContract, parent._nameResolver);
+                var cloner = new AttributeCloner<TAttribute>(attributeSource, context.BindingDataContract, parent._configuration, parent._nameResolver);
 
                 FuncAsyncConverter buildFromAttribute;
                 FuncAsyncConverter converter = null;

--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingProviders/BindToStreamBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingProviders/BindToStreamBindingProvider.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Protocols;
 using Microsoft.Azure.WebJobs.Host.Config;
+using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.Azure.WebJobs.Host.Bindings
 {
@@ -26,14 +27,17 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
         private readonly IConverterManager _converterManager;
 
         private readonly FuncAsyncConverter<TAttribute, Stream> _builder;
+        private readonly IConfiguration _configuration;
 
         public BindToStreamBindingProvider(
             PatternMatcher patternMatcher,
             FileAccess access,
+            IConfiguration configuration,
             INameResolver nameResolver,
             IConverterManager converterManager)
         {
             _builder = patternMatcher.TryGetConverterFunc<TAttribute, Stream>();
+            _configuration = configuration;
             _nameResolver = nameResolver;
             _converterManager = converterManager;
             _access = access;
@@ -297,6 +301,7 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
 
                 IConverterManager cm = parent._converterManager;
                 INameResolver nm = parent._nameResolver;
+                IConfiguration config = parent._configuration;
 
                 object converterParam = null;
                 {
@@ -374,7 +379,7 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
                     return null;
                 }
 
-                var cloner = new AttributeCloner<TAttribute>(attributeSource, context.BindingDataContract, nm);
+                var cloner = new AttributeCloner<TAttribute>(attributeSource, context.BindingDataContract, config, nm);
 
                 ParameterDescriptor param;
                 if (parent.BuildParameterDescriptor != null)

--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingProviders/FilteringBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingProviders/FilteringBindingProvider.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.Azure.WebJobs.Host.Bindings
 {
@@ -14,15 +15,18 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
     internal class FilteringBindingProvider<TAttribute> : IBindingProvider, IBindingRuleProvider
         where TAttribute : Attribute
     {
+        private readonly IConfiguration _configuration;
         private readonly INameResolver _nameResolver;
         private readonly IBindingProvider _inner;
         private readonly FilterNode _description;
 
         public FilteringBindingProvider(
+            IConfiguration configuration,
             INameResolver nameResolver,  
             IBindingProvider inner,
             FilterNode description)
         {
+            _configuration = configuration;
             _nameResolver = nameResolver;
             _inner = inner;
             _description = description;
@@ -38,7 +42,7 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
 
             var attr = context.Parameter.GetCustomAttribute<TAttribute>();
 
-            var cloner = new AttributeCloner<TAttribute>(attr, context.BindingDataContract, _nameResolver);
+            var cloner = new AttributeCloner<TAttribute>(attr, context.BindingDataContract, _configuration, _nameResolver);
             var attrNameResolved = cloner.GetNameResolvedAttribute();
 
             // This may do validation and throw too. 

--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingProviders/GenericCompositeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingProviders/GenericCompositeBindingProvider.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.Azure.WebJobs.Host.Bindings
 {
@@ -20,12 +21,15 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
         private readonly IEnumerable<IBindingProvider> _providers;
 
         private readonly Action<TAttribute, Type> _validator;
+        private readonly IConfiguration _configuration;
         private readonly INameResolver _nameResolver;
 
-        public GenericCompositeBindingProvider(Action<TAttribute, Type> validator, INameResolver nameResolver, params IBindingProvider[] providers)
+        public GenericCompositeBindingProvider(Action<TAttribute, Type> validator, IConfiguration configuration,
+            INameResolver nameResolver, params IBindingProvider[] providers)
         {
             _providers = providers;
             _validator = validator;
+            _configuration = configuration;
             _nameResolver = nameResolver;
         }
 
@@ -47,7 +51,7 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
             {
                 // Expected this will throw on errors. 
                 Type parameterType = context.Parameter.ParameterType;
-                var cloner = new AttributeCloner<TAttribute>(attr, context.BindingDataContract, _nameResolver);
+                var cloner = new AttributeCloner<TAttribute>(attr, context.BindingDataContract, _configuration, _nameResolver);
                 var attrNameResolved = cloner.GetNameResolvedAttribute();
                 _validator(attrNameResolved, parameterType);
             }

--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingProviders/ValidatingWrapperBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingProviders/ValidatingWrapperBindingProvider.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Reflection;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.Azure.WebJobs.Host.Bindings
 {
@@ -14,12 +15,14 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
     {
         private readonly Action<TAttribute, Type> _validator;
         private readonly IBindingProvider _inner;
+        private readonly IConfiguration _configuration;
         private readonly INameResolver _nameResolver;
 
-        public ValidatingWrapperBindingProvider(Action<TAttribute, Type> validator, INameResolver nameResolver, IBindingProvider inner)
+        public ValidatingWrapperBindingProvider(Action<TAttribute, Type> validator, IConfiguration configuration, INameResolver nameResolver, IBindingProvider inner)
         {
             _validator = validator;
             _inner = inner;
+            _configuration = configuration;
             _nameResolver = nameResolver;
         }
 
@@ -39,7 +42,7 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
                 Type parameterType = context.Parameter.ParameterType;
                 var attr = context.Parameter.GetCustomAttribute<TAttribute>();
 
-                var cloner = new AttributeCloner<TAttribute>(attr, context.BindingDataContract, _nameResolver);
+                var cloner = new AttributeCloner<TAttribute>(attr, context.BindingDataContract, _configuration, _nameResolver);
                 var attrNameResolved = cloner.GetNameResolvedAttribute();
                 _validator(attrNameResolved, parameterType);
             }

--- a/src/Microsoft.Azure.WebJobs.Host/Config/ExtensionConfigContext.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Config/ExtensionConfigContext.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Azure.WebJobs.Description;
+using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.Azure.WebJobs.Host.Config
 {
@@ -20,13 +21,15 @@ namespace Microsoft.Azure.WebJobs.Host.Config
 
         // Map of tyepof(TAttribute) --> FluentBindingRule<TAttribute>
         private readonly Dictionary<Type, object> _rules = new Dictionary<Type, object>();
+        private readonly IConfiguration _configuration;
         private readonly IConverterManager _converterManager;
         private readonly IWebHookProvider _webHookProvider;
         private readonly IExtensionRegistry _extensionRegistry;
         private readonly INameResolver _nameResolver;
 
-        public ExtensionConfigContext(INameResolver nameResolver, IConverterManager converterManager, IWebHookProvider webHookProvider, IExtensionRegistry extensionRegistry)
+        public ExtensionConfigContext(IConfiguration configuration, INameResolver nameResolver, IConverterManager converterManager, IWebHookProvider webHookProvider, IExtensionRegistry extensionRegistry)
         {
+            _configuration = configuration;
             _converterManager = converterManager;
             _webHookProvider = webHookProvider;
             _extensionRegistry = extensionRegistry;
@@ -60,7 +63,7 @@ namespace Microsoft.Azure.WebJobs.Host.Config
             if (!this._rules.TryGetValue(typeof(TAttribute), out object temp))
             {
                 // Create and register
-                rule = new FluentBindingRule<TAttribute>(_nameResolver, _converterManager, _extensionRegistry);
+                rule = new FluentBindingRule<TAttribute>(_configuration, _nameResolver, _converterManager, _extensionRegistry);
                 this._rules[typeof(TAttribute)] = rule;
 
                 _updates.Add(rule.ApplyRules);

--- a/src/Microsoft.Azure.WebJobs.Host/ConfigurationUtility.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/ConfigurationUtility.cs
@@ -2,12 +2,11 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Configuration.EnvironmentVariables;
 
 namespace Microsoft.Azure.WebJobs.Host
 {
+    [Obsolete("Use IConfiguration directly")]
     internal static class ConfigurationUtility
     {
         private static Func<IConfiguration> _configurationFactory = BuildConfiguration;

--- a/src/Microsoft.Azure.WebJobs.Host/DefaultExtensionRegistryFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/DefaultExtensionRegistryFactory.cs
@@ -3,19 +3,22 @@
 
 using System.Collections.Generic;
 using Microsoft.Azure.WebJobs.Host.Config;
+using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.Azure.WebJobs.Host
 {
     public class DefaultExtensionRegistryFactory : IExtensionRegistryFactory
     {
+        private readonly IConfiguration _configuration;
         private readonly IEnumerable<IExtensionConfigProvider> _registeredExtensions;
         private readonly IConverterManager _converterManager;
         private readonly IWebHookProvider _webHookProvider;
         private readonly INameResolver _nameResolver;
 
         public DefaultExtensionRegistryFactory(IEnumerable<IExtensionConfigProvider> registeredExtensions, IConverterManager converterManager,
-             INameResolver nameResolver, IWebHookProvider webHookProvider = null)
+             IConfiguration configuration, INameResolver nameResolver, IWebHookProvider webHookProvider = null)
         {
+            _configuration = configuration;
             _registeredExtensions = registeredExtensions;
             _converterManager = converterManager;
             _webHookProvider = webHookProvider;
@@ -26,7 +29,7 @@ namespace Microsoft.Azure.WebJobs.Host
         {
             IExtensionRegistry registry = new DefaultExtensionRegistry();
 
-            ExtensionConfigContext context = new ExtensionConfigContext(_nameResolver, _converterManager, _webHookProvider, registry);
+            ExtensionConfigContext context = new ExtensionConfigContext(_configuration, _nameResolver, _converterManager, _webHookProvider, registry);            
 
             foreach (IExtensionConfigProvider extension in _registeredExtensions)
             {

--- a/src/Microsoft.Azure.WebJobs.Host/DefaultNameResolver.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/DefaultNameResolver.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.Azure.WebJobs
 {
@@ -11,6 +12,13 @@ namespace Microsoft.Azure.WebJobs
     /// </summary>
     public class DefaultNameResolver : INameResolver
     {
+        private readonly IConfiguration _configuration;
+
+        public DefaultNameResolver(IConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+
         /// <summary>
         /// Resolves tokens by looking first in App Settings and then in environment variables.
         /// </summary>
@@ -18,7 +26,7 @@ namespace Microsoft.Azure.WebJobs
         /// <returns>The token value from App Settings or environment variables. If the token is not found, null is returned.</returns>
         public virtual string Resolve(string name)
         {
-            return ConfigurationUtility.GetSetting(name);
+            return _configuration[name];
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Extensions/IConfigurationExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Extensions/IConfigurationExtensions.cs
@@ -15,12 +15,12 @@ namespace Microsoft.Extensions.Configuration
         {
             // first try prefixing
             string prefixedConnectionStringName = GetPrefixedConnectionStringName(connectionStringName);
-            string connectionString = FindConnectionString(configuration, prefixedConnectionStringName);
+            string connectionString = GetConnectionStringOrSetting(configuration, prefixedConnectionStringName);
 
             if (string.IsNullOrEmpty(connectionString))
             {
                 // next try a direct unprefixed lookup
-                connectionString = FindConnectionString(configuration, connectionStringName);
+                connectionString = GetConnectionStringOrSetting(configuration, connectionStringName);
             }
 
             return connectionString;
@@ -52,7 +52,7 @@ namespace Microsoft.Extensions.Configuration
         public static string GetWebJobsExtensionConfigurationSectionPath(this IConfiguration configuration, string extensionName)
         {
             string configPath = configuration.GetWebJobsRootConfigurationPath();
-            configPath = string.IsNullOrEmpty(configPath) 
+            configPath = string.IsNullOrEmpty(configPath)
                 ? ExtensionsSectionKey
                 : ConfigurationPath.Combine(configPath, ExtensionsSectionKey);
 
@@ -69,7 +69,13 @@ namespace Microsoft.Extensions.Configuration
             return Constants.WebJobsConfigurationSectionName + connectionStringName;
         }
 
-        private static string FindConnectionString(IConfiguration configuration, string connectionName) =>
+        /// <summary>
+        /// Looks for a connection string by first checking the ConfigurationStrings section, and then the root.
+        /// </summary>
+        /// <param name="configuration">The configuration.</param>
+        /// <param name="connectionName">The connection string key.</param>
+        /// <returns></returns>
+        public static string GetConnectionStringOrSetting(this IConfiguration configuration, string connectionName) =>
             configuration.GetConnectionString(connectionName) ?? configuration[connectionName];
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Extensions/IExtensionRegistryExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Extensions/IExtensionRegistryExtensions.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Config;
 using Microsoft.Azure.WebJobs.Host.Triggers;
+using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.Azure.WebJobs.Host
 {
@@ -54,7 +55,8 @@ namespace Microsoft.Azure.WebJobs.Host
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter")]
         public static void RegisterBindingRules<TAttribute>(
             this IExtensionRegistry registry, 
-            Action<TAttribute, Type> validator, 
+            Action<TAttribute, Type> validator,
+            IConfiguration configuration,
             INameResolver nameResolver, 
             params IBindingProvider[] bindingProviders)
             where TAttribute : Attribute
@@ -64,7 +66,7 @@ namespace Microsoft.Azure.WebJobs.Host
                 throw new ArgumentNullException("registry");
             }
 
-            var all = new GenericCompositeBindingProvider<TAttribute>(validator, nameResolver, bindingProviders);
+            var all = new GenericCompositeBindingProvider<TAttribute>(validator, configuration, nameResolver, bindingProviders);
             registry.RegisterExtension<IBindingProvider>(all);
         }
 

--- a/src/Microsoft.Azure.WebJobs/ConnectionStringAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs/ConnectionStringAttribute.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Azure.WebJobs.Description
+{
+    /// <summary>
+    /// Place this on binding attributes properties to tell the binders that that the property
+    /// should be automatically resolved as a connection string.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public sealed class ConnectionStringAttribute : Attribute
+    {
+        /// <summary>
+        /// Creates a new instance.
+        /// </summary>
+        public ConnectionStringAttribute()
+        {
+        }
+
+        /// <summary>
+        /// The default connection string name to use, if none specified
+        /// </summary>
+        public string Default { get; set; }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Extensions.ServiceBus.UnitTests/Listeners/ServiceBusQueueListenerFactoryTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.ServiceBus.UnitTests/Listeners/ServiceBusQueueListenerFactoryTests.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Listeners;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.Azure.WebJobs.ServiceBus.Listeners;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
@@ -20,7 +21,9 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Listeners
         {
             var configuration = new ConfigurationBuilder()
                 .AddEnvironmentVariables()
+                .AddTestSettings()
                 .Build();
+
             var config = new ServiceBusOptions
             {
                 ConnectionString = configuration.GetWebJobsConnectionString("ServiceBus")

--- a/test/Microsoft.Azure.WebJobs.Extensions.ServiceBus.UnitTests/Triggers/ServiceBusSubscriptionListenerFactoryTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.ServiceBus.UnitTests/Triggers/ServiceBusSubscriptionListenerFactoryTests.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Listeners;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.Azure.WebJobs.ServiceBus.Listeners;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
@@ -20,7 +21,9 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Listeners
         {
             var configuration = new ConfigurationBuilder()
                 .AddEnvironmentVariables()
+                .AddTestSettings()
                 .Build();
+
             var config = new ServiceBusOptions
             {
                 ConnectionString = configuration.GetWebJobsConnectionString("ServiceBus")

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/ServiceBusRequestAndDependencyCollectionTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/ServiceBusRequestAndDependencyCollectionTests.cs
@@ -36,9 +36,10 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
         {
             var config = new ConfigurationBuilder()
                 .AddEnvironmentVariables()
+                .AddTestSettings()
                 .Build();
 
-            _connectionString = config.GetConnectionString(ServiceBus.Constants.DefaultConnectionStringName);
+            _connectionString = config.GetConnectionStringOrSetting(ServiceBus.Constants.DefaultConnectionStringName);
 
             var connStringBuilder = new ServiceBusConnectionStringBuilder(_connectionString);
             _endpoint = connStringBuilder.Endpoint;
@@ -51,7 +52,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
             {
                 await host.StartAsync();
                 await host.GetJobHost()
-                    .CallAsync(typeof(ServiceBusRequestAndDependencyCollectionTests).GetMethod(nameof(ServiceBusOut)), new {input = "message"});
+                    .CallAsync(typeof(ServiceBusRequestAndDependencyCollectionTests).GetMethod(nameof(ServiceBusOut)), new { input = "message" });
 
                 _functionWaitHandle.WaitOne();
                 await Task.Delay(1000);

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/EventHubEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/EventHubEndToEndTests.cs
@@ -7,12 +7,10 @@ using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Azure.EventHubs;
-using Microsoft.Azure.WebJobs.EventHubs;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
-using Xunit;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 {
@@ -44,7 +42,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 return EventHubTestJobs.Result != null;
             });
 
-            Assert.Equal(id, (object)EventHubTestJobs.Result);
+            Assert.Equal(id, EventHubTestJobs.Result);
         }
 
         [Fact]
@@ -136,7 +134,12 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
             public TestFixture()
             {
-                string connection = Environment.GetEnvironmentVariable("AzureWebJobsTestHubConnection");
+                var config = new ConfigurationBuilder()
+                    .AddEnvironmentVariables()
+                    .AddTestSettings()
+                    .Build();
+
+                string connection = config.GetConnectionStringOrSetting("AzureWebJobsTestHubConnection");
                 Assert.True(!string.IsNullOrEmpty(connection), "Required test connection string is missing.");
 
                 var host = new HostBuilder()

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ServiceBusEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ServiceBusEndToEndTests.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 {
     public class ServiceBusEndToEndTests : IDisposable
     {
+        private const string SecondaryConnectionStringKey = "ServiceBusSecondary";
         private const string Prefix = "core-test-";
         private const string FirstQueueName = Prefix + "queue1";
         private const string SecondQueueName = Prefix + "queue2";
@@ -41,18 +42,19 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         private static string _resultMessage1;
         private static string _resultMessage2;
 
-        private RandomNameResolver _nameResolver;
-        private string _primaryConnectionString;
-        private string _secondaryConnectionString;
+        private readonly RandomNameResolver _nameResolver;
+        private readonly string _primaryConnectionString;
+        private readonly string _secondaryConnectionString;
 
         public ServiceBusEndToEndTests()
         {
             var config = new ConfigurationBuilder()
                 .AddEnvironmentVariables()
+                .AddTestSettings()
                 .Build();
 
             _primaryConnectionString = config.GetConnectionString(ServiceBus.Constants.DefaultConnectionStringName);
-            _secondaryConnectionString = config.GetConnectionString("SecondaryServiceBus");
+            _secondaryConnectionString = config.GetConnectionString(SecondaryConnectionStringKey);
 
             _nameResolver = new RandomNameResolver();
 
@@ -357,7 +359,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             // Demonstrate triggering on a queue in one account, and writing to a topic
             // in the primary subscription
             public static void MultipleAccounts(
-                [ServiceBusTrigger(FirstQueueName, Connection = "ServiceBusSecondary")] string input,
+                [ServiceBusTrigger(FirstQueueName, Connection = SecondaryConnectionStringKey)] string input,
                 [ServiceBus(TopicName)] out string output)
             {
                 output = input;
@@ -433,7 +435,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 }
             }
 
-            Task ExceptionReceivedHandler(ExceptionReceivedEventArgs eventArgs)
+            private Task ExceptionReceivedHandler(ExceptionReceivedEventArgs eventArgs)
             {
                 return Task.CompletedTask;
             }

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/AttributeClonerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/AttributeClonerTests.cs
@@ -14,12 +14,14 @@ using Xunit;
 using Microsoft.Azure.WebJobs.Description;
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;
+using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.Azure.WebJobs.Host.UnitTests
 {
     // Test Attribute Cloner with Storage attributes. 
     public class AttributeClonerTests
     {
+        private static readonly IConfiguration _config = new ConfigurationBuilder().Build();
         private static IReadOnlyDictionary<string, Type> emptyContract = new Dictionary<string, Type>();
 
         // Helper to easily generate a fixed binding contract.
@@ -62,7 +64,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 new BlobAttribute("container/{name}", FileAccess.Write)
             })
             {
-                var cloner = new AttributeCloner<BlobAttribute>(attr, GetBindingContract("name"));
+                var cloner = new AttributeCloner<BlobAttribute>(attr, GetBindingContract("name"), _config);
                 BlobAttribute attr2 = cloner.ResolveFromInvokeString("c/n");
 
                 Assert.Equal("c/n", attr2.BlobPath);
@@ -81,7 +83,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             };
             var ctx = GetCtx(values);
 
-            var cloner = new AttributeCloner<BlobAttribute>(a1, GetBindingContract("name"));
+            var cloner = new AttributeCloner<BlobAttribute>(a1, GetBindingContract("name"), _config);
             var attr2 = cloner.ResolveFromBindingData(ctx);
 
             Assert.Equal("container/green.txt", attr2.BlobPath);
@@ -100,7 +102,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             };
             var ctx = GetCtx(values);
 
-            var cloner = new AttributeCloner<BlobAttribute>(a1, GetBindingContract("name"));
+            var cloner = new AttributeCloner<BlobAttribute>(a1, GetBindingContract("name"), _config);
             var attr2 = cloner.ResolveFromBindingData(ctx);
 
             Assert.Equal("container/green.txt", attr2.BlobPath);

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/TestConfigurationBuilderExtensions.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/TestConfigurationBuilderExtensions.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.Azure.WebJobs.Host.TestCommon
+{
+    public static class TestConfigurationBuilderExtensions
+    {
+        /// <summary>
+        /// Allows configuration to come from %userprofile%\.azurefunctions\appsettings.tests.json
+        /// </summary>
+        /// <param name="builder">The configuration builder.</param>
+        /// <returns>The modified configuration builder.</returns>
+        public static IConfigurationBuilder AddTestSettings(this IConfigurationBuilder builder)
+        {
+            string configPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".azurefunctions", "appsettings.tests.json");
+            return builder.AddJsonFile(configPath, true);
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/TestHelpers.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/TestHelpers.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Azure.WebJobs.Host.TestCommon
             return (T)constructor.Invoke(null);
         }
 
-    
+
 
         // Test that we get an indexing error (FunctionIndexingException)  
         // functionName - the function name that has the indexing error. 
@@ -140,14 +140,18 @@ namespace Microsoft.Azure.WebJobs.Host.TestCommon
         public static IHostBuilder ConfigureDefaultTestHost(this IHostBuilder builder, Action<IWebJobsBuilder> configureWebJobs, params Type[] types)
         {
             return builder.ConfigureWebJobs(configureWebJobs)
-                  .ConfigureServices(services =>
-                 {
-                     services.AddSingleton<ITypeLocator>(new FakeTypeLocator(types));
+                .ConfigureAppConfiguration(c =>
+                {
+                    c.AddTestSettings();
+                })
+                .ConfigureServices(services =>
+                {
+                    services.AddSingleton<ITypeLocator>(new FakeTypeLocator(types));
 
-                     // Register this to fail a test if a background exception is thrown
-                     services.AddSingleton<IWebJobsExceptionHandlerFactory, TestExceptionHandlerFactory>();
-                 })
-                 .ConfigureTestLogger();
+                    // Register this to fail a test if a background exception is thrown
+                    services.AddSingleton<IWebJobsExceptionHandlerFactory, TestExceptionHandlerFactory>();
+                })
+                .ConfigureTestLogger();
         }
 
         public static IHostBuilder ConfigureDefaultTestHost<TProgram>(this IHostBuilder builder,
@@ -253,7 +257,7 @@ namespace Microsoft.Azure.WebJobs.Host.TestCommon
         {
             await host.CallAsync(typeof(T).GetMethod(methodName));
         }
-        
+
         public static TOptions GetOptions<TOptions>(this IHost host) where TOptions : class, new()
         {
             return host.Services.GetService<IOptions<TOptions>>().Value;
@@ -288,7 +292,7 @@ namespace Microsoft.Azure.WebJobs.Host.TestCommon
 
             if (newlyIntroducedPublicTypes.Length > 0)
             {
-                string message = String.Format("Found {0} unexpected public type{1}: \r\n{2}",
+                string message = string.Format("Found {0} unexpected public type{1}: \r\n{2}",
                     newlyIntroducedPublicTypes.Length,
                     newlyIntroducedPublicTypes.Length == 1 ? "" : "s",
                     string.Join("\r\n", newlyIntroducedPublicTypes));
@@ -299,12 +303,28 @@ namespace Microsoft.Azure.WebJobs.Host.TestCommon
 
             if (missingPublicTypes.Length > 0)
             {
-                string message = String.Format("missing {0} public type{1}: \r\n{2}",
+                string message = string.Format("missing {0} public type{1}: \r\n{2}",
                     missingPublicTypes.Length,
                     missingPublicTypes.Length == 1 ? "" : "s",
                     string.Join("\r\n", missingPublicTypes));
                 Assert.True(false, message);
             }
+        }
+
+        public static IDictionary<string, string> CreateInMemoryCollection()
+        {
+            return new Dictionary<string, string>();
+        }
+
+        public static IDictionary<string, string> AddSetting(this IDictionary<string, string> dict, string name, string value)
+        {
+            dict.Add(name, value);
+            return dict;
+        }
+
+        public static IConfiguration BuildConfiguration(this IDictionary<string, string> dict)
+        {
+            return new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
         }
     }
 

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/AttributeClonerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/AttributeClonerTests.cs
@@ -3,17 +3,16 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
 using System.Reflection;
 using System.Threading;
-using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Description;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Bindings.Path;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Microsoft.Extensions.Configuration;
 using Xunit;
-using Microsoft.Azure.WebJobs.Description;
-using System.ComponentModel.DataAnnotations;
-using System.Globalization;
 
 namespace Microsoft.Azure.WebJobs.Host.UnitTests
 {
@@ -31,8 +30,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         {
             public Attr2(string resolvedProp2, string constantProp)
             {
-                this.ResolvedProp2 = resolvedProp2;
-                this.ConstantProp = constantProp;
+                ResolvedProp2 = resolvedProp2;
+                ConstantProp = constantProp;
             }
 
             [AutoResolve]
@@ -48,6 +47,10 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
 
             [AppSetting(Default = "default")]
             public string DefaultSetting { get; set; }
+
+            // This lookup will be under ConnectionStrings
+            [ConnectionString(Default = "default")]
+            public string Connection { get; set; }
         }
 
         public class Attr3 : Attribute
@@ -162,7 +165,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         public class ValidationOnlyAttribute : Attribute
         {
             // Allow  { } that look like token substitution, but it's not since this isn't AutoResolve
-            [RegularExpression("^.{1,3}$")] 
+            [RegularExpression("^.{1,3}$")]
             public string Value { get; set; }
         }
 
@@ -187,7 +190,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             return d;
         }
 
-        private static IReadOnlyDictionary<string, Type> emptyContract = new Dictionary<string, Type>();
+        private static readonly IReadOnlyDictionary<string, Type> emptyContract = new Dictionary<string, Type>();
+        private static readonly IConfiguration _emptyConfig = new ConfigurationBuilder().Build();
 
         // Enforce binding contracts statically.
         [Fact]
@@ -197,7 +201,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
 
             try
             {
-                var cloner = new AttributeCloner<Attr1>(a1, emptyContract);
+                var cloner = new AttributeCloner<Attr1>(a1, emptyContract, _emptyConfig);
                 Assert.True(false, "Should have caught binding contract mismatch");
             }
             catch (InvalidOperationException e)
@@ -219,7 +223,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             var nameResolver = new FakeNameResolver();
             nameResolver._dict["test"] = "ABC";
 
-            var cloner = new AttributeCloner<Attr1>(a1, emptyContract, nameResolver);
+            var cloner = new AttributeCloner<Attr1>(a1, emptyContract, _emptyConfig, nameResolver);
             Attr1 attr2 = cloner.ResolveFromInvokeString("xy");
 
             Assert.Equal("xy", attr2.Path);
@@ -230,11 +234,12 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         [Fact]
         public void InvokeStringMultipleResolvedProperties()
         {
-            Attr2 attr = new Attr2("{p2}", "constant") {
+            Attr2 attr = new Attr2("{p2}", "constant")
+            {
                 ResolvedProp1 = "{p1}"
             };
 
-            var cloner = new AttributeCloner<Attr2>(attr, GetBindingContract("p1", "p2"));
+            var cloner = new AttributeCloner<Attr2>(attr, GetBindingContract("p1", "p2"), _emptyConfig);
 
             Attr2 attrResolved = cloner.ResolveFromBindings(new Dictionary<string, object> { { "p1", "v1" }, { "p2", "v2" } });
 
@@ -257,7 +262,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             Attr1 a1 = new Attr1 { Path = "x%appsetting%y-{k}" };
 
             var nameResolver = new FakeNameResolver().Add("appsetting", "ABC");
-            var cloner = new AttributeCloner<Attr1>(a1, GetBindingContract("k"), nameResolver);
+            var cloner = new AttributeCloner<Attr1>(a1, GetBindingContract("k"), _emptyConfig, nameResolver);
 
             // Get the attribute with %% resolved (happens at indexing time), but not {} (not resolved until runtime)
             var attrPre = cloner.GetNameResolvedAttribute();
@@ -291,7 +296,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             };
             var ctx = GetCtx(values);
 
-            var cloner = new AttributeCloner<Attr1>(a1, GetBindingContract("request", "key2"));
+            var cloner = new AttributeCloner<Attr1>(a1, GetBindingContract("request", "key2"), _emptyConfig);
             var attr2 = cloner.ResolveFromBindingData(ctx);
 
             Assert.Equal("ey123-val2", attr2.Path);
@@ -302,27 +307,39 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         {
             Attr2 a2 = new Attr2(string.Empty, string.Empty) { ResolvedSetting = "appsetting" };
 
-            var nameResolver = new FakeNameResolver().Add("appsetting", "ABC");
-            var cloner = new AttributeCloner<Attr2>(a2, emptyContract, nameResolver);
+            var nameResolver = new FakeNameResolver();
+
+            var config = TestHelpers.CreateInMemoryCollection()
+                .AddSetting("appsetting", "ABC")
+                .AddSetting("connectionStrings:default", "fromConnStr")
+                .BuildConfiguration();
+
+            var cloner = new AttributeCloner<Attr2>(a2, emptyContract, config, nameResolver);
 
             var a2Cloned = cloner.GetNameResolvedAttribute();
             Assert.Equal("ABC", a2Cloned.ResolvedSetting);
+            Assert.Equal("fromConnStr", a2Cloned.Connection);
         }
 
         [Fact]
         public void Setting_WithNoValueInResolver_ThrowsIfNoDefault()
         {
             Attr2 a2 = new Attr2(string.Empty, string.Empty) { ResolvedSetting = "appsetting" };
-            var exc = Assert.Throws<InvalidOperationException>(() => new AttributeCloner<Attr2>(a2, emptyContract));
-            Assert.Equal($"Unable to resolve app setting for property 'Attr2.ResolvedSetting'. Make sure the app setting exists and has a valid value.", exc.Message);
+            var exc = Assert.Throws<InvalidOperationException>(() => new AttributeCloner<Attr2>(a2, emptyContract, _emptyConfig));
+            Assert.Equal($"Unable to resolve the value for property 'Attr2.ResolvedSetting'. Make sure the setting exists and has a valid value.", exc.Message);
         }
 
         [Fact]
         public void Setting_WithNoValueInResolver_UsesDefault()
         {
             Attr2 a2 = new Attr2(string.Empty, string.Empty) { ResolvedSetting = "appsetting" };
-            var nameResolver = new FakeNameResolver().Add("appsetting", "ABC").Add("default", "default");
-            var cloner = new AttributeCloner<Attr2>(a2, emptyContract, nameResolver);
+            var nameResolver = new FakeNameResolver();
+            var config = TestHelpers.CreateInMemoryCollection()
+                .AddSetting("appsetting", "ABC")
+                .AddSetting("default", "default")
+                .BuildConfiguration();
+
+            var cloner = new AttributeCloner<Attr2>(a2, emptyContract, config, nameResolver);
 
             var a2Cloned = cloner.GetNameResolvedAttribute();
             Assert.Equal("default", a2Cloned.DefaultSetting);
@@ -332,8 +349,14 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         public void AppSettingAttribute_Resolves_IfDefaultSet()
         {
             Attr3 a3 = new Attr3() { Required = "req", Default = "env" };
-            var nameResolver = new FakeNameResolver().Add("env", "envval").Add("req", "reqval");
-            var cloner = new AttributeCloner<Attr3>(a3, emptyContract, nameResolver);
+            var nameResolver = new FakeNameResolver();
+
+            var config = TestHelpers.CreateInMemoryCollection()
+                .AddSetting("env", "envval")
+                .AddSetting("req", "reqval")
+                .BuildConfiguration();
+
+            var cloner = new AttributeCloner<Attr3>(a3, emptyContract, config, nameResolver);
             var cloned = cloner.GetNameResolvedAttribute();
             Assert.Equal("reqval", cloned.Required);
             Assert.Equal("envval", cloned.Default);
@@ -343,8 +366,14 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         public void AppSettingAttribute_Resolves_IfDefaultMatched()
         {
             Attr3 a3 = new Attr3() { Required = "req" };
-            var nameResolver = new FakeNameResolver().Add("default", "defaultval").Add("req", "reqval");
-            var cloner = new AttributeCloner<Attr3>(a3, emptyContract, nameResolver);
+            var nameResolver = new FakeNameResolver();
+
+            var config = TestHelpers.CreateInMemoryCollection()
+                .AddSetting("default", "defaultval")
+                .AddSetting("req", "reqval")
+                .BuildConfiguration();
+
+            var cloner = new AttributeCloner<Attr3>(a3, emptyContract, config, nameResolver);
             var cloned = cloner.GetNameResolvedAttribute();
             Assert.Equal("reqval", cloned.Required);
             Assert.Equal("defaultval", cloned.Default);
@@ -354,7 +383,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         public void AppSettingAttribute_Throws_IfDefaultUnmatched()
         {
             Attr3 a3 = new Attr3() { Required = "req" };
-            Assert.Throws<InvalidOperationException>(() => new AttributeCloner<Attr3>(a3, emptyContract));
+            Assert.Throws<InvalidOperationException>(() => new AttributeCloner<Attr3>(a3, emptyContract, _emptyConfig));
         }
 
         [Fact]
@@ -362,7 +391,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         {
             Attr2 a2 = new Attr2(string.Empty, string.Empty);
 
-            var cloner = new AttributeCloner<Attr2>(a2, emptyContract);
+            var cloner = new AttributeCloner<Attr2>(a2, emptyContract, _emptyConfig);
 
             Attr2 a2Clone = cloner.ResolveFromBindingData(GetCtx(null));
 
@@ -377,9 +406,13 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             a4.AppSetting = a4.AutoResolve = name;
 
             var nameResolver = new FakeNameResolver()
-                .Add("y", "Setting")
-                .Add(name, "AppSetting");
-            var cloner = new AttributeCloner<Attr4>(a4, GetBindingContract("x"), nameResolver);
+                .Add("y", "Setting");
+
+            var config = TestHelpers.CreateInMemoryCollection()
+                .AddSetting(name, "AppSetting")
+                .BuildConfiguration();
+
+            var cloner = new AttributeCloner<Attr4>(a4, GetBindingContract("x"), config, nameResolver);
             var cloned = cloner.GetNameResolvedAttribute();
             // autoresolve resolves tokens
             Assert.Equal("test{x}andSetting", cloned.AutoResolve);
@@ -395,28 +428,87 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             a4.AppSetting = null;
 
             var nameResolver = new FakeNameResolver();
-            var cloner = new AttributeCloner<Attr4>(a4, emptyContract, nameResolver);
+            var cloner = new AttributeCloner<Attr4>(a4, emptyContract, _emptyConfig, nameResolver);
             var cloned = cloner.GetNameResolvedAttribute();
             Assert.Equal("auto", cloned.AutoResolve);
             Assert.Equal(null, cloned.AppSetting);
+        }
+
+        public class ConnectionStrings : Attribute
+        {
+            [ConnectionString]
+            public string Connection { get; set; }
+
+            [ConnectionString]
+            public string ConnectionAtRoot { get; set; }
+
+            [ConnectionString]
+            public string ConnectionWithNestedPath { get; set; }
+
+            [ConnectionString(Default = "defaultSetting")]
+            public string ConnectionOverrideDefault { get; set; }
+
+            [ConnectionString(Default = "defaultSetting")]
+            public string ConnectionWithDefault { get; set; }
+
+            [ConnectionString(Default = "nested:path:defaultKey")]
+            public string ConnectionWithNestedDefaultPath { get; set; }
+
+            [AppSetting(Default = "defaultSetting")]
+            public string AppSettingWithDefault { get; set; }
+        }
+
+        [Fact]
+        public void ConnectionStringAttribute_ResolvesCorrectly()
+        {
+            ConnectionStrings attr = new ConnectionStrings
+            {
+                Connection = "key",
+                ConnectionAtRoot = "rootKey",
+                ConnectionWithNestedPath = "nested:path:key",
+                ConnectionOverrideDefault = "overridden"
+            };
+
+            var config = TestHelpers.CreateInMemoryCollection()
+                .AddSetting("key", "unused")
+                .AddSetting("rootKey", "rootValue")
+                .AddSetting("connectionStrings:key", "connectionStringsValue")
+                .AddSetting("nested:path:key", "nestedPathValue")
+                .AddSetting("nested:path:defaultKey", "nestedPathDefaultValue")
+                .AddSetting("connectionStrings:overridden", "connectionStringsOverriddenValue")
+                .AddSetting("connectionStrings:defaultSetting", "fromConnStr")
+                .AddSetting("defaultSetting", "fromRoot")
+                .BuildConfiguration();
+
+            var nameResolver = new FakeNameResolver();
+            var cloner = new AttributeCloner<ConnectionStrings>(attr, emptyContract, config, nameResolver);
+            var cloned = cloner.GetNameResolvedAttribute();
+
+            Assert.Equal("connectionStringsValue", cloned.Connection);
+            Assert.Equal("rootValue", cloned.ConnectionAtRoot);
+            Assert.Equal("nestedPathValue", cloned.ConnectionWithNestedPath);
+            Assert.Equal("connectionStringsOverriddenValue", cloned.ConnectionOverrideDefault);
+            Assert.Equal("nestedPathDefaultValue", cloned.ConnectionWithNestedDefaultPath);
+            Assert.Equal("fromConnStr", cloned.ConnectionWithDefault);
+            Assert.Equal("fromRoot", cloned.AppSettingWithDefault);
         }
 
         [Fact]
         public void AttributeCloner_Throws_IfAppSettingAndAutoResolve()
         {
             InvalidAnnotation a = new InvalidAnnotation();
-            var exc = Assert.Throws<InvalidOperationException>(() => new AttributeCloner<InvalidAnnotation>(a, emptyContract));
-            Assert.Equal("Property 'Required' cannot be annotated with both AppSetting and AutoResolve.", exc.Message);
+            var exc = Assert.Throws<InvalidOperationException>(() => new AttributeCloner<InvalidAnnotation>(a, emptyContract, _emptyConfig));
+            Assert.Equal("Property 'Required' can only be annotated with one of the types AppSettingAttribute, AutoResolveAttribute, and ConnectionStringAttribute.", exc.Message);
         }
 
         [Fact]
         public void AttributeCloner_Throws_IfAutoResolveIsNotString()
         {
             var a = new InvalidNonStringAutoResolve();
-            var exc = Assert.Throws<InvalidOperationException>(() => new AttributeCloner<InvalidNonStringAutoResolve>(a, emptyContract));
-            Assert.Equal("AutoResolve or AppSetting property 'Required' must be of type string.", exc.Message);
+            var exc = Assert.Throws<InvalidOperationException>(() => new AttributeCloner<InvalidNonStringAutoResolve>(a, emptyContract, _emptyConfig));
+            Assert.Equal("ConnectionStringAttribute, AutoResolveAttribute, or AppSettingAttribute property 'Required' must be of type string.", exc.Message);
         }
-        
+
         // Default to MethodName  kicks in if the (pre-resolved) value is null. 
         [Theory]
         [InlineData(null, "MyMethod")]
@@ -446,11 +538,11 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             }.AddToBindingData(values);
 
             var ctx = GetCtx(values);
-                        
-            var cloner = new AttributeCloner<Attr5>(attr, GetBindingContract(values), nameResolver);
+
+            var cloner = new AttributeCloner<Attr5>(attr, GetBindingContract(values), _emptyConfig, nameResolver);
 
             var attr2 = cloner.ResolveFromBindingData(ctx);
-            Assert.Equal(expectedValue, attr2.AutoResolve);            
+            Assert.Equal(expectedValue, attr2.AutoResolve);
         }
 
         // Default can't access instance binding data. 
@@ -471,14 +563,14 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
 
             try
             {
-                new AttributeCloner<BadDefaultAttr>(attr, GetBindingContract(values));
+                new AttributeCloner<BadDefaultAttr>(attr, GetBindingContract(values), _emptyConfig);
                 Assert.False(true);
             }
             catch (InvalidOperationException e)
             {
                 // Verify message. 
                 Assert.True(e.Message.StartsWith("Default contract can only refer to the 'sys' binding data: "));
-            }            
+            }
         }
 
         // Malformed %% fail in ctor.
@@ -489,7 +581,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         {
             Attr1 attr = new Attr1 { Path = "%bad" };
 
-            Assert.Throws<InvalidOperationException>(() => new AttributeCloner<Attr1>(attr, emptyContract));
+            Assert.Throws<InvalidOperationException>(() => new AttributeCloner<Attr1>(attr, emptyContract, _emptyConfig));
         }
 
         [Fact]
@@ -497,7 +589,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         {
             var attr = new Attr2("%bad", "constant");
 
-            Assert.Throws<InvalidOperationException>(() => new AttributeCloner<Attr2>(attr, emptyContract));
+            Assert.Throws<InvalidOperationException>(() => new AttributeCloner<Attr2>(attr, emptyContract, _emptyConfig));
         }
 
         // Malformed %% fail in ctor.
@@ -508,10 +600,10 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         {
             Attr1 attr = new Attr1 { Path = "%missing%" };
 
-            Assert.Throws<InvalidOperationException>(() => new AttributeCloner<Attr1>(attr, emptyContract));
+            Assert.Throws<InvalidOperationException>(() => new AttributeCloner<Attr1>(attr, emptyContract, _emptyConfig));
         }
 
-        static Action<object> skipValidation = (_) => { };
+        private static readonly Action<object> skipValidation = (_) => { };
 
         [Fact]
         public void TryAutoResolveValue_UnresolvedValue_ThrowsExpectedException()
@@ -525,8 +617,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             var attr = prop.GetCustomAttribute<AppSettingAttribute>();
             string resolvedValue = "MySetting";
 
-            var ex = Assert.Throws<InvalidOperationException>(() => AttributeCloner<Attr2>.GetAppSettingResolver(resolvedValue, attr, resolver, prop, skipValidation));
-            Assert.Contains("Unable to resolve app setting for property 'Attr2.ResolvedSetting'.", ex.Message);
+            var ex = Assert.Throws<InvalidOperationException>(() => AttributeCloner<Attr2>.GetConfigurationResolver(resolvedValue, attr.Default, prop, skipValidation, s => _emptyConfig[s]));
+            Assert.Contains("Unable to resolve the value for property 'Attr2.ResolvedSetting'.", ex.Message);
         }
 
         [Fact]
@@ -579,7 +671,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             ValidationWithAutoResolveAttribute attr = new ValidationWithAutoResolveAttribute { Value = "a{name}" };
 
             // Can't fail yet. 
-            var cloner = new AttributeCloner<ValidationWithAutoResolveAttribute>(attr, GetBindingContract("name"));
+            var cloner = new AttributeCloner<ValidationWithAutoResolveAttribute>(attr, GetBindingContract("name"), _emptyConfig);
 
             // Valid 
             {
@@ -588,7 +680,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                     { "name", "aa" },  // Ok 
                 };
                 var ctx = GetCtx(values);
-                
+
                 var attr2 = cloner.ResolveFromBindingData(ctx);
                 Assert.Equal("aaa", attr2.Value);
             }
@@ -602,14 +694,14 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 var ctx = GetCtx(values);
 
                 Assert.Throws<InvalidOperationException>(() =>
-                       cloner.ResolveFromBindingData(ctx));                
+                       cloner.ResolveFromBindingData(ctx));
             }
         }
-        
+
         // If there are no { }, we can determine validity immediately. 
         [Fact]
         public void Validation_Early_Succeed()
-        {            
+        {
             ValidationWithAutoResolveAttribute attr = new ValidationWithAutoResolveAttribute { Value = "aaa" };
 
             Dictionary<string, object> values = new Dictionary<string, object>()
@@ -618,7 +710,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             };
             var ctx = GetCtx(values);
 
-            var cloner = new AttributeCloner<ValidationWithAutoResolveAttribute>(attr, GetBindingContract("name"));
+            var cloner = new AttributeCloner<ValidationWithAutoResolveAttribute>(attr, GetBindingContract("name"), _emptyConfig);
             var attr2 = cloner.ResolveFromBindingData(ctx);
 
             Assert.Equal("aaa", attr2.Value);
@@ -632,16 +724,16 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
 
             // No { }, so we can determine validity immediately 
             ValidationWithAutoResolveAttribute attr = new ValidationWithAutoResolveAttribute { Value = IllegalValue };
-                        
+
             Dictionary<string, object> values = new Dictionary<string, object>()
             {
                 { "name", "ignored" }, // ignored since no {name} token in the attr
             };
             var ctx = GetCtx(values);
-                        
+
             try
             {
-                new AttributeCloner<ValidationWithAutoResolveAttribute>(attr, GetBindingContract("name"));
+                new AttributeCloner<ValidationWithAutoResolveAttribute>(attr, GetBindingContract("name"), _emptyConfig);
                 Assert.False(true, "Validation should have failed");
             }
             catch (InvalidOperationException e)
@@ -659,7 +751,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
 
             // No { }, so we can determine validity immediately 
             ValidationWithAppSettingAttribute attr = new ValidationWithAppSettingAttribute { Value = "bbb" };
-                        
+
             Dictionary<string, object> values = new Dictionary<string, object>()
             {
                 { "name", "ignored" }, // ignored since no {name} token in the attr
@@ -668,9 +760,9 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
 
             try
             {
-                new AttributeCloner<ValidationWithAppSettingAttribute>(attr, GetBindingContract("name"));
+                new AttributeCloner<ValidationWithAppSettingAttribute>(attr, GetBindingContract("name"), _emptyConfig);
                 Assert.False(true, "Validation should have failed");
-            } 
+            }
             catch (InvalidOperationException e)
             {
                 // Since this is [AppSetting], don't include the illegal value in the message. It could be secret. 
@@ -680,7 +772,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
 
         // No AppSetting/AutoResolve, so validate early 
         [Theory]
-        [InlineData("{x}", true)] 
+        [InlineData("{x}", true)]
         [InlineData("%x%", true)]
         [InlineData("{x", true)]
         [InlineData("illegal", false)]
@@ -696,7 +788,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
 
             try
             {
-                var cloner = new AttributeCloner<ValidationOnlyAttribute>(attr, GetBindingContract("name"));
+                var cloner = new AttributeCloner<ValidationOnlyAttribute>(attr, GetBindingContract("name"), _emptyConfig);
 
                 if (shouldSucceed)
                 {
@@ -704,7 +796,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                     var attrResolved = cloner.ResolveFromBindings(values);
 
                     // no autoresolve/appsetting, so the final value should be the same as the input value. 
-                    Assert.Equal(value, attrResolved.Value); 
+                    Assert.Equal(value, attrResolved.Value);
 
                     return;
                 }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/ExtensionConfigContextTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/ExtensionConfigContextTests.cs
@@ -6,18 +6,21 @@ using System.IO;
 using Microsoft.Azure.WebJobs.Description;
 using Microsoft.Azure.WebJobs.Host.Config;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Microsoft.Extensions.Configuration;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Host.UnitTests
 {
     public class ExtensionConfigContextTests
     {
+        private static readonly IConfiguration _config = new ConfigurationBuilder().Build();
+
         [Fact]
         public void BasicRules()
         {
             ConverterManager cm = new ConverterManager();
             INameResolver nr = new FakeNameResolver();
-            var ctx = new ExtensionConfigContext(nr, cm, null, null);
+            var ctx = new ExtensionConfigContext(_config, nr, cm, null, null);
 
             // Simulates extension initialization scope.
             {
@@ -51,7 +54,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         public void Converters()
         {
             ConverterManager cm = new ConverterManager();
-            var ctx = new ExtensionConfigContext(null, cm, null, null);
+            var ctx = new ExtensionConfigContext(_config, null, cm, null, null);
 
             // Simulates extension initialization scope.
             {
@@ -76,7 +79,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         [Fact]
         public void Error_IfMissingBindingAttribute()
         {
-            var ctx = new ExtensionConfigContext(null, null, null, null);
+            var ctx = new ExtensionConfigContext(_config, null, null, null, null);
 
             // 'Attribute' 
             Assert.Throws<InvalidOperationException>(() => ctx.AddBindingRule<Attribute>());
@@ -85,7 +88,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         [Fact]
         public void CallingAddBindingRule_Multiple_Times()
         {
-            var ctx = new ExtensionConfigContext(null, null, null, null);
+            var ctx = new ExtensionConfigContext(_config, null, null, null, null);
 
             // First time is fine
             var rule1 = ctx.AddBindingRule<TestAttribute>();
@@ -99,7 +102,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         [Fact]
         public void ErrorOnDanglingWhen()
         {
-            var ctx = new ExtensionConfigContext(null, null, null, null);
+            var ctx = new ExtensionConfigContext(_config, null, null, null, null);
 
             // Simulates extension initialization scope.
             {

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
@@ -74,6 +74,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 "BinderExtensions",
                 "BindingAttribute",
                 "ConnectionProviderAttribute",
+                "ConnectionStringAttribute",
                 "DisableAttribute",
                 "ExtensionAttribute",
                 "FunctionNameAttribute",


### PR DESCRIPTION
Allows binding attributes to set `[ConnectionString]` (as opposed to `[AppSetting]`, which instructs the attribute cloner to look up the key with `IConfiguration.GetConnectionString()` first, before falling back to the root configuration.