### PR TITLE
Fix broken test

### DIFF
--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/HttpDependencyCollectionTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/HttpDependencyCollectionTests.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
 
             Assert.Equal("Http", dependency.Type);
             Assert.Equal("www.microsoft.com", dependency.Target);
-            Assert.Equal("https://www.microsoft.com", dependency.Data);
+            Assert.Equal("https://www.microsoft.com/", dependency.Data);
             Assert.Equal("GET /", dependency.Name);
         }
 


### PR DESCRIPTION
UserCodeHttpCallsAreReported was broken because of a missing '/' in a expected result.
What I could identify I how how actual result is build. So, I am not sure if this is an issue of an outdated test or a wrong result.