### PR TITLE
Fixing Package metadata

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Core.NuGet/WebJobs.Core.nuspec
+++ b/src/Microsoft.Azure.WebJobs.Core.NuGet/WebJobs.Core.nuspec
@@ -5,7 +5,7 @@
     <title>Microsoft.Azure.WebJobs.Core</title>
     <version>$NuGetPackageVersion$</version>
     <authors>Microsoft</authors>
-    <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <summary>Microsoft.Azure.WebJobs is a library for writing WebJobs in Microsoft Azure. This package contains the runtime assemblies for Microsoft.Azure.WebJobs.</summary>
     <description>This library simplifies the task of adding background processing to your Microsoft Azure Web Sites. The SDK uses Microsoft Azure Storage, triggering a function in your program when items are added to Queues and Blobs. A dashboard provides rich monitoring and diagnostics for the programs that you write by using the SDK. For more information, please visit http://go.microsoft.com/fwlink/?LinkID=320971</description>
     <releaseNotes>Release Notes: https://github.com/Azure/azure-webjobs-sdk/releases</releaseNotes>

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights.NuGet/WebJobs.Logging.ApplicationInsights.nuspec
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights.NuGet/WebJobs.Logging.ApplicationInsights.nuspec
@@ -5,7 +5,7 @@
     <title>Microsoft.Azure.WebJobs.Logging.ApplicationInsights</title>
     <version>$NuGetPackageVersion$</version>
     <authors>Microsoft</authors>
-    <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <summary>Microsoft.Azure.WebJobs.Logging.ApplicationInsights is a library for writing WebJobs logs with ILogger and Application Insights.</summary>
     <description>This package contains the runtime assemblies for Microsoft.Azure.WebJobs.Logging.ApplicationInsights. For more information, please visit http://go.microsoft.com/fwlink/?LinkID=320971</description>
     <releaseNotes>Release Notes: https://github.com/Azure/azure-webjobs-sdk/releases</releaseNotes>

--- a/src/Microsoft.Azure.WebJobs.Logging.NuGet/WebJobs.Logging.nuspec
+++ b/src/Microsoft.Azure.WebJobs.Logging.NuGet/WebJobs.Logging.nuspec
@@ -5,7 +5,7 @@
     <title>Microsoft.Azure.WebJobs.Logging</title>
     <version>$NuGetPackageVersion$</version>
     <authors>Microsoft</authors>
-    <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <summary>Microsoft.Azure.WebJobs.Logging is a library for writing Microsoft Azure WebJobs Logs.</summary>
     <description>This package contains the runtime assemblies for Microsoft.Azure.WebJobs.Logging. For more information, please visit http://go.microsoft.com/fwlink/?LinkID=320971</description>
     <releaseNotes>Release Notes: https://github.com/Azure/azure-webjobs-sdk/releases</releaseNotes>

--- a/src/Microsoft.Azure.WebJobs.NuGet/WebJobs.nuspec
+++ b/src/Microsoft.Azure.WebJobs.NuGet/WebJobs.nuspec
@@ -5,7 +5,7 @@
     <title>Microsoft.Azure.WebJobs</title>
     <version>$NuGetPackageVersion$</version>
     <authors>Microsoft</authors>
-    <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <summary>Microsoft.Azure.WebJobs.Host is a library for writing WebJobs in Microsoft Azure. The host is a container where all the functions in your program can execute. This package contains the runtime assemblies for Microsoft.Azure.WebJobs.Host.</summary>
     <description>This package contains the runtime assemblies for Microsoft.Azure.WebJobs.Host. It also adds rich diagnostics capabilities which makes it easier to monitor the WebJobs in the dashboard. For more information, please visit http://go.microsoft.com/fwlink/?LinkID=320971</description>
     <releaseNotes>Release Notes: https://github.com/Azure/azure-webjobs-sdk/releases</releaseNotes>

--- a/src/Microsoft.Azure.WebJobs.ServiceBus.NuGet/WebJobs.ServiceBus.nuspec
+++ b/src/Microsoft.Azure.WebJobs.ServiceBus.NuGet/WebJobs.ServiceBus.nuspec
@@ -5,7 +5,7 @@
     <title>Microsoft.Azure.WebJobs.ServiceBus</title>
     <version>$NuGetPackageVersion$</version>
     <authors>Microsoft</authors>
-    <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <summary>Microsoft.Azure.WebJobs.ServiceBus is a library for writing Microsoft Azure WebJobs using Service Bus. This package contains the runtime assemblies for Microsoft.Azure.WebJobs.ServiceBus.</summary>
     <description>This package contains the runtime assemblies for Microsoft.Azure.WebJobs.ServiceBus. For more information, please visit http://go.microsoft.com/fwlink/?LinkID=320971</description>
     <releaseNotes>Release Notes: https://github.com/Azure/azure-webjobs-sdk/releases</releaseNotes>

--- a/tools/NuGetProj.settings.targets
+++ b/tools/NuGetProj.settings.targets
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <WebJobsRootPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\'))</WebJobsRootPath>
     <WebJobsToolsPath>$(MSBuildThisFileDirectory)</WebJobsToolsPath>
-    <WebJobsPackageEULA>http://www.microsoft.com/web/webpi/eula/aspnetcomponent_rtw_enu.htm</WebJobsPackageEULA>
+    <WebJobsPackageEULA>https://go.microsoft.com/fwlink/?linkid=2028464</WebJobsPackageEULA>
     <Version>2.3.0</Version>
     <PrereleaseTag>-beta1</PrereleaseTag>
     


### PR DESCRIPTION
Fixes required to conform to new rules [here](https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki?wikiVersion=GBwikiMaster&pagePath=%2FProduct%20Development%20Reference%2FNuGet%2FPublishing%20a%20NuGet%20package&anchor=troubleshooting-package-publishing-errors). We've already made these changes for v3.