### PR TITLE
Fixing memory leaks

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostContext.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostContext.cs
@@ -96,6 +96,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             if (!_disposed)
             {
                 _listener.Dispose();
+                (_functionEventCollector as IDisposable)?.Dispose();
 
                 _disposed = true;
             }

--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/Aggregator/FunctionResultAggregator.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/Aggregator/FunctionResultAggregator.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Azure.WebJobs.Logging
 
         private Timer _windowTimer;
         private IDisposable[] _disposables;
+        private bool _disposed = false;
 
         public FunctionResultAggregator(int batchSize, TimeSpan batchTimeout, ILoggerFactory loggerFactory)
         {
@@ -129,19 +130,24 @@ namespace Microsoft.Azure.WebJobs.Logging
 
         public void Dispose()
         {
-            if (_disposables != null)
+            if (!_disposed)
             {
-                foreach (var d in _disposables)
+                if (_disposables != null)
                 {
-                    d.Dispose();
+                    foreach (var d in _disposables)
+                    {
+                        d.Dispose();
+                    }
+                    _disposables = null;
                 }
-                _disposables = null;
-            }
 
-            if (_windowTimer != null)
-            {
-                _windowTimer.Dispose();
-                _windowTimer = null;
+                if (_windowTimer != null)
+                {
+                    _windowTimer.Dispose();
+                    _windowTimer = null;
+                }
+
+                _disposed = true;
             }
         }
     }

--- a/src/Microsoft.Azure.WebJobs.Host/Queues/Listeners/SharedQueueWatcher.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Queues/Listeners/SharedQueueWatcher.cs
@@ -2,21 +2,31 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace Microsoft.Azure.WebJobs.Host.Queues.Listeners
 {
     internal class SharedQueueWatcher : IMessageEnqueuedWatcher
     {
-        private readonly ConcurrentDictionary<string, ConcurrentBag<INotificationCommand>> _registrations =
-            new ConcurrentDictionary<string, ConcurrentBag<INotificationCommand>>();
+        private readonly object _lock = new object();
+
+        private readonly ConcurrentDictionary<string, ICollection<INotificationCommand>> _registrations =
+            new ConcurrentDictionary<string, ICollection<INotificationCommand>>();
 
         public void Notify(string enqueuedInQueueName)
         {
-            ConcurrentBag<INotificationCommand> queueRegistrations;
-
-            if (_registrations.TryGetValue(enqueuedInQueueName, out queueRegistrations))
+            if (_registrations.TryGetValue(enqueuedInQueueName, out ICollection<INotificationCommand> queueRegistrations))
             {
-                foreach (INotificationCommand registration in queueRegistrations.ToArray())
+                INotificationCommand[] registrations;
+
+                lock (_lock)
+                {
+                    registrations = queueRegistrations.ToArray();
+                }
+
+                foreach (INotificationCommand registration in registrations)
                 {
                     registration.Notify();
                 }
@@ -26,8 +36,16 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Listeners
         public void Register(string queueName, INotificationCommand notification)
         {
             _registrations.AddOrUpdate(queueName,
-                new ConcurrentBag<INotificationCommand>(new INotificationCommand[] { notification }),
-                (i, existing) => { existing.Add(notification); return existing; });
+                new Collection<INotificationCommand> { notification },
+                (i, existing) =>
+                {
+                    lock (_lock)
+                    {
+                        existing.Add(notification);
+                    }
+
+                    return existing;
+                });
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubConfiguration.cs
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus/EventHubs/EventHubConfiguration.cs
@@ -445,12 +445,12 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
                 .AddConverter<EventData, byte[]>(ConvertEventData2Bytes);
 
             // register the background exception handler
-            MessagingExceptionHandler.Subscribe(_options, context.Trace, context.Config.LoggerFactory);
+            var exceptionHandler = MessagingExceptionHandler.Subscribe(_options, context.Trace, context.Config.LoggerFactory);
 
             // register our trigger binding provider
             INameResolver nameResolver = context.Config.NameResolver;
             IConverterManager cm = context.Config.GetService<IConverterManager>();
-            var triggerBindingProvider = new EventHubTriggerAttributeBindingProvider(nameResolver, cm, this);
+            var triggerBindingProvider = new EventHubTriggerAttributeBindingProvider(nameResolver, cm, this, exceptionHandler);
             context.AddBindingRule<EventHubTriggerAttribute>()
                 .BindToTrigger(triggerBindingProvider);
 

--- a/src/Packages/Packages.csproj
+++ b/src/Packages/Packages.csproj
@@ -66,7 +66,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/CompositeFunctionEventCollectorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/CompositeFunctionEventCollectorTests.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Azure.WebJobs.Host.Loggers;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
+{
+    public class CompositeFunctionEventCollectorTests
+    {
+        [Fact]
+        public void Dispose_Disposes()
+        {
+            // Test a couple collectors that implement IDisposable, and a couple that don't.
+            var collection = new Collection<IAsyncCollector<FunctionInstanceLogEntry>>();
+
+            var mockDisposable1 = new Mock<IDisposable>(MockBehavior.Strict);
+            mockDisposable1.Setup(p => p.Dispose());
+            collection.Add(mockDisposable1.As<IAsyncCollector<FunctionInstanceLogEntry>>().Object);
+
+            var mockDisposable2 = new Mock<IDisposable>(MockBehavior.Strict);
+            mockDisposable2.Setup(p => p.Dispose());
+            collection.Add(mockDisposable2.As<IAsyncCollector<FunctionInstanceLogEntry>>().Object);
+
+            collection.Add(new Mock<IAsyncCollector<FunctionInstanceLogEntry>>(MockBehavior.Strict).Object);
+            collection.Add(new Mock<IAsyncCollector<FunctionInstanceLogEntry>>(MockBehavior.Strict).Object);
+
+            var collector = new CompositeFunctionEventCollector(collection.ToArray());
+            collector.Dispose();
+
+            mockDisposable1.Verify(p => p.Dispose(), Times.Once);
+            mockDisposable2.Verify(p => p.Dispose(), Times.Once);
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
@@ -257,6 +257,7 @@
     <Compile Include="Blobs\CompletedAsyncResult.cs" />
     <Compile Include="Blobs\WatchableReadStreamTests.cs" />
     <Compile Include="Common\BindingPathAttribute.cs" />
+    <Compile Include="Executors\CompositeFunctionEventCollectorTests.cs" />
     <Compile Include="Filters\FunctionFilterTests.cs" />
     <Compile Include="Executors\TriggeredFunctionExecutorTests.cs" />
     <Compile Include="ExtensionConfigContextTests.cs" />


### PR DESCRIPTION
Should fix https://github.com/Azure/azure-functions-host/issues/2907. There's 3 issues being fixed here:

#### Disposing of aggregator
We were never disposing the Aggregator, which uses a timer with a callback to itself. It implemented IDisposable, but we never called it.

#### Removing ConcurrentBag usage
ConcurrentBag stores objects in ThreadLocal storage to highly optimize for same thread read/writes. That’s interesting, but doesn’t explain why the objects are not getting collected.

So now I’m suspecting that we’re hitting this -- https://github.com/dotnet/corefx/issues/23068 (the issue is in the .NET Core repo, but I’d expect that the behavior is the same in full framework). Our object graphs in these bags is huge due to the captured ScriptHost. So I’m pretty certain we’ve got a circular reference in there that’s preventing these objects from getting cleaned up.

I switched the two places we used ConcurrentBag to use ICollections (with simple locking) and the leak went away. At first I implemented IDisposable and made sure we were clearing the dictionaries, which also worked, but finding the right way to dispose of the SharedQueueWatcher was… challenging in v1. I think removing ConcurrentBag altogether will work fine for us. It looks like we can also swap to ConcurrentQueue, which does not use ThreadLocal storage.

#### EventHub ExceptionReceived
We’re not unsubscribing from EventHub’s ExceptionReceived event.
