### PR TITLE
fixing JobHostFunctionTimeoutOptions usage

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Config/JobHostFunctionTimeoutOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Config/JobHostFunctionTimeoutOptions.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Globalization;
 using System.Threading;
 
 namespace Microsoft.Azure.WebJobs.Host
@@ -13,9 +12,9 @@ namespace Microsoft.Azure.WebJobs.Host
     public class JobHostFunctionTimeoutOptions
     {
         /// <summary>
-        /// Gets the timeout value.
+        /// Gets or sets the timeout value. The default value is <see cref="TimeSpan.Zero"/>, which indicates no timeout.
         /// </summary>
-        public TimeSpan Timeout { get; set; }
+        public TimeSpan Timeout { get; set; } = TimeSpan.Zero;
 
         /// <summary>
         /// Gets or sets a value indicating whether function invocations will timeout when
@@ -24,12 +23,12 @@ namespace Microsoft.Azure.WebJobs.Host
         public bool TimeoutWhileDebugging { get; set; }
 
         /// <summary>
-        /// When true, an exception is thrown when a function timeout expires.
+        /// Gets or sets a value indicating whether an exception is thrown when a function timeout expires.
         /// </summary>
         public bool ThrowOnTimeout { get; set; }
 
         /// <summary>
-        /// The amount of time to wait between canceling the timeout <see cref="CancellationToken"/> and throwing
+        /// Gets or sets the amount of time to wait between canceling the timeout <see cref="CancellationToken"/> and throwing
         /// a FunctionTimeoutException. This gives functions time to perform any graceful shutdown. 
         /// Only applies if <see cref="ThrowOnTimeout"/> is true.
         /// </summary>
@@ -37,11 +36,11 @@ namespace Microsoft.Azure.WebJobs.Host
 
         internal TimeoutAttribute ToAttribute()
         {
-            return new TimeoutAttribute(this.Timeout.ToString())
+            return new TimeoutAttribute(Timeout.ToString())
             {
-                TimeoutWhileDebugging = this.TimeoutWhileDebugging,
-                ThrowOnTimeout = this.ThrowOnTimeout,
-                GracePeriod = this.GracePeriod,
+                TimeoutWhileDebugging = TimeoutWhileDebugging,
+                ThrowOnTimeout = ThrowOnTimeout,
+                GracePeriod = GracePeriod,
             };
         }
     }

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionExecutor.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             [LogConstants.LogLevelKey] = LogLevel.Information
         };
 
-        private IFunctionOutputLogger _functionOutputLogger;
+        private readonly IFunctionOutputLogger _functionOutputLogger;
         private HostOutputMessage _hostOutputMessage;
 
         public FunctionExecutor(
@@ -130,7 +130,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
                     await NotifyCompleteAsync(instanceLogEntry, functionCompletedMessage.Arguments, exceptionInfo);
                     _resultsLogger?.LogFunctionResult(instanceLogEntry);
                 }
-                
+
                 if (functionCompletedMessage != null)
                 {
                     await _functionInstanceLogger.LogFunctionCompletedAsync(functionCompletedMessage, logCompletedCancellationToken);
@@ -300,11 +300,11 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             {
                 if (outputLog != null)
                 {
-                    ((IDisposable)outputLog).Dispose();
+                    outputLog.Dispose();
                 }
                 if (updateOutputLogTimer != null)
                 {
-                    ((IDisposable)updateOutputLogTimer).Dispose();
+                    updateOutputLogTimer.Dispose();
                 }
             }
         }
@@ -317,43 +317,38 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
         internal static System.Timers.Timer StartFunctionTimeout(IFunctionInstance instance, TimeoutAttribute attribute,
             CancellationTokenSource cancellationTokenSource, ILogger logger)
         {
-            if (attribute == null)
+            if (attribute == null || attribute.Timeout <= TimeSpan.Zero)
             {
                 return null;
             }
 
-            TimeSpan? timeout = attribute.Timeout;
+            TimeSpan timeout = attribute.Timeout;
 
-            if (timeout != null)
+            bool usingCancellationToken = instance.FunctionDescriptor.HasCancellationToken;
+            if (!usingCancellationToken && !attribute.ThrowOnTimeout)
             {
-                bool usingCancellationToken = instance.FunctionDescriptor.HasCancellationToken;
-                if (!usingCancellationToken && !attribute.ThrowOnTimeout)
-                {
-                    // function doesn't bind to the CancellationToken and we will not throw if it fires,
-                    // so no point in setting up the cancellation timer
-                    return null;
-                }
-
-                // Create a Timer that will cancel the token source when it fires. We're using our
-                // own Timer (rather than CancellationToken.CancelAfter) so we can write a log entry
-                // before cancellation occurs.
-                var timer = new System.Timers.Timer(timeout.Value.TotalMilliseconds)
-                {
-                    AutoReset = false
-                };
-
-                timer.Elapsed += (o, e) =>
-                {
-                    OnFunctionTimeout(timer, instance.FunctionDescriptor, instance.Id, timeout.Value, attribute.TimeoutWhileDebugging, logger, cancellationTokenSource,
-                        () => Debugger.IsAttached);
-                };
-
-                timer.Start();
-
-                return timer;
+                // function doesn't bind to the CancellationToken and we will not throw if it fires,
+                // so no point in setting up the cancellation timer
+                return null;
             }
 
-            return null;
+            // Create a Timer that will cancel the token source when it fires. We're using our
+            // own Timer (rather than CancellationToken.CancelAfter) so we can write a log entry
+            // before cancellation occurs.
+            var timer = new System.Timers.Timer(timeout.TotalMilliseconds)
+            {
+                AutoReset = false
+            };
+
+            timer.Elapsed += (o, e) =>
+            {
+                OnFunctionTimeout(timer, instance.FunctionDescriptor, instance.Id, timeout, attribute.TimeoutWhileDebugging, logger, cancellationTokenSource,
+                    () => Debugger.IsAttached);
+            };
+
+            timer.Start();
+
+            return timer;
         }
 
         internal static void OnFunctionTimeout(System.Timers.Timer timer, FunctionDescriptor method, Guid instanceId, TimeSpan timeout, bool timeoutWhileDebugging,
@@ -456,7 +451,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             {
                 if (updateParameterLogTimer != null)
                 {
-                    ((IDisposable)updateParameterLogTimer).Dispose();
+                    updateParameterLogTimer.Dispose();
                 }
 
                 parameterHelper.FlushParameterWatchers();
@@ -780,7 +775,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             private IReadOnlyList<string> _parameterNames;
 
             // state bag passed to all function filters
-            private IDictionary<string, object> _filterContextProperties = new Dictionary<string, object>();
+            private readonly IDictionary<string, object> _filterContextProperties = new Dictionary<string, object>();
 
             // the return value of the function
             private object _returnValue;
@@ -800,7 +795,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
                 }
 
                 _functionInstance = functionInstance;
-                this._parameterNames = functionInstance.Invoker.ParameterNames;
+                _parameterNames = functionInstance.Invoker.ParameterNames;
             }
 
             // Phsyical objects to pass to the underlying method Info. These will get updated for out-parameters. 
@@ -817,7 +812,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
 
             public void Initialize()
             {
-                this.JobInstance = _functionInstance.Invoker.CreateInstance();
+                JobInstance = _functionInstance.Invoker.CreateInstance();
             }
 
             // Convert the parameters and their names to a dictionary
@@ -843,7 +838,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
                 }
                 Dictionary<string, IWatcher> watches = new Dictionary<string, IWatcher>();
 
-                foreach (KeyValuePair<string, IValueProvider> item in this._parameters)
+                foreach (KeyValuePair<string, IValueProvider> item in _parameters)
                 {
                     IWatchable watchable = item.Value as IWatchable;
                     if (watchable != null)
@@ -886,7 +881,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             // run the binding source to create a set of IValueProviders for this instance. 
             public async Task BindAsync(IBindingSource bindingSource, ValueBindingContext context)
             {
-                this._parameters = await bindingSource.BindAsync(context);
+                _parameters = await bindingSource.BindAsync(context);
             }
 
             public IDictionary<string, string> CreateInvokeStringArguments()
@@ -935,7 +930,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
                     delayedBindingException = new DelayedException(new AggregateException(bindingExceptions));
                 }
 
-                this.InvokeParameters = reflectionParameters;
+                InvokeParameters = reflectionParameters;
                 return delayedBindingException;
             }
 
@@ -943,9 +938,8 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             // Null if not found. 
             public async Task<SingletonLock> GetSingletonLockAsync()
             {
-                IValueProvider singletonValueProvider = null;
                 SingletonLock singleton = null;
-                if (_parameters.TryGetValue(SingletonValueProvider.SingletonParameterName, out singletonValueProvider))
+                if (_parameters.TryGetValue(SingletonValueProvider.SingletonParameterName, out IValueProvider singletonValueProvider))
                 {
                     singleton = (SingletonLock)(await singletonValueProvider.GetValueAsync());
                 }
@@ -959,16 +953,16 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             // occurred by the time messages are enqueued.
             public async Task ProcessOutputParameters(CancellationToken cancellationToken)
             {
-                string[] parameterNamesInBindOrder = this.SortParameterNamesInStepOrder();
+                string[] parameterNamesInBindOrder = SortParameterNamesInStepOrder();
                 foreach (string name in parameterNamesInBindOrder)
                 {
-                    IValueProvider provider = this._parameters[name];
+                    IValueProvider provider = _parameters[name];
                     IValueBinder binder = provider as IValueBinder;
 
                     if (binder != null)
                     {
                         bool isReturn = name == FunctionIndexer.ReturnParamName;
-                        object argument = isReturn ? this._returnValue : this.InvokeParameters[this.GetParameterIndex(name)];
+                        object argument = isReturn ? _returnValue : InvokeParameters[GetParameterIndex(name)];
 
                         try
                         {
@@ -981,7 +975,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
                         }
                         catch (Exception exception)
                         {
-                            string message = String.Format(CultureInfo.InvariantCulture,
+                            string message = string.Format(CultureInfo.InvariantCulture,
                                 "Error while handling parameter {0} after function returned:", name);
                             throw new InvalidOperationException(message, exception);
                         }

--- a/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexProvider.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Bindings;
-using Microsoft.Azure.WebJobs.Host.Config;
 using Microsoft.Azure.WebJobs.Host.Dispatch;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Triggers;
@@ -72,7 +71,7 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
         {
             FunctionIndex index = new FunctionIndex();
             IBindingProvider bindingProvider = _bindingProviderFactory;
-            FunctionIndexer indexer = new FunctionIndexer(_triggerBindingProvider, bindingProvider, _activator, _executor, _extensions, _singletonManager, _loggerFactory, null, _sharedQueue, allowPartialHostStartup: _allowPartialHostStartup);
+            FunctionIndexer indexer = new FunctionIndexer(_triggerBindingProvider, bindingProvider, _activator, _executor, _extensions, _singletonManager, _loggerFactory, null, _sharedQueue, _defaultTimeout, _allowPartialHostStartup);
             IReadOnlyList<Type> types = _typeLocator.GetTypes();
 
             foreach (Type type in types)


### PR DESCRIPTION
We weren't passing the default timeout values into our Executor. This means that any changes to `JobHostFunctionTimeoutOptions` wasn't honored. This is how functions handles precompiled timeouts, so it's a bug that needs fixing.

Note that there's a handful of formatting fixes that VS auto-performed for me (removing `this.` and removing unnecessary casts). I love getting these in when I can, but let me know if I need to back them out. 