### PR TITLE
Removing obsolete QueuesOptions.MaxPollingInterval TimeSpanConverter

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Queues/Config/QueuesOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Queues/Config/QueuesOptions.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Globalization;
 using Microsoft.Azure.WebJobs.Host.Queues.Listeners;
-using Newtonsoft.Json;
 
 namespace Microsoft.Azure.WebJobs.Host
 {
@@ -87,7 +86,6 @@ namespace Microsoft.Azure.WebJobs.Host
         /// Gets or sets the longest period of time to wait before checking for a message to arrive when a queue remains
         /// empty.
         /// </summary>
-        [JsonConverter(typeof(MillisecondTimeSpanConverter))]
         public TimeSpan MaxPollingInterval
         {
             get { return _maxPollingInterval; }
@@ -148,48 +146,6 @@ namespace Microsoft.Azure.WebJobs.Host
             set
             {
                 _visibilityTimeout = value;
-            }
-        }
-
-        /// <summary>
-        /// Converter used to allow a TimeSpan property to be specified either
-        /// as a TimeSpan string or as milliseconds.
-        /// </summary>
-        private class MillisecondTimeSpanConverter : JsonConverter
-        {
-            public override bool CanConvert(Type objectType)
-            {
-                return objectType == typeof(string) || objectType == typeof(int);
-            }
-
-            public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-            {
-                if (reader == null)
-                {
-                    throw new ArgumentNullException(nameof(reader));
-                }
-
-                if (reader.TokenType == JsonToken.String)
-                {
-                    return TimeSpan.Parse((string)reader.Value);
-                }
-                else if (reader.TokenType == JsonToken.Integer)
-                {
-                    return TimeSpan.FromMilliseconds(Convert.ToInt32(reader.Value));
-                }
-                else
-                {
-                    return existingValue;
-                }
-            }
-
-            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-            {
-                if (serializer == null)
-                {
-                    throw new ArgumentNullException(nameof(serializer));
-                }
-                serializer.Serialize(writer, value);
             }
         }
     }

--- a/test/Microsoft.Azure.Webjobs.Extensions.Storage.UnitTests/Queues/QueuesOptionsTests.cs
+++ b/test/Microsoft.Azure.Webjobs.Extensions.Storage.UnitTests/Queues/QueuesOptionsTests.cs
@@ -62,19 +62,10 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         {
             var jo = new JObject
             {
-                { "MaxPollingInterval", 5000 }
+                { "MaxPollingInterval", "00:00:05" }
             };
             var options = jo.ToObject<QueuesOptions>();
             Assert.Equal(TimeSpan.FromMilliseconds(5000), options.MaxPollingInterval);
-            string json = JsonConvert.SerializeObject(options);
-
-            jo = new JObject
-            {
-                { "MaxPollingInterval", "00:00:05" }
-            };
-            options = jo.ToObject<QueuesOptions>();
-            Assert.Equal(TimeSpan.FromMilliseconds(5000), options.MaxPollingInterval);
-            json = JsonConvert.SerializeObject(options);
         }
     }
 }


### PR DESCRIPTION
We had this converter in v2 which worked for Functions because we were serializing/deserializing host.json and applying configuration ourselves.

In v3 we've moved to the .NET Core configuration system and those values do not go through normal serialization paths and do not invoke JSON.NET converters. So in v3 there was an inadvertent change to no longer support millisecond conversions to TimeSpan. In v3 QueuesOptions.MaxPollingInterval must be specified as a TimeSpan in json.