### PR TITLE
Set ApplicaitonInsights RoleInstance to function name

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/Constants/LogConstants.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/Constants/LogConstants.cs
@@ -140,6 +140,11 @@ namespace Microsoft.Azure.WebJobs.Logging
         public const int MetricEventId = 1;
 
         /// <summary>
+        /// Gets the name of the key used to store a metric name.
+        /// </summary>
+        public const string MetricNameKey = "MetricName";
+
+        /// <summary>
         /// Gets the name of the key used to store a metric sum.
         /// </summary>
         public const string MetricValueKey = "Value";

--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/LoggerExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/LoggerExtensions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Extensions.Logging
         {
             IDictionary<string, object> state = properties == null ? new Dictionary<string, object>() : new Dictionary<string, object>(properties);
 
-            state[LogConstants.NameKey] = name;
+            state[LogConstants.MetricNameKey] = name;
             state[LogConstants.MetricValueKey] = value;
 
             IDictionary<string, object> payload = new ReadOnlyDictionary<string, object>(state);

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                 LogConstants.LogLevelKey,
                 LogConstants.EventIdKey,
                 LogConstants.OriginalFormatKey,
+                LogConstants.MetricNameKey,
                 ScopeKeys.Event,
                 ScopeKeys.FunctionInvocationId,
                 ScopeKeys.FunctionName,
@@ -125,7 +126,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                 // next entry if found.
                 switch (entry.Key)
                 {
-                    case LogConstants.NameKey:
+                    case LogConstants.MetricNameKey:
                         telemetry.Name = entry.Value.ToString();
                         continue;
                     case LogConstants.MetricValueKey:

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/WebJobsTelemetryInitializer.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/WebJobsTelemetryInitializer.cs
@@ -97,8 +97,6 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                                 request.Context.Operation.Name = tag.Value;
                                 request.Context.Cloud.RoleInstance = tag.Value;
                                 break;
-                            case LogConstants.FullNameKey:
-                                break;
                             default:
                                 request.Properties[tag.Key] = tag.Value;
                                 break;

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/HttpDependencyCollectionTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/HttpDependencyCollectionTests.cs
@@ -113,7 +113,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
                     request.Id);
             }
 
-
             // PUT conatiner, HEAD blob, PUT lease, PUT content
             // since there could be failures and retries, we should expect more
             Assert.True(outDependencies.Count <= 4);
@@ -324,7 +323,12 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
                 Assert.Equal(blobName, dependency.Properties["Blob"]);
             }
 
-            TelemetryValidationHelpers.ValidateHttpDependency(dependency, operationName, operationId, requestId, LogCategories.Bindings);
+            TelemetryValidationHelpers.ValidateHttpDependency(
+                dependency, 
+                operationName, 
+                operationId, 
+                requestId, 
+                LogCategories.Bindings);
         }
 
 
@@ -338,7 +342,12 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
             Assert.Equal("Azure queue", dependency.Type);
             Assert.True(dependency.Name.EndsWith(queueName));
 
-            TelemetryValidationHelpers.ValidateHttpDependency(dependency, operationName, operationId, requestId, LogCategories.Bindings);
+            TelemetryValidationHelpers.ValidateHttpDependency(
+                dependency, 
+                operationName, 
+                operationId, 
+                requestId, 
+                LogCategories.Bindings);
         }
 
         public IHost ConfigureHost(LogLevel logLevel)

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/ServiceBusRequestAndDependencyCollectionTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/ServiceBusRequestAndDependencyCollectionTests.cs
@@ -75,8 +75,21 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
             string operationId = manualCallRequest.Context.Operation.Id;
             Assert.Equal(operationId, sbTriggerRequest.Context.Operation.Id);
 
-            ValidateServiceBusDependency(sbOutDependency, _endpoint, _queueName, "Send", nameof(ServiceBusOut), operationId, manualCallRequest.Id);
-            ValidateServiceBusRequest(sbTriggerRequest, _endpoint, _queueName, nameof(ServiceBusTrigger), operationId, sbOutDependency.Id);
+            ValidateServiceBusDependency(
+                sbOutDependency,
+                _endpoint, 
+                _queueName, 
+                "Send", 
+                nameof(ServiceBusOut),
+                operationId, 
+                manualCallRequest.Id);
+            ValidateServiceBusRequest(
+                sbTriggerRequest, 
+                _endpoint, 
+                _queueName, 
+                nameof(ServiceBusTrigger), 
+                operationId,
+                sbOutDependency.Id);
         }
 
         [Fact]
@@ -103,7 +116,13 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
 
             Assert.NotNull(requests.Single().Context.Operation.Id);
 
-            ValidateServiceBusRequest(requests.Single(), _endpoint, _queueName, nameof(ServiceBusTrigger), null, null);
+            ValidateServiceBusRequest(
+                requests.Single(),
+                _endpoint,
+                _queueName,
+                nameof(ServiceBusTrigger),
+                null,
+                null);
         }
 
         [NoAutomaticTrigger]
@@ -139,7 +158,12 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
             Assert.True(double.TryParse(request.Properties[LogConstants.FunctionExecutionTimeKey], out double functionDuration));
             Assert.True(request.Duration.TotalMilliseconds >= functionDuration);
 
-            TelemetryValidationHelpers.ValidateRequest(request, operationName, operationId, parentId, LogCategories.Results);
+            TelemetryValidationHelpers.ValidateRequest(
+                request, 
+                operationName, 
+                operationId, 
+                parentId, 
+                LogCategories.Results);
         }
 
         private void ValidateServiceBusDependency(
@@ -156,7 +180,12 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
             Assert.Equal(name, dependency.Name);
             Assert.True(dependency.Success);
             Assert.Null(dependency.Data);
-            TelemetryValidationHelpers.ValidateDependency(dependency, operationName, operationId, parentId, LogCategories.Bindings);
+            TelemetryValidationHelpers.ValidateDependency(
+                dependency,
+                operationName,
+                operationId,
+                parentId,
+                LogCategories.Bindings);
         }
 
         public IHost ConfigureHost()

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/TelemetryValidationHelpers.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/TelemetryValidationHelpers.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
             Assert.NotNull(dependency.Id);
             Assert.Equal(operationId, dependency.Context.Operation.Id);
             Assert.Equal(operationName, dependency.Context.Operation.Name);
+            Assert.Equal(operationName, dependency.Context.Cloud.RoleInstance);
             Assert.Equal(parentId, dependency.Context.Operation.ParentId);
             Assert.True(dependency.Properties.ContainsKey(LogConstants.InvocationIdKey));
         }
@@ -65,6 +66,8 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
             Assert.Equal(operationName, request.Context.Operation.Name);
             Assert.True(request.Properties.ContainsKey(LogConstants.InvocationIdKey));
             Assert.True(request.Properties.ContainsKey(LogConstants.TriggerReasonKey));
+
+            Assert.Equal(operationName, request.Context.Cloud.RoleInstance);
         }
     }
 }


### PR DESCRIPTION
ApplicationInsights uses RoleInstance on the AppMap to show a number of instances of a role.
Role is node on the app map and is described by RoleName (function site name). 

Now, the roleInstance is set to function instance id that looks like `55eae20aa29dec69f13da780338872e0b0cbfd220429444bad0527b131af78d3`.

It results in several issues in UX. 

E.g. every time function restarts or runs on a new host it results in increase of number of instances on the node. If there are multiple functions on the same host, they are still shown as one instance.

Performacne analysis blade allows to group telemetry by role instance and aggregate data. Having one roleInstance here is also not useful.

It makes sense for this number to match functions on the host rather than instances of functions. And having real number of function instances does not seem really useful in serverless architecture.

This change sets RoleInstance to the function name on all telemetry that is sent in the scope of the function. Other telemetries such as host start/stop events, heartbeats are still sent with function instance id. This should not affect AppMap/performance blade behavior because this telemetry does not participate in distributed tracing.
