### PR TITLE
Enable AppInsights http requests collection and W3C distributed tracing support

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.ApplicationInsights.W3C;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
@@ -18,6 +19,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
     internal class ApplicationInsightsLogger : ILogger
     {
         private readonly TelemetryClient _telemetryClient;
+        private readonly ApplicationInsightsLoggerOptions _loggerOptions;
         private readonly string _categoryName;
         private readonly bool _isUserFunction = false;
 
@@ -43,9 +45,10 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                 OperationContext
             };
 
-        public ApplicationInsightsLogger(TelemetryClient client, string categoryName)
+        public ApplicationInsightsLogger(TelemetryClient client, string categoryName, ApplicationInsightsLoggerOptions loggerOptions)
         {
             _telemetryClient = client;
+            _loggerOptions = loggerOptions;
             _categoryName = categoryName ?? DefaultCategoryName;
             _isUserFunction = LogCategories.IsFunctionUserCategory(categoryName);
         }
@@ -450,6 +453,18 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
 
                     // We'll need to store this operation context so we can stop it when the function completes
                     IOperationHolder<RequestTelemetry> operation = _telemetryClient.StartOperation(request);
+
+#pragma warning disable 612, 618
+                    if (_loggerOptions.EnableW3CDistributedTracing)
+                    {
+                        // currently ApplicationInsights supports 2 parallel correlation schemes:
+                        // legacy and W3C, they both appear in telemetry. UX handles all differences in operation Ids. 
+                        // This will be resolved in next .NET SDK on Activity level.
+                        // This ensures W3C context is set on the Activity.
+                        Activity.Current?.GenerateW3CContext();
+                    }
+#pragma warning restore 612, 618
+
                     stateValues[OperationContext] = operation;
                 }
             }

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
@@ -8,12 +8,37 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
 {
     public class ApplicationInsightsLoggerOptions
     {
+        /// <summary>
+        /// Gets or sets Application Insights instrumentation key.
+        /// </summary>
         public string InstrumentationKey { get; set; }
 
+        /// <summary>
+        /// Gets or sets sampling settings.
+        /// </summary>
         public SamplingPercentageEstimatorSettings SamplingSettings { get; set; }
 
+        /// <summary>
+        /// Gets or sets snapshot collection options.
+        /// </summary>
         public SnapshotCollectorConfiguration SnapshotConfiguration { get; set; }
 
+        /// <summary>
+        /// Gets or sets authentication key for Quick Pulse (Live Metrics).
+        /// </summary>
         public string QuickPulseAuthenticationApiKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets flag that enables support of W3C distributed tracing protocol
+        /// (and turns on legacy correlation schema).  Enabled by default.
+        /// </summary>
+        public bool EnableW3CDistributedTracing { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a flag that enables injection of multi-component correlation headers into responses.
+        /// This allows Application Insights to construct an Application Map to  when several
+        /// instrumentation keys are used.  Disabled by default.
+        /// </summary>
+        public bool EnableResponseHeaderInjection { get; set; } = true;
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerProvider.cs
@@ -8,21 +8,22 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
 {
-
     [ProviderAlias(Alias)]
     public class ApplicationInsightsLoggerProvider : ILoggerProvider
     {
         internal const string Alias = "ApplicationInsights";
 
         private readonly TelemetryClient _client;
+        private readonly ApplicationInsightsLoggerOptions _loggerOptions;
         private bool _disposed;
 
-        public ApplicationInsightsLoggerProvider(TelemetryClient client)
+        public ApplicationInsightsLoggerProvider(TelemetryClient client, ApplicationInsightsLoggerOptions loggerOptions)
         {
             _client = client ?? throw new ArgumentNullException(nameof(client));
+            _loggerOptions = loggerOptions ?? throw new ArgumentNullException(nameof(loggerOptions));
         }
 
-        public ILogger CreateLogger(string categoryName) => new ApplicationInsightsLogger(_client, categoryName);
+        public ILogger CreateLogger(string categoryName) => new ApplicationInsightsLogger(_client, categoryName, _loggerOptions);
 
         public void Dispose()
         {

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsLoggingBuilderExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsLoggingBuilderExtensions.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Extensions.Logging
             {
                 // We want all logs to flow through the logger so they show up in QuickPulse.
                 // To do that, we'll hide all registered rules inside of this one. They will be re-populated
-                // and used by the FilteringTelemetryProcessor futher down the pipeline.
+                // and used by the FilteringTelemetryProcessor further down the pipeline.
                 string fullTypeName = typeof(ApplicationInsightsLoggerProvider).FullName;
                 IList<LoggerFilterRule> matchingRules = o.Rules.Where(r =>
                 {

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
@@ -5,7 +5,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Reflection.Metadata.Ecma335;
 using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.AspNetCore;
+using Microsoft.ApplicationInsights.AspNetCore.Extensions;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DependencyCollector;
 using Microsoft.ApplicationInsights.Extensibility;
@@ -13,11 +16,13 @@ using Microsoft.ApplicationInsights.Extensibility.Implementation;
 using Microsoft.ApplicationInsights.Extensibility.Implementation.ApplicationId;
 using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse;
 using Microsoft.ApplicationInsights.SnapshotCollector;
+using Microsoft.ApplicationInsights.W3C;
 using Microsoft.ApplicationInsights.WindowsServer;
 using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Logging.ApplicationInsights;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Configuration;
 using Microsoft.Extensions.Options;
@@ -38,6 +43,8 @@ namespace Microsoft.Extensions.DependencyInjection
 
         public static IServiceCollection AddApplicationInsights(this IServiceCollection services)
         {
+            services.TryAddSingleton<ISdkVersionProvider, WebJobsSdkVersionProvider>();
+
             // Bind to the configuration section registered with 
             services.AddOptions<ApplicationInsightsLoggerOptions>()
                 .Configure<ILoggerProviderConfiguration<ApplicationInsightsLoggerProvider>>((options, config) =>
@@ -47,14 +54,17 @@ namespace Microsoft.Extensions.DependencyInjection
 
             services.AddSingleton<ITelemetryInitializer, HttpDependenciesParsingTelemetryInitializer>();
             services.AddSingleton<ITelemetryInitializer, WebJobsRoleEnvironmentTelemetryInitializer>();
-            services.AddSingleton<ITelemetryInitializer, WebJobsTelemetryInitializer>();
             services.AddSingleton<ITelemetryInitializer, WebJobsSanitizingInitializer>();
+            services.AddSingleton<ITelemetryInitializer, WebJobsTelemetryInitializer>();
+
             services.AddSingleton<ITelemetryModule, QuickPulseTelemetryModule>();
 
             services.AddSingleton<IApplicationIdProvider, ApplicationInsightsApplicationIdProvider>();
 
             services.AddSingleton<ITelemetryModule, DependencyTrackingTelemetryModule>(provider =>
             {
+                var options = provider.GetService<IOptions<ApplicationInsightsLoggerOptions>>().Value;
+
                 var dependencyCollector = new DependencyTrackingTelemetryModule();
                 var excludedDomains = dependencyCollector.ExcludeComponentCorrelationHttpHeadersOnDomains;
                 excludedDomains.Add("core.windows.net");
@@ -67,8 +77,29 @@ namespace Microsoft.Extensions.DependencyInjection
                 var includedActivities = dependencyCollector.IncludeDiagnosticSourceActivities;
                 includedActivities.Add("Microsoft.Azure.ServiceBus");
 
+                dependencyCollector.EnableW3CHeadersInjection = options.EnableW3CDistributedTracing;
                 return dependencyCollector;
             });
+
+            services.AddSingleton<ITelemetryModule, RequestTrackingTelemetryModule>(provider =>
+            {
+                var options = provider.GetService<IOptions<ApplicationInsightsLoggerOptions>>().Value;
+                var appIdProvider = provider.GetService<IApplicationIdProvider>();
+
+                var requestCollector =
+                    new RequestTrackingTelemetryModule(appIdProvider)
+                    {
+                        CollectionOptions = new RequestCollectionOptions
+                        {
+                            TrackExceptions = false, // webjobs/functions track exceptions themselves
+                            EnableW3CDistributedTracing = options.EnableW3CDistributedTracing,
+                            InjectResponseHeaders = options.EnableResponseHeaderInjection
+                        }
+                    };
+
+                return requestCollector;
+            });
+
             services.AddSingleton<ITelemetryModule, AppServicesHeartbeatTelemetryModule>();
 
             services.AddSingleton<ITelemetryChannel, ServerTelemetryChannel>();
@@ -92,6 +123,16 @@ namespace Microsoft.Extensions.DependencyInjection
                     TelemetryConfiguration.Active.InstrumentationKey = options.InstrumentationKey;
                     TelemetryConfiguration.Active.TelemetryInitializers.Add(
                         new WebJobsRoleEnvironmentTelemetryInitializer());
+                    if (options.EnableW3CDistributedTracing)
+                    {
+#pragma warning disable 612, 618
+                        // W3C distributed tracing is enabled by the feature flag inside ApplicationInsights SDK
+                        // W3COperationCorrelationTelemetryInitializer will go away once W3C is implemented
+                        // in the DiagnosticSource (.NET)
+
+                        TelemetryConfiguration.Active.TelemetryInitializers.Add(new W3COperationCorrelationTelemetryInitializer());
+#pragma warning restore 612, 618
+                    }
                 }
 
                 SetupTelemetryConfiguration(
@@ -107,17 +148,24 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
             services.AddSingleton<TelemetryClient>(provider =>
+                {
+                    TelemetryConfiguration configuration = provider.GetService<TelemetryConfiguration>();
+                    TelemetryClient client = new TelemetryClient(configuration);
+
+                    ISdkVersionProvider versionProvider = provider.GetService<ISdkVersionProvider>();
+                    client.Context.GetInternalContext().SdkVersion = versionProvider?.GetSdkVersion();
+
+                    return client;
+                }
+            );
+
+            services.AddSingleton<ILoggerProvider, ApplicationInsightsLoggerProvider>(provider =>
             {
-                TelemetryConfiguration configuration = provider.GetService<TelemetryConfiguration>();
-                TelemetryClient client = new TelemetryClient(configuration);
+                TelemetryClient client = provider.GetService<TelemetryClient>();
+                ApplicationInsightsLoggerOptions options = provider.GetService<IOptions<ApplicationInsightsLoggerOptions>>().Value;
 
-                string assemblyVersion = GetAssemblyFileVersion(typeof(JobHost).Assembly);
-                client.Context.GetInternalContext().SdkVersion = $"webjobs: {assemblyVersion}";
-
-                return client;
+                return new ApplicationInsightsLoggerProvider(client, options);
             });
-
-            services.AddSingleton<ILoggerProvider, ApplicationInsightsLoggerProvider>();
 
             return services;
         }
@@ -162,6 +210,16 @@ namespace Microsoft.Extensions.DependencyInjection
             if (options.InstrumentationKey != null)
             {
                 configuration.InstrumentationKey = options.InstrumentationKey;
+            }
+
+            if (options.EnableW3CDistributedTracing)
+            {
+#pragma warning disable 612, 618
+                // W3C distributed tracing is enabled by the feature flag inside ApplicationInsights SDK
+                // W3COperationCorrelationTelemetryInitializer will go away once W3C is implemented
+                // in the DiagnosticSource (.NET)
+                configuration.TelemetryInitializers.Add(new W3COperationCorrelationTelemetryInitializer());
+#pragma warning restore 612, 618
             }
 
             configuration.TelemetryChannel = channel;
@@ -221,11 +279,6 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             configuration.ApplicationIdProvider = applicationIdProvider;
-        }
-        internal static string GetAssemblyFileVersion(Assembly assembly)
-        {
-            AssemblyFileVersionAttribute fileVersionAttr = assembly.GetCustomAttribute<AssemblyFileVersionAttribute>();
-            return fileVersionAttr?.Version ?? LoggingConstants.Unknown;
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ISdkVersionProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ISdkVersionProvider.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Reflection;
+
+namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
+{
+    public interface ISdkVersionProvider
+    {
+        string GetSdkVersion();
+    }
+
+    internal class WebJobsSdkVersionProvider : ISdkVersionProvider
+    {
+        private readonly string sdkVersion = "webjobs: " + GetAssemblyFileVersion(typeof(JobHost).Assembly);
+
+        public string GetSdkVersion()
+        {
+            return sdkVersion;
+        }
+
+        internal static string GetAssemblyFileVersion(Assembly assembly)
+        {
+            AssemblyFileVersionAttribute fileVersionAttr = assembly.GetCustomAttribute<AssemblyFileVersionAttribute>();
+            return fileVersionAttr?.Version ?? LoggingConstants.Unknown;
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
@@ -24,17 +24,18 @@
   </ItemGroup>
   
   <ItemGroup>
-  <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.7.2" />
+  <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.5.0" />
+  <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.8.1" />
   <PackageReference Include="Microsoft.ApplicationInsights.SnapshotCollector" Version="1.3.0" />
-  <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.7.2" />
-  <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.7.2" />
+  <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.8.1" />
+  <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.8.0" />
   <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.1.0" />
   <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.0" />
   <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.7.2" />
-    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.7.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.8.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.0" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />

--- a/test/Microsoft.Azure.WebJobs.Extensions.ServiceBus.UnitTests/WebJobs.Extensions.ServiceBus.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.ServiceBus.UnitTests/WebJobs.Extensions.ServiceBus.UnitTests.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.7.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/ApplicationInsightsEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/ApplicationInsightsEndToEndTests.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Reflection;
 using System.Text;
 using System.Threading;
@@ -19,6 +20,12 @@ using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.Extensibility.Implementation;
 using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Extensions.DependencyInjection;
@@ -29,7 +36,7 @@ using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 {
-    public class ApplicationInsightsEndToEndTests : IDisposable
+    public class ApplicationInsightsEndToEndTests : IDisposable, IClassFixture<ApplicationInsightsEndToEndTests.CustomTestWebHostFactory>
     {
         private const string _mockApplicationInsightsUrl = "http://localhost:4005/v2/track/";
         private const string _mockQuickPulseUrl = "http://localhost:4005/QuickPulseService.svc/";
@@ -41,6 +48,15 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         private const string _customScopeValue = "MyCustomScopeValue";
 
         private const string _dateFormat = "HH':'mm':'ss'.'fffZ";
+        private const int _expectedResponseCode = 204;
+        private static readonly Uri _expectedUrl = new Uri("http://localhost/some/path");
+
+        private readonly CustomTestWebHostFactory _factory;
+
+        public ApplicationInsightsEndToEndTests(CustomTestWebHostFactory factory)
+        {
+            _factory = factory;
+        }
 
         private IHost ConfigureHost(LogLevel minLevel = LogLevel.Information)
         {
@@ -321,7 +337,49 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 RequestTelemetry functionRequest = requestTelemetries.Single();
                 Assert.Same(outerRequest, functionRequest);
 
+                Assert.True(double.TryParse(functionRequest.Properties[LogConstants.FunctionExecutionTimeKey], out double functionDuration));
+                Assert.True(functionRequest.Duration.TotalMilliseconds >= functionDuration);
+
                 ValidateRequest(functionRequest, testName, true);
+            }
+        }
+
+        [Fact]
+        public async Task ApplicationInsights_HttpRequestTracking()
+        {
+            var client = _factory.CreateClient();
+
+            string testName = nameof(TestApplicationInsightsInformation);
+            using (IHost host = ConfigureHost())
+            {
+                Startup.Host = host;
+                await host.StartAsync();
+
+                var request = new HttpRequestMessage(HttpMethod.Get, "/some/path");
+                request.Headers.Add("traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01");
+
+                await client.SendAsync(request);
+
+                await host.StopAsync();
+
+                // Validate the request
+                // There must be only one reported by the AppInsights request collector
+                RequestTelemetry[] requestTelemetries = _channel.Telemetries.OfType<RequestTelemetry>().ToArray();
+                Assert.Single(requestTelemetries);
+
+                RequestTelemetry functionRequest = requestTelemetries.Single();
+
+                Assert.True(double.TryParse(functionRequest.Properties[LogConstants.FunctionExecutionTimeKey], out double functionDuration));
+                Assert.True(functionRequest.Duration.TotalMilliseconds >= functionDuration);
+                ValidateRequest(
+                    functionRequest,
+                    testName,
+                    true,
+                    "4bf92f3577b34da6a3ce929d0e0e4736",
+                    "|4bf92f3577b34da6a3ce929d0e0e4736.00f067aa0ba902b7.");
+
+                Assert.Equal(_expectedUrl, functionRequest.Url);
+                Assert.Equal(_expectedResponseCode.ToString(), functionRequest.ResponseCode);
             }
         }
 
@@ -647,7 +705,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             ValidateSdkVersion(telemetry);
         }
 
-        private static void ValidateRequest(RequestTelemetry telemetry, string operationName, bool success)
+        private static void ValidateRequest(RequestTelemetry telemetry, string operationName, bool success, string operationId = null, string parentId = null)
         {
             Assert.NotNull(telemetry.Context.Operation.Id);
             Assert.Equal(operationName, telemetry.Context.Operation.Name);
@@ -659,7 +717,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             Assert.Equal($"ApplicationInsightsEndToEndTests.{operationName}", telemetry.Properties[LogConstants.FullNameKey]);
             Assert.Equal("This function was programmatically called via the host APIs.", telemetry.Properties[LogConstants.TriggerReasonKey]);
 
-            ValidateSdkVersion(telemetry);
+            TelemetryValidationHelpers.ValidateRequest(telemetry, operationName, operationId, parentId, LogCategories.Results, success? LogLevel.Information : LogLevel.Error);
         }
 
         private static void ValidateSdkVersion(ITelemetry telemetry)
@@ -733,6 +791,42 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         public void Dispose()
         {
             _channel?.Dispose();
+        }
+
+
+        public class Startup
+        {
+            internal static IHost Host;
+
+            public void ConfigureServices(IServiceCollection services)
+            {
+            }
+
+            public void Configure(IApplicationBuilder app, AspNetCore.Hosting.IHostingEnvironment env)
+            {
+                app.Run(async (context) =>
+                {
+                    MethodInfo methodInfo = typeof(ApplicationInsightsEndToEndTests).GetMethod(nameof(TestApplicationInsightsInformation), BindingFlags.Public | BindingFlags.Static);
+                    await Host.GetJobHost().CallAsync(methodInfo, new { input = "input" });
+                    context.Response.StatusCode = _expectedResponseCode;
+                    await context.Response.WriteAsync("Hello World!");
+                });
+            }
+        }
+
+        public class CustomTestWebHostFactory : WebApplicationFactory<ApplicationInsightsEndToEndTests.Startup>
+        {
+            protected override IWebHostBuilder CreateWebHostBuilder()
+            {
+                return WebHost.CreateDefaultBuilder()
+                    .UseStartup<ApplicationInsightsEndToEndTests.Startup>();
+            }
+
+            protected override void ConfigureWebHost(IWebHostBuilder builder)
+            {
+                builder.UseContentRoot(".");
+                base.ConfigureWebHost(builder);
+            }
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/HttpDependencyCollectionTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/HttpDependencyCollectionTests.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
             }
 
 
-            // PUT conatiner, HEAD blob, PUT lease, PUT content
+            // PUT container, HEAD blob, PUT lease, PUT content
             // since there could be failures and retries, we should expect more
             Assert.True(outDependencies.Count <= 4);
 
@@ -154,7 +154,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
 
             Assert.Equal("Http", dependency.Type);
             Assert.Equal("www.microsoft.com", dependency.Target);
-            Assert.Equal("https://www.microsoft.com", dependency.Data);
+            Assert.Equal("https://www.microsoft.com/", dependency.Data);
             Assert.Equal("GET /", dependency.Name);
         }
 
@@ -278,7 +278,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
             using (HttpClient httpClient = new HttpClient())
             {
                 // we don't really care about the result, so, we'll ignore all errors
-                await httpClient.GetAsync("http://microsoft.com").ContinueWith(t => { });
+                await httpClient.GetAsync("http://microsoft.com/").ContinueWith(t => { });
             }
             _functionWaitHandle.Set();
         }

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/ServiceBusRequestAndDependencyCollectionTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/ServiceBusRequestAndDependencyCollectionTests.cs
@@ -29,7 +29,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
         private const string _mockApplicationInsightsKey = "some_key";
         private readonly string _endpoint;
         private readonly string _connectionString;
-        private RandomNameResolver _resolver;
         private readonly TestTelemetryChannel _channel = new TestTelemetryChannel();
         private static readonly AutoResetEvent _functionWaitHandle = new AutoResetEvent(false);
 
@@ -67,16 +66,27 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
             Assert.Equal(2, requests.Count);
             Assert.Single(dependencies);
 
-            Assert.Single(requests.Where(r => r.Context.Operation.ParentId == dependencies.Single().Id));
-            var sbTriggerRequest = requests.Single(r => r.Context.Operation.ParentId == dependencies.Single().Id);
+            Assert.Single(requests.Where(r => r.Name == nameof(ServiceBusTrigger)));
+            var sbTriggerRequest = requests.Single(r => r.Name == nameof(ServiceBusTrigger));
             var manualCallRequest = requests.Single(r => r.Name == nameof(ServiceBusOut));
             var sbOutDependency = dependencies.Single();
 
-            string operationId = manualCallRequest.Context.Operation.Id;
-            Assert.Equal(operationId, sbTriggerRequest.Context.Operation.Id);
+            string manualOperationId = manualCallRequest.Context.Operation.Id;
+            string triggerOperationId = sbTriggerRequest.Context.Operation.Id;
 
-            ValidateServiceBusDependency(sbOutDependency, _endpoint, _queueName, "Send", nameof(ServiceBusOut), operationId, manualCallRequest.Id);
-            ValidateServiceBusRequest(sbTriggerRequest, _endpoint, _queueName, nameof(ServiceBusTrigger), operationId, sbOutDependency.Id);
+            // currently ApplicationInsights supports 2 parallel correlation schemes:
+            // legacy and W3C, they both appear in telemetry. UX handles all differences in operation Ids. 
+            // This will be resolved in next .NET SDK on Activity level
+            string dependencyLegacyId = sbOutDependency.Properties.Single(p => p.Key == "ai_legacyRequestId").Value;
+            string triggerCallLegacyRootId = sbTriggerRequest.Properties.Single(p => p.Key == "ai_legacyRootId").Value;
+            string manualCallLegacyRootId = manualCallRequest.Properties.Single(p => p.Key == "ai_legacyRootId").Value;
+
+            Assert.Equal(sbTriggerRequest.Context.Operation.ParentId, dependencyLegacyId);
+            Assert.Equal(manualOperationId, sbOutDependency.Context.Operation.Id);
+            Assert.Equal(manualCallLegacyRootId, triggerCallLegacyRootId);
+
+            ValidateServiceBusDependency(sbOutDependency, _endpoint, _queueName, "Send", nameof(ServiceBusOut), manualOperationId, manualCallRequest.Id);
+            ValidateServiceBusRequest(sbTriggerRequest, _endpoint, _queueName, nameof(ServiceBusTrigger), triggerOperationId, dependencyLegacyId);
         }
 
         [Fact]
@@ -161,8 +171,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
 
         public IHost ConfigureHost()
         {
-            _resolver = new RandomNameResolver();
-
             IHost host = new HostBuilder()
                 .ConfigureDefaultTestHost<ServiceBusRequestAndDependencyCollectionTests>(b =>
                 {

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/TelemetryValidationHelpers.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/TelemetryValidationHelpers.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility.Implementation;
 using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Extensions.Logging;
 using Xunit;
@@ -46,10 +47,11 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
             string operationName,
             string operationId,
             string parentId,
-            string category)
+            string category,
+            LogLevel logLevel = LogLevel.Information)
         {
             Assert.Equal(category, request.Properties[LogConstants.CategoryNameKey]);
-            Assert.Equal(LogLevel.Information.ToString(), request.Properties[LogConstants.LogLevelKey]);
+            Assert.Equal(logLevel.ToString(), request.Properties[LogConstants.LogLevelKey]);
             Assert.NotNull(request.Name);
             Assert.NotNull(request.Id);
 
@@ -65,6 +67,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
             Assert.Equal(operationName, request.Context.Operation.Name);
             Assert.True(request.Properties.ContainsKey(LogConstants.InvocationIdKey));
             Assert.True(request.Properties.ContainsKey(LogConstants.TriggerReasonKey));
+            Assert.StartsWith("webjobs:", request.Context.GetInternalContext().SdkVersion);
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/WebJobs.Host.EndToEndTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/WebJobs.Host.EndToEndTests.csproj
@@ -23,11 +23,13 @@
 
   <ItemGroup>
     <PackageReference Include="appinsights.testlogger" Version="1.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="3.0.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.7.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Moq" Version="4.7.145" />

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/WebJobs.Host.FunctionalTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/WebJobs.Host.FunctionalTests.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.7.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Moq" Version="4.7.145" />

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.AspNetCore;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DependencyCollector;
 using Microsoft.ApplicationInsights.Extensibility;
@@ -12,6 +13,7 @@ using Microsoft.ApplicationInsights.Extensibility.Implementation;
 using Microsoft.ApplicationInsights.Extensibility.Implementation.ApplicationId;
 using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse;
 using Microsoft.ApplicationInsights.SnapshotCollector;
+using Microsoft.ApplicationInsights.W3C;
 using Microsoft.ApplicationInsights.WindowsServer;
 using Microsoft.ApplicationInsights.WindowsServer.Channel.Implementation;
 using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
@@ -41,13 +43,18 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                 var config = host.Services.GetService<TelemetryConfiguration>();
 
                 // Verify Initializers
-                Assert.Equal(5, config.TelemetryInitializers.Count);
+                Assert.Equal(6, config.TelemetryInitializers.Count);
                 // These will throw if there are not exactly one
                 Assert.Single(config.TelemetryInitializers.OfType<OperationCorrelationTelemetryInitializer>());
                 Assert.Single(config.TelemetryInitializers.OfType<HttpDependenciesParsingTelemetryInitializer>());
                 Assert.Single(config.TelemetryInitializers.OfType<WebJobsRoleEnvironmentTelemetryInitializer>());
                 Assert.Single(config.TelemetryInitializers.OfType<WebJobsTelemetryInitializer>());
                 Assert.Single(config.TelemetryInitializers.OfType<WebJobsSanitizingInitializer>());
+                Assert.Single(config.TelemetryInitializers.OfType<W3COperationCorrelationTelemetryInitializer>());
+
+                var sdkVersionProvider = host.Services.GetServices<ISdkVersionProvider>().ToList();
+                Assert.Single(sdkVersionProvider);
+                Assert.Single(sdkVersionProvider.OfType<WebJobsSdkVersionProvider>());
 
                 // Verify Channel
                 Assert.IsType<ServerTelemetryChannel>(config.TelemetryChannel);
@@ -55,15 +62,26 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                 var modules = host.Services.GetServices<ITelemetryModule>().ToList();
 
                 // Verify Modules
-                Assert.Equal(3, modules.Count);
+                Assert.Equal(4, modules.Count);
                 Assert.Single(modules.OfType<DependencyTrackingTelemetryModule>());
+
                 Assert.Single(modules.OfType<QuickPulseTelemetryModule>());
                 Assert.Single(modules.OfType<AppServicesHeartbeatTelemetryModule>());
+                Assert.Single(modules.OfType<RequestTrackingTelemetryModule>());
+
+                var dependencyModule = modules.OfType<DependencyTrackingTelemetryModule>().Single();
+                var requestModule = modules.OfType<RequestTrackingTelemetryModule>().Single();
+
+                Assert.True(dependencyModule.EnableW3CHeadersInjection);
+                Assert.True(requestModule.CollectionOptions.EnableW3CDistributedTracing);
+                Assert.True(requestModule.CollectionOptions.InjectResponseHeaders);
+                Assert.False(requestModule.CollectionOptions.TrackExceptions);
+
                 Assert.Same(config.TelemetryChannel, host.Services.GetServices<ITelemetryChannel>().Single());
                 // Verify client
                 var client = host.Services.GetService<TelemetryClient>();
                 Assert.NotNull(client);
-                Assert.True(client.Context.GetInternalContext().SdkVersion.StartsWith("webjobs"));
+                Assert.StartsWith("webjobs", client.Context.GetInternalContext().SdkVersion);
 
                 // Verify provider
                 var providers = host.Services.GetServices<ILoggerProvider>().ToList();
@@ -110,6 +128,33 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             }
         }
 
+
+        [Fact]
+        public void DependencyInjectionConfiguration_ConfiguresRequestCollectionOptions()
+        {
+            using (var host = new HostBuilder()
+                .ConfigureLogging(b =>
+                {
+                    b.AddApplicationInsights(o =>
+                    {
+                        o.InstrumentationKey = "some key";
+                        o.EnableW3CDistributedTracing = false;
+                        o.EnableResponseHeaderInjection = false;
+                    });
+                })
+                .Build())
+            {
+                var modules = host.Services.GetServices<ITelemetryModule>().ToList();
+                var dependencyModule = modules.OfType<DependencyTrackingTelemetryModule>().Single();
+                var requestModule = modules.OfType<RequestTrackingTelemetryModule>().Single();
+
+                Assert.False(dependencyModule.EnableW3CHeadersInjection);
+                Assert.False(requestModule.CollectionOptions.EnableW3CDistributedTracing);
+                Assert.False(requestModule.CollectionOptions.InjectResponseHeaders);
+                Assert.False(requestModule.CollectionOptions.TrackExceptions);
+            }
+        }
+        
         [Fact]
         public void DependencyInjectionConfiguration_ConfiguresQuickPulseAuthApiKey()
         {
@@ -191,7 +236,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                 }).Build())
             {
                 // Verify Initializers
-                Assert.Equal(2, TelemetryConfiguration.Active.TelemetryInitializers.Count);
+                Assert.Equal(3, TelemetryConfiguration.Active.TelemetryInitializers.Count);
 
                 // These will throw if there are not exactly one
                 Assert.Single(TelemetryConfiguration.Active.TelemetryInitializers.OfType<OperationCorrelationTelemetryInitializer>());
@@ -228,11 +273,12 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                 }).Build())
             {
                 // Verify Initializers
-                Assert.Equal(2, TelemetryConfiguration.Active.TelemetryInitializers.Count);
+                Assert.Equal(3, TelemetryConfiguration.Active.TelemetryInitializers.Count);
 
                 // These will throw if there are not exactly one
                 Assert.Single(TelemetryConfiguration.Active.TelemetryInitializers.OfType<OperationCorrelationTelemetryInitializer>());
                 Assert.Single(TelemetryConfiguration.Active.TelemetryInitializers.OfType<WebJobsRoleEnvironmentTelemetryInitializer>());
+                Assert.Single(TelemetryConfiguration.Active.TelemetryInitializers.OfType<W3COperationCorrelationTelemetryInitializer>());
 
                 // ikey should still be set
                 Assert.Equal("some key", TelemetryConfiguration.Active.InstrumentationKey);

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsLoggerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsLoggerTests.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.ApplicationInsights.W3C;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Indexers;
@@ -87,8 +88,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             string expectedOperationId, expectedRequestId;
             using (logger.BeginFunctionScope(CreateFunctionInstance(_invocationId), _hostInstanceId))
             {
-                expectedRequestId = Activity.Current.Id;
-                expectedOperationId = Activity.Current.RootId;
+                expectedRequestId = $"|{Activity.Current.GetTraceId()}.{Activity.Current.GetSpanId()}.";
+                expectedOperationId = Activity.Current.GetTraceId();
 
                 // sleep briefly to provide a non-zero Duration
                 await Task.Delay(100);
@@ -122,8 +123,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             string expectedOperationId, expectedRequestId;
             using (logger.BeginFunctionScope(CreateFunctionInstance(_invocationId), _hostInstanceId))
             {
-                expectedRequestId = Activity.Current.Id;
-                expectedOperationId = Activity.Current.RootId;
+                expectedRequestId = $"|{Activity.Current.GetTraceId()}.{Activity.Current.GetSpanId()}.";
+                expectedOperationId = Activity.Current.GetTraceId();
 
                 logger.LogFunctionResult(result);
             }
@@ -213,8 +214,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                 logger.LogTrace("Trace");
                 logger.LogWarning("Warning");
 
-                expectedRequestId = Activity.Current.Id;
-                expectedOperationId = Activity.Current.RootId;
+                expectedRequestId = $"|{Activity.Current.GetTraceId()}.{Activity.Current.GetSpanId()}.";
+                expectedOperationId = Activity.Current.GetTraceId();
             }
 
             Assert.Equal(6, _channel.Telemetries.Count);
@@ -280,8 +281,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             {
                 logger.LogError(0, ex, "Error with customer: {customer}.", "John Doe");
 
-                expectedRequestId = Activity.Current.Id;
-                expectedOperationId = Activity.Current.RootId;
+                expectedRequestId = $"|{Activity.Current.GetTraceId()}.{Activity.Current.GetSpanId()}.";
+                expectedOperationId = Activity.Current.GetTraceId();
             }
 
             void ValidateProperties(ISupportProperties telemetry)
@@ -330,8 +331,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             {
                 logger.LogMetric("CustomMetric", 44.9);
 
-                expectedRequestId = Activity.Current.Id;
-                expectedOperationId = Activity.Current.RootId;
+                expectedRequestId = $"|{Activity.Current.GetTraceId()}.{Activity.Current.GetSpanId()}.";
+                expectedOperationId = Activity.Current.GetTraceId();
             }
 
             var telemetry = _channel.Telemetries.Single() as MetricTelemetry;
@@ -393,8 +394,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             string expectedOperationId, expectedRequestId;
             using (logger.BeginFunctionScope(CreateFunctionInstance(scopeGuid), _hostInstanceId))
             {
-                expectedRequestId = Activity.Current.Id;
-                expectedOperationId = Activity.Current.RootId;
+                expectedRequestId = $"|{Activity.Current.GetTraceId()}.{Activity.Current.GetSpanId()}.";
+                expectedOperationId = Activity.Current.GetTraceId();
 
                 var props = new Dictionary<string, object>
                 {
@@ -452,8 +453,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                 };
                 logger.LogMetric("CustomMetric", 1.1, props);
 
-                expectedRequestId = Activity.Current.Id;
-                expectedOperationId = Activity.Current.RootId;
+                expectedRequestId = $"|{Activity.Current.GetTraceId()}.{Activity.Current.GetSpanId()}.";
+                expectedOperationId = Activity.Current.GetTraceId();
             }
 
             var telemetry = _channel.Telemetries.Single() as MetricTelemetry;
@@ -727,7 +728,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
 
         private ILogger CreateLogger(string category)
         {
-            return new ApplicationInsightsLogger(_client, category);
+            return new ApplicationInsightsLogger(_client, category, new ApplicationInsightsLoggerOptions());
         }
 
         private static void ValidateScope(IDictionary<string, object> expected)

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/FilteringTelemetryProcessorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/FilteringTelemetryProcessorTests.cs
@@ -138,9 +138,15 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
 
         private class TestTelemetry : ISupportProperties, ITelemetry
         {
+            public void SerializeData(ISerializationWriter serializationWriter)
+            {
+                throw new NotImplementedException();
+            }
+
             public DateTimeOffset Timestamp { get; set; }
 
             public TelemetryContext Context { get; } = null;
+            public IExtension Extension { get; set; }
 
             public string Sequence { get; set; }
 

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
@@ -256,7 +256,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             {
                 "ApplicationInsightsLoggerOptions",
                 "ApplicationInsightsLoggerProvider",
-                "ApplicationInsightsLoggingBuilderExtensions"
+                "ApplicationInsightsLoggingBuilderExtensions",
+                "ISdkVersionProvider"
             };
 
             TestHelpers.AssertPublicTypes(expected, assembly);

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.7.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />

--- a/test/Microsoft.Azure.WebJobs.Logging.FunctionalTests/WebJobs.Logging.FunctionalTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Logging.FunctionalTests/WebJobs.Logging.FunctionalTests.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.7.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Moq" Version="4.7.145" />

--- a/test/Microsoft.Azure.Webjobs.Extensions.Storage.UnitTests/WebJobs.Extensions.Storage.UnitTests.csproj
+++ b/test/Microsoft.Azure.Webjobs.Extensions.Storage.UnitTests/WebJobs.Extensions.Storage.UnitTests.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.7.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />


### PR DESCRIPTION
This change brings correlation with upstream services for HttpTrigger.

ApplicationInsights is configured to:
- collect Http requests with extra info like URL and status code
- support W3C distributed tracing protocol 

Related to https://github.com/Azure/azure-functions-host/issues/2447