### PR TITLE
Raise HostInitialized callback AFTER listeners are created

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostConfigurationExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostConfigurationExtensions.cs
@@ -285,8 +285,14 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
                 }
 
                 IFunctionIndex functions = await functionIndexProvider.GetAsync(combinedCancellationToken);
-                IListenerFactory functionsListenerFactory = new HostListenerFactory(functions.ReadAll(), singletonManager, activator, nameResolver, trace, loggerFactory, config.AllowPartialHostStartup);
-
+                Action listenersCreatedCallback = () =>
+                {
+                    // only trigger HostInitialized after all listeners are created (but before
+                    // they are started).
+                    host.OnHostInitialized();
+                };
+                IListenerFactory functionsListenerFactory = new HostListenerFactory(functions.ReadAll(), singletonManager, activator, nameResolver, trace, loggerFactory, config.AllowPartialHostStartup, listenersCreatedCallback);
+                
                 IFunctionExecutor hostCallExecutor;
                 IListener listener;
                 HostOutputMessage hostOutputMessage;

--- a/src/Microsoft.Azure.WebJobs.Host/JobHost.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/JobHost.cs
@@ -426,10 +426,6 @@ namespace Microsoft.Azure.WebJobs
 
                 var context = await _config.CreateJobHostContextAsync(_services, this, _shutdownTokenSource.Token, cancellationToken);
 
-                // must call this BEFORE setting the results below
-                // since listener startup is blocking on those members
-                OnHostInitialized();
-
                 _context = context;
                 _listener = context.Listener;
                 _logger = _context.LoggerFactory?.CreateLogger(LogCategories.Startup);
@@ -446,7 +442,7 @@ namespace Microsoft.Azure.WebJobs
         /// Called when host initialization has been completed, but before listeners
         /// are started.
         /// </summary>
-        protected virtual void OnHostInitialized()
+        protected internal virtual void OnHostInitialized()
         {
         }
 

--- a/src/Microsoft.Azure.WebJobs.Host/Listeners/HostListenerFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Listeners/HostListenerFactory.cs
@@ -27,9 +27,10 @@ namespace Microsoft.Azure.WebJobs.Host.Listeners
         private readonly ILoggerFactory _loggerFactory;
         private readonly ILogger _logger;
         private readonly bool _allowPartialHostStartup;
+        private readonly Action _listenersCreatedCallback;
 
         public HostListenerFactory(IEnumerable<IFunctionDefinition> functionDefinitions, SingletonManager singletonManager, IJobActivator activator, INameResolver nameResolver,
-            TraceWriter trace, ILoggerFactory loggerFactory, bool allowPartialHostStartup = false)
+            TraceWriter trace, ILoggerFactory loggerFactory, bool allowPartialHostStartup = false, Action listenersCreatedCallback = null)
         {
             _functionDefinitions = functionDefinitions;
             _singletonManager = singletonManager;
@@ -39,6 +40,7 @@ namespace Microsoft.Azure.WebJobs.Host.Listeners
             _loggerFactory = loggerFactory;
             _logger = _loggerFactory?.CreateLogger(LogCategories.Startup);
             _allowPartialHostStartup = allowPartialHostStartup;
+            _listenersCreatedCallback = listenersCreatedCallback;
         }
 
         public async Task<IListener> CreateAsync(CancellationToken cancellationToken)
@@ -75,6 +77,8 @@ namespace Microsoft.Azure.WebJobs.Host.Listeners
                 listener = new FunctionListener(listener, functionDefinition.Descriptor, _trace, _loggerFactory, _allowPartialHostStartup);
                 listeners.Add(listener);
             }
+
+            _listenersCreatedCallback?.Invoke();
 
             return new CompositeListener(listeners);
         }


### PR DESCRIPTION
Part of the fix for https://github.com/Azure/azure-functions-host/issues/4021.

The issue is we're raising the HostInitialized callback/event after functions are indexed, but BEFORE listeners are created. That creates a problem for WebHook extensions, since they rely on having access to the function executor to implement their WebHook handler. The earliest the binding can have access to this executor is on listener creation.

Rather than delay until after listeners are fully started, I just move the event a little later. In the context of AzureFunctions, this allows the `[RequiresRunningHost]` filter [here](https://github.com/Azure/azure-functions-host/blob/2942e616bdfadf3a41760505b480d5533a3348c4/src/WebJobs.Script.WebHost/Controllers/AdminController.cs#L213) to be satisfied after listeners are created, but before they are fully started (since that can take a while and is not required).

See also the corresponding fix [here](https://github.com/Azure/azure-functions-eventgrid-extension/pull/65) to the EventGrid extension. Pulling both of these fixes together into Functions will address the issue.