### PR TITLE
Consider appsettings file for current environment

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsHostBuilderExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsHostBuilderExtensions.cs
@@ -27,7 +27,9 @@ namespace Microsoft.Extensions.Hosting
         {
             builder.ConfigureAppConfiguration(config =>
             {
-                config.AddJsonFile("appsettings.json", optional: true);
+                var hostingEnvironment = context.HostingEnvironment;
+                config.AddJsonFile("appsettings.json", optional: true)
+                      .AddJsonFile("appsettings." + hostingEnvironment.EnvironmentName + ".json", optional: true);
                 config.AddEnvironmentVariables();
             });
 

--- a/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsHostBuilderExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsHostBuilderExtensions.cs
@@ -29,8 +29,8 @@ namespace Microsoft.Extensions.Hosting
             {
                 var env = hostingContext.HostingEnvironment;
 
-                config.AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-                      .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: true);
+                config.AddJsonFile("appsettings.json", optional: true)
+                      .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true);
 
                 config.AddEnvironmentVariables();
             });

--- a/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsHostBuilderExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsHostBuilderExtensions.cs
@@ -25,11 +25,13 @@ namespace Microsoft.Extensions.Hosting
 
         public static IHostBuilder ConfigureWebJobs(this IHostBuilder builder, Action<IWebJobsBuilder> configure, Action<JobHostOptions> configureOptions)
         {
-            builder.ConfigureAppConfiguration(config =>
+            builder.ConfigureAppConfiguration((hostingContext, config) =>
             {
-                var hostingEnvironment = context.HostingEnvironment;
-                config.AddJsonFile("appsettings.json", optional: true)
-                      .AddJsonFile("appsettings." + hostingEnvironment.EnvironmentName + ".json", optional: true);
+                var env = hostingContext.HostingEnvironment;
+
+                config.AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+                      .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: true);
+
                 config.AddEnvironmentVariables();
             });
 


### PR DESCRIPTION
I noticed that the environment specific appsettings file (e.g. `appsettings.staging.json`) is ignored.
This PR adds the functionality to include this file. I basically copied the code from here: 
https://github.com/aspnet/AspNetCore/blob/3c09d644cccdb21801f7a79e1188a1a1212de5d9/src/DefaultBuilder/src/WebHost.cs#L165

There are probably unit tests missing, etc. but before doing that, I wanted to see if the changes are even wanted.