### PR TITLE
Telemetry is (wrongfully) filtered out

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/WebJobsTelemetryInitializer.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/WebJobsTelemetryInitializer.cs
@@ -80,10 +80,14 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                     telemetryProps[LogConstants.CategoryNameKey] = category;
                 }
 
-                LogLevel? logLevel = scopeProps.GetValueOrDefault<LogLevel?>(LogConstants.LogLevelKey);
-                if (logLevel != null)
+                // only set loglevel for filtering on trace telemetry
+                if (telemetry is TraceTelemetry)
                 {
-                    telemetryProps[LogConstants.LogLevelKey] = logLevel.Value.ToString();
+                    LogLevel? logLevel = scopeProps.GetValueOrDefault<LogLevel?>(LogConstants.LogLevelKey);
+                    if (logLevel != null)
+                    {
+                        telemetryProps[LogConstants.LogLevelKey] = logLevel.Value.ToString();
+                    }
                 }
 
                 int? eventId = scopeProps.GetValueOrDefault<int?>(LogConstants.EventIdKey);


### PR DESCRIPTION
When configuring the loggingbuilder to use applicationinsights, other types of telemetry are filtered out. For example, if i only want warnings to show up in ApplicationInsights i configure my appsettings like:

```
  "Logging": {
    "IncludeScopes": false,
    "LogLevel": {
      "Default": "Information"
    },
    "ApplicationInsights": {
      "LogLevel": {
        "Default": "Warning"
      }
    }
  }
```

When i now send custom metrics or events to application insights, they are assigned a default LogLevel in `FunctionExecutor.cs`:
```
using (logger.BeginScope(new Dictionary<string, object>
{
    [LogConstants.CategoryNameKey] = LogCategories.CreateFunctionCategory(instance.FunctionDescriptor.LogName),
    [LogConstants.LogLevelKey] = LogLevel.Information
}))
```

In `WebJobsTelemetryInitializer` it obtains the scope from:
```
IDictionary<string, object> scopeProps = DictionaryLoggerScope.GetMergedStateDictionary() ?? new Dictionary<string, object>();
```
which now holds the `LogLevel` set to `Information`, for all types of telemetry. It then updates the telemetry:

```
LogLevel? logLevel = scopeProps.GetValueOrDefault<LogLevel?>(LogConstants.LogLevelKey);
if (logLevel != null)
{
    telemetryProps[LogConstants.LogLevelKey] = logLevel.Value.ToString();
}
```
In the `FilteringTelemetryProcessor` it then filters out the telemetry due to the loglevel set to information...

Proposal in this PR is to only set the LogLevel property to `TraceTelemetry`. It can either be fixed here or we adjust the `FilteringTelemetryProcessor` to only filter out `TraceTelemetry`

Regards,
Mark

