### PR TITLE
Update CloudBlobClientComparer.cs

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Listeners/CloudBlobClientComparer.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Listeners/CloudBlobClientComparer.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
                 throw new ArgumentNullException("y");
             }
 
-            return x.Credentials.AccountName == y.Credentials.AccountName;
+            return x.BaseUri == y.BaseUri;
         }
 
         public int GetHashCode(CloudBlobClient obj)
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
                 throw new ArgumentNullException("obj");
             }
 
-            return obj.Credentials.AccountName.GetHashCode();
+            return obj.BaseUri.GetHashCode();
         }
     }
 }


### PR DESCRIPTION
Credentials don't always have the account name.  There are 3 credential types; key, SAS, and token.  All 3 types have a base URI, which is also unique.  I think this will allow SAS style connection strings.