### PR TITLE
Functions v1: Update ApplicationInsights to 2.6.4 and enable heartbeats

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
+++ b/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
@@ -102,9 +102,8 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Core" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Diagnostics.DiagnosticSource.4.3.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Globalization.Calendars, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Globalization.Calendars.4.3.0\lib\net46\System.Globalization.Calendars.dll</HintPath>

--- a/src/Microsoft.Azure.WebJobs.Host/packages.config
+++ b/src/Microsoft.Azure.WebJobs.Host/packages.config
@@ -18,7 +18,7 @@
   <package id="System.ComponentModel.EventBasedAsync" version="4.3.0" targetFramework="net45" />
   <package id="System.Console" version="4.3.0" targetFramework="net46" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net46" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.3.0" targetFramework="net46" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net46" />
   <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net46" />
   <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net46" />
   <package id="System.Dynamic.Runtime" version="4.3.0" targetFramework="net45" />

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights.NuGet/WebJobs.Logging.ApplicationInsights.nuspec
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights.NuGet/WebJobs.Logging.ApplicationInsights.nuspec
@@ -16,7 +16,7 @@
     <tags>Microsoft Azure WebJobs Jobs Logging Application Insights windowsazureofficial Web</tags>
     <dependencies>
       <dependency id="Microsoft.Azure.WebJobs" version="[$WebJobsPackageVersion$]" />
-      <dependency id="Microsoft.ApplicationInsights.WindowsServer" version="2.4.1" />
+      <dependency id="Microsoft.ApplicationInsights.WindowsServer" version="2.6.4" />
     </dependencies>
   </metadata>
 </package>

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
@@ -52,20 +52,20 @@
     <Reference Include="Microsoft.AI.Agent.Intercept, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.ApplicationInsights.Agent.Intercept.2.4.0\lib\net45\Microsoft.AI.Agent.Intercept.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AI.DependencyCollector, Version=2.4.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.ApplicationInsights.DependencyCollector.2.4.1\lib\net45\Microsoft.AI.DependencyCollector.dll</HintPath>
+    <Reference Include="Microsoft.AI.DependencyCollector, Version=2.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.ApplicationInsights.DependencyCollector.2.6.4\lib\net45\Microsoft.AI.DependencyCollector.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AI.PerfCounterCollector, Version=2.4.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.ApplicationInsights.PerfCounterCollector.2.4.1\lib\net45\Microsoft.AI.PerfCounterCollector.dll</HintPath>
+    <Reference Include="Microsoft.AI.PerfCounterCollector, Version=2.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.ApplicationInsights.PerfCounterCollector.2.6.4\lib\net45\Microsoft.AI.PerfCounterCollector.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AI.ServerTelemetryChannel, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.4.0\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
+    <Reference Include="Microsoft.AI.ServerTelemetryChannel, Version=2.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.6.4\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AI.WindowsServer, Version=2.4.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.ApplicationInsights.WindowsServer.2.4.1\lib\net45\Microsoft.AI.WindowsServer.dll</HintPath>
+    <Reference Include="Microsoft.AI.WindowsServer, Version=2.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.ApplicationInsights.WindowsServer.2.6.4\lib\net45\Microsoft.AI.WindowsServer.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.ApplicationInsights.2.4.0\lib\net46\Microsoft.ApplicationInsights.dll</HintPath>
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.ApplicationInsights.2.6.4\lib\net46\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.Logging.Abstractions.1.1.1\lib\netstandard1.1\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
@@ -125,6 +125,7 @@
       <HintPath>..\..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net46\System.Security.Cryptography.X509Certificates.dll</HintPath>
     </Reference>
     <Reference Include="System.Web" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/app.config
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/app.config
@@ -18,6 +18,14 @@
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/packages.config
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.4.0" targetFramework="net46" />
+  <package id="Microsoft.ApplicationInsights" version="2.6.4" targetFramework="net46" />
   <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.4.0" targetFramework="net46" />
-  <package id="Microsoft.ApplicationInsights.DependencyCollector" version="2.4.1" targetFramework="net46" />
-  <package id="Microsoft.ApplicationInsights.PerfCounterCollector" version="2.4.1" targetFramework="net46" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer" version="2.4.1" targetFramework="net46" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.4.0" targetFramework="net46" />
+  <package id="Microsoft.ApplicationInsights.DependencyCollector" version="2.6.4" targetFramework="net46" />
+  <package id="Microsoft.ApplicationInsights.PerfCounterCollector" version="2.6.4" targetFramework="net46" />
+  <package id="Microsoft.ApplicationInsights.WindowsServer" version="2.6.4" targetFramework="net46" />
+  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.6.4" targetFramework="net46" />
   <package id="Microsoft.Extensions.Logging.Abstractions" version="1.1.1" targetFramework="net46" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net46" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net46" />

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/WebJobs.ServiceBus.csproj
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/WebJobs.ServiceBus.csproj
@@ -112,8 +112,8 @@
       <HintPath>..\..\packages\System.Console.4.3.0\lib\net46\System.Console.dll</HintPath>
     </Reference>
     <Reference Include="System.Core" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Diagnostics.DiagnosticSource.4.3.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Globalization.Calendars, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Globalization.Calendars.4.3.0\lib\net46\System.Globalization.Calendars.dll</HintPath>

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/app.config
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/app.config
@@ -28,7 +28,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/packages.config
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/packages.config
@@ -21,7 +21,7 @@
   <package id="System.ComponentModel.EventBasedAsync" version="4.3.0" targetFramework="net45" />
   <package id="System.Console" version="4.3.0" targetFramework="net46" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net46" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.3.0" targetFramework="net46" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net46" />
   <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net46" />
   <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net46" />
   <package id="System.Dynamic.Runtime" version="4.3.0" targetFramework="net45" />

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/App.config
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/App.config
@@ -47,11 +47,15 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.4.0" newVersion="2.6.4.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/App.config
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/App.config
@@ -47,7 +47,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsightsEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsightsEndToEndTests.cs
@@ -13,6 +13,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility.Implementation;
 using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse;
 using Microsoft.ApplicationInsights.WindowsServer.Channel.Implementation;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
@@ -516,10 +517,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
         private static void ValidateSdkVersion(ITelemetry telemetry)
         {
-            PropertyInfo propInfo = typeof(TelemetryContext).GetProperty("Tags", BindingFlags.NonPublic | BindingFlags.Instance);
-            IDictionary<string, string> tags = propInfo.GetValue(telemetry.Context) as IDictionary<string, string>;
-
-            Assert.StartsWith("webjobs: ", tags["ai.internal.sdkVersion"]);
+            Assert.StartsWith("webjobs: ", telemetry.Context.GetInternalContext().SdkVersion);
         }
 
         private class QuickPulsePayload

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/WebJobs.Host.EndToEndTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/WebJobs.Host.EndToEndTests.csproj
@@ -42,14 +42,14 @@
     <LangVersion>default</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.AI.PerfCounterCollector, Version=2.4.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.ApplicationInsights.PerfCounterCollector.2.4.1\lib\net45\Microsoft.AI.PerfCounterCollector.dll</HintPath>
+    <Reference Include="Microsoft.AI.PerfCounterCollector, Version=2.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.ApplicationInsights.PerfCounterCollector.2.6.4\lib\net45\Microsoft.AI.PerfCounterCollector.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AI.ServerTelemetryChannel, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.4.0\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
+    <Reference Include="Microsoft.AI.ServerTelemetryChannel, Version=2.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.6.4\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.ApplicationInsights.2.4.0\lib\net46\Microsoft.ApplicationInsights.dll</HintPath>
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.ApplicationInsights.2.6.4\lib\net46\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
@@ -170,6 +170,8 @@
       <HintPath>..\..\packages\System.Spatial.5.8.2\lib\net40\System.Spatial.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Web" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml.ReaderWriter, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/packages.config
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.ApplicationInsights" version="2.4.0" targetFramework="net46" />
-  <package id="Microsoft.ApplicationInsights.PerfCounterCollector" version="2.4.1" targetFramework="net46" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.4.0" targetFramework="net46" />
+  <package id="Microsoft.ApplicationInsights" version="2.6.4" targetFramework="net46" />
+  <package id="Microsoft.ApplicationInsights.PerfCounterCollector" version="2.6.4" targetFramework="net46" />
+  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.6.4" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net45" />

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/DefaultTelemetryClientFactoryTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/DefaultTelemetryClientFactoryTests.cs
@@ -11,10 +11,36 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
 {
     public class DefaultTelemetryClientFactoryTests
     {
+        private static readonly string InstrumentationKey = "123";
+
         [Fact]
-        public void InitializeConfiguguration_Configures()
+        public void InitializeConfiguration_Configures()
         {
-            var factory = new DefaultTelemetryClientFactory(string.Empty, null, null);
+            var factory = new DefaultTelemetryClientFactory(InstrumentationKey, null, null);
+            var config = factory.InitializeConfiguration();
+
+            // Verify Initializers
+            Assert.Equal(3, config.TelemetryInitializers.Count);
+
+            Assert.Single(config.TelemetryInitializers.OfType<WebJobsRoleEnvironmentTelemetryInitializer>());
+            Assert.Single(config.TelemetryInitializers.OfType<WebJobsTelemetryInitializer>());
+            Assert.Single(config.TelemetryInitializers.OfType<WebJobsSanitizingInitializer>());
+
+            // Verify Channel
+            Assert.IsType<ServerTelemetryChannel>(config.TelemetryChannel);
+
+            // Verify Active
+            Assert.Equal(config.InstrumentationKey, TelemetryConfiguration.Active.InstrumentationKey);
+
+            Assert.Single(TelemetryConfiguration.Active.TelemetryInitializers
+                .OfType<WebJobsRoleEnvironmentTelemetryInitializer>());
+        }
+
+        [Fact]
+        public void InitializeConfiguration_ConfiguresActiveEvenIfIKeySet()
+        {
+            TelemetryConfiguration.Active.InstrumentationKey = InstrumentationKey;
+            var factory = new DefaultTelemetryClientFactory(InstrumentationKey, null, null);
             var config = factory.InitializeConfiguration();
 
             // Verify Initializers

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/DefaultTelemetryClientFactoryTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/DefaultTelemetryClientFactoryTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Linq;
+using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
 using Microsoft.Azure.WebJobs.Logging.ApplicationInsights;
 using Xunit;
@@ -18,13 +19,19 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
 
             // Verify Initializers
             Assert.Equal(3, config.TelemetryInitializers.Count);
-            // These will throw if there are not exactly one
-            config.TelemetryInitializers.OfType<WebJobsRoleEnvironmentTelemetryInitializer>().Single();
-            config.TelemetryInitializers.OfType<WebJobsTelemetryInitializer>().Single();
-            config.TelemetryInitializers.OfType<WebJobsSanitizingInitializer>().Single();
+
+            Assert.Single(config.TelemetryInitializers.OfType<WebJobsRoleEnvironmentTelemetryInitializer>());
+            Assert.Single(config.TelemetryInitializers.OfType<WebJobsTelemetryInitializer>());
+            Assert.Single(config.TelemetryInitializers.OfType<WebJobsSanitizingInitializer>());
 
             // Verify Channel
             Assert.IsType<ServerTelemetryChannel>(config.TelemetryChannel);
+
+            // Verify Active
+            Assert.Equal(config.InstrumentationKey, TelemetryConfiguration.Active.InstrumentationKey);
+
+            Assert.Single(TelemetryConfiguration.Active.TelemetryInitializers
+                .OfType<WebJobsRoleEnvironmentTelemetryInitializer>());
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/FilteringTelemetryProcessorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/FilteringTelemetryProcessorTests.cs
@@ -138,6 +138,11 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
 
         private class TestTelemetry : ISupportProperties, ITelemetry
         {
+            public ITelemetry DeepClone()
+            {
+                throw new NotImplementedException();
+            }
+
             public DateTimeOffset Timestamp { get; set; }
 
             public TelemetryContext Context { get; } = null;

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
@@ -58,20 +58,20 @@
     <Reference Include="Microsoft.AI.Agent.Intercept, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.ApplicationInsights.Agent.Intercept.2.4.0\lib\net45\Microsoft.AI.Agent.Intercept.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AI.DependencyCollector, Version=2.4.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.ApplicationInsights.DependencyCollector.2.4.1\lib\net45\Microsoft.AI.DependencyCollector.dll</HintPath>
+    <Reference Include="Microsoft.AI.DependencyCollector, Version=2.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.ApplicationInsights.DependencyCollector.2.6.4\lib\net45\Microsoft.AI.DependencyCollector.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AI.PerfCounterCollector, Version=2.4.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.ApplicationInsights.PerfCounterCollector.2.4.1\lib\net45\Microsoft.AI.PerfCounterCollector.dll</HintPath>
+    <Reference Include="Microsoft.AI.PerfCounterCollector, Version=2.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.ApplicationInsights.PerfCounterCollector.2.6.4\lib\net45\Microsoft.AI.PerfCounterCollector.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AI.ServerTelemetryChannel, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.4.0\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
+    <Reference Include="Microsoft.AI.ServerTelemetryChannel, Version=2.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.6.4\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AI.WindowsServer, Version=2.4.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.ApplicationInsights.WindowsServer.2.4.1\lib\net45\Microsoft.AI.WindowsServer.dll</HintPath>
+    <Reference Include="Microsoft.AI.WindowsServer, Version=2.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.ApplicationInsights.WindowsServer.2.6.4\lib\net45\Microsoft.AI.WindowsServer.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.ApplicationInsights.2.4.0\lib\net46\Microsoft.ApplicationInsights.dll</HintPath>
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.ApplicationInsights.2.6.4\lib\net46\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
@@ -194,6 +194,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml.ReaderWriter, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/app.config
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/app.config
@@ -38,7 +38,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/app.config
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/app.config
@@ -38,7 +38,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/packages.config
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
-  <package id="Microsoft.ApplicationInsights" version="2.4.0" targetFramework="net46" />
+  <package id="Microsoft.ApplicationInsights" version="2.6.4" targetFramework="net46" />
   <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.4.0" targetFramework="net46" />
-  <package id="Microsoft.ApplicationInsights.DependencyCollector" version="2.4.1" targetFramework="net46" />
-  <package id="Microsoft.ApplicationInsights.PerfCounterCollector" version="2.4.1" targetFramework="net46" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer" version="2.4.1" targetFramework="net46" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.4.0" targetFramework="net46" />
+  <package id="Microsoft.ApplicationInsights.DependencyCollector" version="2.6.4" targetFramework="net46" />
+  <package id="Microsoft.ApplicationInsights.PerfCounterCollector" version="2.6.4" targetFramework="net46" />
+  <package id="Microsoft.ApplicationInsights.WindowsServer" version="2.6.4" targetFramework="net46" />
+  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.6.4" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net45" />

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/WebJobs.ServiceBus.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/WebJobs.ServiceBus.UnitTests.csproj
@@ -116,8 +116,8 @@
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.Data" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Diagnostics.DiagnosticSource.4.3.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Globalization.Calendars, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Globalization.Calendars.4.3.0\lib\net46\System.Globalization.Calendars.dll</HintPath>

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/app.config
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/app.config
@@ -35,7 +35,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/packages.config
+++ b/test/Microsoft.Azure.WebJobs.ServiceBus.UnitTests/packages.config
@@ -22,7 +22,7 @@
   <package id="System.ComponentModel.EventBasedAsync" version="4.3.0" targetFramework="net45" />
   <package id="System.Console" version="4.3.0" targetFramework="net46" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net46" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.3.0" targetFramework="net46" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net46" />
   <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net46" />
   <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net46" />
   <package id="System.Dynamic.Runtime" version="4.3.0" targetFramework="net45" />


### PR DESCRIPTION
This change enables ApplicaitonInsights heartbeats.

It requires ApplicaitonInsights SDK update

AI is updated to 2.6.4 (minimum suitable version)
DiagnosticSource is consolidated across projects to 4.4.0 (this version is enforced by AI)

@brettsam please review
