### PR TITLE
Fix TelemetryConfiguration.Active setup to fix rolename and instancename on heartbeats

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
@@ -89,11 +89,17 @@ namespace Microsoft.Extensions.DependencyInjection
                 // we have to touch (and create) Active configuration before initializing telemetry modules
                 // Active configuration is used to report AppInsights heartbeats
                 // role environment telemetry initializer is needed to correlate heartbeats to particular host
+
+                var activeConfig = TelemetryConfiguration.Active;
                 if (!string.IsNullOrEmpty(options.InstrumentationKey) &&
-                    string.IsNullOrEmpty(TelemetryConfiguration.Active.InstrumentationKey))
+                    string.IsNullOrEmpty(activeConfig.InstrumentationKey))
                 {
-                    TelemetryConfiguration.Active.InstrumentationKey = options.InstrumentationKey;
-                    TelemetryConfiguration.Active.TelemetryInitializers.Add(
+                    activeConfig.InstrumentationKey = options.InstrumentationKey;
+                }
+
+                if (!activeConfig.TelemetryInitializers.OfType<WebJobsRoleEnvironmentTelemetryInitializer>().Any())
+                {
+                    activeConfig.TelemetryInitializers.Add(
                         new WebJobsRoleEnvironmentTelemetryInitializer());
                 }
 


### PR DESCRIPTION
When we set up Active config, we  check that instrumentation key is set and do nothing if it is set.

However, ikey is read automatically from the environment variable, i.e. we don't set up WebJobsRoleEnvironmentTelemetryInititalizer. 

So telemetry (heartbeats) that is reported using Active config does not have rolename and instance info.