### PR TITLE
Version bump

### DIFF
--- a/src/Common/CommonAssemblyInfo.cs
+++ b/src/Common/CommonAssemblyInfo.cs
@@ -8,11 +8,11 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("Microsoft Corporation")]
 [assembly: AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
 
-[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyVersion("2.4.0.0")]
 
 // The official build will replace the third place with the build number.
 // For example, 1.0.0.0 becomes 1.0.1234.0
-[assembly: AssemblyFileVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.4.0.0")]
 
 // The official build will insert the commit hash here.
 [assembly: AssemblyInformationalVersion("")]

--- a/tools/NuGetProj.settings.targets
+++ b/tools/NuGetProj.settings.targets
@@ -4,8 +4,8 @@
     <WebJobsRootPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\'))</WebJobsRootPath>
     <WebJobsToolsPath>$(MSBuildThisFileDirectory)</WebJobsToolsPath>
     <WebJobsPackageEULA>https://go.microsoft.com/fwlink/?linkid=2028464</WebJobsPackageEULA>
-    <Version>2.3.1</Version>
-    <PrereleaseTag></PrereleaseTag>
+    <Version>2.4.0</Version>
+    <PrereleaseTag>-beta1</PrereleaseTag>
     
     <!-- $(PackageSuffix), typically something like '-12345', is passed in as a build property. -->
     <WebJobsPackageVersion>$(Version)$(PrereleaseTag)$(PackageSuffix)</WebJobsPackageVersion>


### PR DESCRIPTION
Currently our assembly version is at 2.3.0 but package version was incorrectly bumped to 2.3.1. Since 2.3.0 has RTM'ed on nuget, we need a new package/assembly verison 2.4.0 beta.