### PR TITLE
fixing issues with auto-tracking of Http and Service Bus triggers

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -32,13 +32,13 @@ foreach ($project in $projects)
   {
     $cmd += "--version-suffix", "-$packageSuffix"
   }
-  
+  WRITE-HOST "dotnet $cmd"
   & dotnet $cmd  
 }
 
 ### Sign package if build is not a PR
 $isPr = Test-Path env:APPVEYOR_PULL_REQUEST_NUMBER
-if (-not $isPr) {
+if (-not $isPr -and -not $isLocal) {
   & ".\tools\RunSigningJob.ps1" 
   if (-not $?) { exit 1 }
 }

--- a/sample/SampleHost/SampleHost.csproj
+++ b/sample/SampleHost/SampleHost.csproj
@@ -30,6 +30,12 @@
     <ProjectReference Include="..\..\src\Microsoft.Azure.WebJobs.Logging.ApplicationInsights\WebJobs.Logging.ApplicationInsights.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Azure.WebJobs.Extensions.ServiceBus\WebJobs.Extensions.ServiceBus.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
   
 
 </Project>

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
@@ -370,7 +370,6 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                     switch (prop.Key)
                     {
                         case LogConstants.StartTimeKey:
-                        case LogConstants.SucceededKey:
                         case LogConstants.EndTimeKey:
                             // These values are set by the calls to Start/Stop the telemetry. Other
                             // Loggers may want them, but we'll ignore.

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Processors/OperationFilteringTelemetryProcessor.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Processors/OperationFilteringTelemetryProcessor.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.Extensibility.Implementation;
 
@@ -9,7 +10,9 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
 {
     internal class OperationFilteringTelemetryProcessor : ITelemetryProcessor
     {
+        private const string ProcessedKey = "Processed";
         private readonly ITelemetryProcessor _next;
+        private static object _lock = new object();
 
         public OperationFilteringTelemetryProcessor(ITelemetryProcessor next)
         {
@@ -18,6 +21,22 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
 
         public void Process(ITelemetry item)
         {
+            // There are scenarios in Functions where we can have two TelemetryClients running for a short period.
+            // We use this property to ensure we only send one of the RequestTelemetry objects (auto-tracked by App 
+            // Insights) to the server.
+            if (item is RequestTelemetry request)
+            {
+                lock (_lock)
+                {
+                    if (request.Properties.ContainsKey(ProcessedKey))
+                    {
+                        return;
+                    }
+
+                    request.Properties[ProcessedKey] = "1";
+                }
+            }
+
             // WebJobs host does many internal calls, polling queues and blobs, etc...
             // we do not want to report all of them by default, but only those which are relevant for
             // function execution: bindings and user code (which have category and level stamped on the telemetry).

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/ServiceBusRequestAndDependencyCollectionTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/ServiceBusRequestAndDependencyCollectionTests.cs
@@ -45,16 +45,19 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
             _endpoint = connStringBuilder.Endpoint;
         }
 
-        [Fact]
-        public async Task ServiceBusDepenedenciesAndRequestAreTracked()
+        [Theory]
+        [InlineData("message", true)]
+        [InlineData("throw", false)]
+        public async Task ServiceBusDepenedenciesAndRequestAreTracked(string message, bool success)
         {
             using (var host = ConfigureHost())
             {
                 await host.StartAsync();
-                await host.GetJobHost()
-                    .CallAsync(typeof(ServiceBusRequestAndDependencyCollectionTests).GetMethod(nameof(ServiceBusOut)), new { input = "message" });
 
+                await host.GetJobHost()
+                    .CallAsync(typeof(ServiceBusRequestAndDependencyCollectionTests).GetMethod(nameof(ServiceBusOut)), new { input = message });
                 _functionWaitHandle.WaitOne();
+
                 await Task.Delay(1000);
 
                 await host.StopAsync();
@@ -64,12 +67,15 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
             List<DependencyTelemetry> dependencies = _channel.Telemetries.OfType<DependencyTelemetry>().ToList();
 
             Assert.Equal(2, requests.Count);
-            Assert.Single(dependencies);
 
-            Assert.Single(requests.Where(r => r.Name == nameof(ServiceBusTrigger)));
+            // One dependency for the 'Send' from ServiceBusOut
+            // One dependency for the 'Complete' call in ServiceBusTrigger
+            Assert.Equal(2, dependencies.Count);
+            var sbOutDependency = dependencies.Single(d => d.Name == "Send");
+            Assert.Single(dependencies, d => d.Name == "Complete");
+
             var sbTriggerRequest = requests.Single(r => r.Name == nameof(ServiceBusTrigger));
             var manualCallRequest = requests.Single(r => r.Name == nameof(ServiceBusOut));
-            var sbOutDependency = dependencies.Single();
 
             string manualOperationId = manualCallRequest.Context.Operation.Id;
             string triggerOperationId = sbTriggerRequest.Context.Operation.Id;
@@ -86,7 +92,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
             Assert.Equal(manualCallLegacyRootId, triggerCallLegacyRootId);
 
             ValidateServiceBusDependency(sbOutDependency, _endpoint, _queueName, "Send", nameof(ServiceBusOut), manualOperationId, manualCallRequest.Id);
-            ValidateServiceBusRequest(sbTriggerRequest, _endpoint, _queueName, nameof(ServiceBusTrigger), triggerOperationId, dependencyLegacyId);
+            ValidateServiceBusRequest(sbTriggerRequest, success, _endpoint, _queueName, nameof(ServiceBusTrigger), triggerOperationId, dependencyLegacyId);
         }
 
         [Fact]
@@ -109,11 +115,14 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
             List<DependencyTelemetry> dependencies = _channel.Telemetries.OfType<DependencyTelemetry>().ToList();
 
             Assert.Single(requests);
-            Assert.Empty(dependencies);
+            
+            // The call to Complete the message registers as a dependency
+            Assert.Single(dependencies);
+            Assert.Equal("Complete", dependencies.Single().Name);
 
             Assert.NotNull(requests.Single().Context.Operation.Id);
 
-            ValidateServiceBusRequest(requests.Single(), _endpoint, _queueName, nameof(ServiceBusTrigger), null, null);
+            ValidateServiceBusRequest(requests.Single(), true, _endpoint, _queueName, nameof(ServiceBusTrigger), null, null);
         }
 
         [NoAutomaticTrigger]
@@ -125,16 +134,31 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
             message = input;
         }
 
-        public static void ServiceBusTrigger(
+        public static async Task ServiceBusTrigger(
             [ServiceBusTrigger(_queueName)] string message,
+            MessageReceiver messageReceiver,
+            string lockToken,
             TextWriter logger)
         {
-            logger.WriteLine($"C# script processed queue message: '{message}'");
-            _functionWaitHandle.Set();
+            try
+            {
+                logger.WriteLine($"C# script processed queue message: '{message}'");
+
+                if (message == "throw")
+                {
+                    throw new InvalidOperationException("boom!");
+                }
+            }
+            finally
+            {
+                await messageReceiver.CompleteAsync(lockToken);
+                _functionWaitHandle.Set();
+            }
         }
 
         private void ValidateServiceBusRequest(
             RequestTelemetry request,
+            bool success,
             string endpoint,
             string queueName,
             string operationName,
@@ -149,7 +173,10 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
             Assert.True(double.TryParse(request.Properties[LogConstants.FunctionExecutionTimeKey], out double functionDuration));
             Assert.True(request.Duration.TotalMilliseconds >= functionDuration);
 
-            TelemetryValidationHelpers.ValidateRequest(request, operationName, operationId, parentId, LogCategories.Results);
+            Assert.DoesNotContain(request.Properties, p => p.Key == LogConstants.HttpMethodKey);
+
+            TelemetryValidationHelpers.ValidateRequest(request, operationName, operationId, parentId, LogCategories.Results,
+                success ? LogLevel.Information : LogLevel.Error, success);
         }
 
         private void ValidateServiceBusDependency(
@@ -175,7 +202,12 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
                 .ConfigureDefaultTestHost<ServiceBusRequestAndDependencyCollectionTests>(b =>
                 {
                     b.AddAzureStorage();
-                    b.AddServiceBus();
+                    b.AddServiceBus(o =>
+                    {
+                        // We'll complete these ourselves as we don't
+                        // want failures constantly retrying.
+                        o.MessageHandlerOptions.AutoComplete = false;
+                    });
                 })
                 .ConfigureLogging(b =>
                 {

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/TelemetryValidationHelpers.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/TelemetryValidationHelpers.cs
@@ -48,7 +48,11 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
             string operationId,
             string parentId,
             string category,
-            LogLevel logLevel = LogLevel.Information)
+            LogLevel logLevel = LogLevel.Information,
+            bool success = true,
+            string statusCode = "0",
+            string httpMethod = null)
+
         {
             Assert.Equal(category, request.Properties[LogConstants.CategoryNameKey]);
             Assert.Equal(logLevel.ToString(), request.Properties[LogConstants.LogLevelKey]);
@@ -68,6 +72,20 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
             Assert.True(request.Properties.ContainsKey(LogConstants.InvocationIdKey));
             Assert.True(request.Properties.ContainsKey(LogConstants.TriggerReasonKey));
             Assert.StartsWith("webjobs:", request.Context.GetInternalContext().SdkVersion);
+
+            Assert.Equal(success, request.Success);
+            Assert.Equal(statusCode, request.ResponseCode);
+
+            Assert.DoesNotContain(request.Properties, p => p.Key == LogConstants.SucceededKey);
+
+            if (httpMethod != null)
+            {
+                Assert.Equal(httpMethod, request.Properties[LogConstants.HttpMethodKey]);
+            }
+            else
+            {
+                Assert.DoesNotContain(request.Properties, p => p.Key == LogConstants.HttpMethodKey);
+            }
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/WebJobsSanitizingInitializerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/WebJobsSanitizingInitializerTests.cs
@@ -33,6 +33,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             telemetry.Properties.Add("6", AssemblyLoadError);
             telemetry.Properties.Add("7", TestStrigWithAllowedTokenAndSecretToken);
 
+            // Run it through twice to ensure idempotency
+            initializer.Initialize(telemetry);
             initializer.Initialize(telemetry);
 
             Assert.Equal(telemetry.Properties["1"], SecretReplacement);
@@ -56,6 +58,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
 
             var telemetry = new TraceTelemetry(StorageString);
 
+            // Run it through twice to ensure idempotency
+            initializer.Initialize(telemetry);
             initializer.Initialize(telemetry);
 
             // Just test a simple scenario; the SanitizerTests validate others

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/WebJobsTelemetryInitializerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/WebJobsTelemetryInitializerTests.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.Azure.WebJobs.Logging;
+using Microsoft.Azure.WebJobs.Logging.ApplicationInsights;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
+{
+    public class WebJobsTelemetryInitializerTests
+    {
+        // App Insights performs auto-tracking by watching DiagnosticSources 
+        // from the .NET Framework. During host restarts in Functions, it's 
+        // possible that we have two TelemetryClients running simultaneously in
+        // the same process (one stopping; one starting). This means the same 
+        // Telemetry may go through the initializer twice. These tests verify
+        // the trickier scenarios.
+
+        [Fact]
+        public void Initializer_IsIdempotent_HttpRequest()
+        {
+            string functionName = "MyFunction";
+            string status = "409";
+            Uri uri = new Uri("http://localhost/api/somemethod?secret=secret");
+
+            // Simulate an HttpRequest
+            var request = new RequestTelemetry
+            {
+                Url = uri,
+                ResponseCode = status,
+                Name = "POST api/somemethod",
+            };
+
+            request.Properties[LogConstants.NameKey] = functionName;
+            request.Properties[LogConstants.SucceededKey] = "true";
+
+            var initializer = new WebJobsTelemetryInitializer(new WebJobsSdkVersionProvider());
+
+            initializer.Initialize(request);
+            initializer.Initialize(request);
+
+            Assert.Equal(functionName, request.Name);
+            Assert.Equal(status, request.ResponseCode);
+            Assert.Equal(true, request.Success);
+            Assert.Equal(uri.GetLeftPart(UriPartial.Path), request.Url.ToString());
+            Assert.Equal("POST", request.Properties[LogConstants.HttpMethodKey]);
+            Assert.DoesNotContain(request.Properties, p => p.Key == LogConstants.SucceededKey);
+        }
+
+        [Fact]
+        public void Initializer_IsIdempotent_ServiceBusRequest()
+        {
+            string functionName = "MyFunction";
+
+            // Simulate an HttpRequest
+            var request = new RequestTelemetry
+            {
+                ResponseCode = string.Empty,
+                Name = "",
+            };
+
+            request.Properties[LogConstants.NameKey] = functionName;
+            request.Properties[LogConstants.SucceededKey] = "true";
+
+            var initializer = new WebJobsTelemetryInitializer(new WebJobsSdkVersionProvider());
+
+            initializer.Initialize(request);
+            initializer.Initialize(request);
+
+            Assert.Equal(functionName, request.Name);
+            Assert.Equal("0", request.ResponseCode);
+            Assert.Equal(true, request.Success);
+            Assert.Null(request.Url);
+            Assert.DoesNotContain(request.Properties, p => p.Key == LogConstants.HttpMethodKey);
+            Assert.DoesNotContain(request.Properties, p => p.Key == LogConstants.SucceededKey);
+        }
+    }
+}


### PR DESCRIPTION
While porting the new Http auto-tracking changes to Functions, I ran into a handful of issues that this commit now fixes:
- Auto-tracked Service Bus requests were getting "200" status code. We now set this to "0".
- The URL for auto-tracked Http requests contained the query string, which we want to prevent.
- Because we overwrite Http request `Name` with the function name, we had lost the HttpMethod. I now pull that out and put it into the `HttpMethod` property, like we did in v1.
- We were not looking at the function result when setting Success. This needs to be pulled from the `Suceeded` property and explicitly set on the telemetry. Fixes #2012.
- During host restarts in Functions, it was possible for us to see auto-tracked `RequestTelemetry` flow through our initializers and processors twice. This is because one TelemetryClient was shutting down while another was starting up, and they were overlapping. Since they both watch for requests with DiagnosticListeners, they were both taking the request through their pipelines. I improved this by
    - Making sure our initializers are idempotent. Even if a telemetry flows through twice, it ends up the same.
    - Setting an explicit property when telemetry has already gone through the processor pipeline. If we see it again, we return without sending it to App Insights.

Tests have been beefed up, and new ones written, to cover all of this.