### PR TITLE
Fix default operation name on ServiceBus requests

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
@@ -375,7 +375,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                         case LogConstants.DurationKey:
                             if (prop.Value is TimeSpan duration)
                             {
-                                currentActivity.AddTag(prop.Key, duration.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
+                                currentActivity.AddTag(LogConstants.FunctionExecutionTimeKey, duration.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
                             }
                             break;
                         default:

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/WebJobsTelemetryInitializer.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/WebJobsTelemetryInitializer.cs
@@ -95,13 +95,18 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                                 request.Context.Operation.Name = tag.Value;
                                 request.Name = tag.Value;
                                 break;
-                            case LogConstants.DurationKey:
-                                request.Properties[LogConstants.FunctionExecutionTimeKey] = tag.Value;
-                                break;
                             default:
                                 request.Properties[tag.Key] = tag.Value;
                                 break;
                         }
+                    }
+                }
+                else // workaround for https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/1038
+                {
+                    if (request.Properties.TryGetValue(LogConstants.NameKey, out var functionName))
+                    {
+                        request.Context.Operation.Name = functionName;
+                        request.Name = functionName;
                     }
                 }
             }

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/TelemetryValidationHelpers.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/TelemetryValidationHelpers.cs
@@ -52,9 +52,17 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
             Assert.Equal(LogLevel.Information.ToString(), request.Properties[LogConstants.LogLevelKey]);
             Assert.NotNull(request.Name);
             Assert.NotNull(request.Id);
-            Assert.Equal(operationId, request.Context.Operation.Id);
+
+            if (operationId != null)
+            {
+                Assert.Equal(operationId, request.Context.Operation.Id);
+            }
+
+            if (parentId != null)
+            {
+                Assert.Equal(parentId, request.Context.Operation.ParentId);
+            }
             Assert.Equal(operationName, request.Context.Operation.Name);
-            Assert.Equal(parentId, request.Context.Operation.ParentId);
             Assert.True(request.Properties.ContainsKey(LogConstants.InvocationIdKey));
             Assert.True(request.Properties.ContainsKey(LogConstants.TriggerReasonKey));
         }


### PR DESCRIPTION
Because of https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/1038 some ServiceBus requests do not have operation name set to function name.

This happens because AppInsights stops the Activity prematurely. It will be fixed in the next ApplicationInsights SDK release.

This change provides workaround for this issue. It could be safely removed with update of AI SDK.