### PR TITLE
[AppInsights] fixing SB result-reporting

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -38,7 +38,7 @@ foreach ($project in $projects)
 
 ### Sign package if build is not a PR
 $isPr = Test-Path env:APPVEYOR_PULL_REQUEST_NUMBER
-if (-not $isPr) {
+if (-not $isPr -and -not $isLocal) {
   & ".\tools\RunSigningJob.ps1" 
   if (-not $?) { exit 1 }
 }

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
@@ -367,7 +367,6 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                     switch (prop.Key)
                     {
                         case LogConstants.StartTimeKey:
-                        case LogConstants.SucceededKey:
                         case LogConstants.EndTimeKey:
                             // These values are set by the calls to Start/Stop the telemetry. Other
                             // Loggers may want them, but we'll ignore.

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ISdkVersionProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ISdkVersionProvider.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Reflection;
+
+namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
+{
+    public interface ISdkVersionProvider
+    {
+        string GetSdkVersion();
+    }
+    internal class WebJobsSdkVersionProvider : ISdkVersionProvider
+    {
+        private readonly string sdkVersion = "webjobs: " + GetAssemblyFileVersion(typeof(JobHost).Assembly);
+        public string GetSdkVersion()
+        {
+            return sdkVersion;
+        }
+        internal static string GetAssemblyFileVersion(Assembly assembly)
+        {
+            AssemblyFileVersionAttribute fileVersionAttr = assembly.GetCustomAttribute<AssemblyFileVersionAttribute>();
+            return fileVersionAttr?.Version ?? LoggingConstants.Unknown;
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/HttpDependencyCollectionTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/HttpDependencyCollectionTests.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
 
             Assert.Equal("Http", dependency.Type);
             Assert.Equal("www.microsoft.com", dependency.Target);
-            Assert.Equal("https://www.microsoft.com/", dependency.Data);
+            Assert.Contains("https://www.microsoft.com", dependency.Data);
             Assert.Equal("GET /", dependency.Name);
         }
 

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
@@ -49,6 +49,10 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                 Assert.Single(config.TelemetryInitializers.OfType<WebJobsTelemetryInitializer>());
                 Assert.Single(config.TelemetryInitializers.OfType<WebJobsSanitizingInitializer>());
 
+                var sdkVersionProvider = host.Services.GetServices<ISdkVersionProvider>().ToList();
+                Assert.Single(sdkVersionProvider);
+                Assert.Single(sdkVersionProvider.OfType<WebJobsSdkVersionProvider>());
+
                 // Verify Channel
                 Assert.IsType<ServerTelemetryChannel>(config.TelemetryChannel);
 

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
@@ -256,7 +256,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             {
                 "ApplicationInsightsLoggerOptions",
                 "ApplicationInsightsLoggerProvider",
-                "ApplicationInsightsLoggingBuilderExtensions"
+                "ApplicationInsightsLoggingBuilderExtensions",
+                "ISdkVersionProvider"
             };
 
             TestHelpers.AssertPublicTypes(expected, assembly);


### PR DESCRIPTION
Fixes #2012. 

Also re-adds `ISdkVersionProvider` from the reverted Http tracking commit, as it's a better way for us to update the version in multiple places.