### PR TITLE
Set VisibilityTimeout on QueueListener when set in QueueOptions

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Queues/Listeners/QueueListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Queues/Listeners/QueueListener.cs
@@ -74,7 +74,14 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Listeners
 
             // if the function runs longer than this, the invisibility will be updated
             // on a timer periodically for the duration of the function execution
-            _visibilityTimeout = TimeSpan.FromMinutes(10);
+            if (_queueOptions.VisibilityTimeout > TimeSpan.Zero)
+            {
+                _visibilityTimeout = _queueOptions.VisibilityTimeout;
+            }
+            else
+            {
+                _visibilityTimeout = TimeSpan.FromMinutes(10);
+            }
 
             if (sharedWatcher != null)
             {

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Queues/Listeners/QueueListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Queues/Listeners/QueueListener.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Listeners
 
             // if the function runs longer than this, the invisibility will be updated
             // on a timer periodically for the duration of the function execution
-            if (_queueOptions.VisibilityTimeout != default)
+            if (_queueOptions.VisibilityTimeout > TimeSpan.Zero)
             {
                 _visibilityTimeout = _queueOptions.VisibilityTimeout;
             }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Queues/Listeners/QueueListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Queues/Listeners/QueueListener.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Listeners
 
             // if the function runs longer than this, the invisibility will be updated
             // on a timer periodically for the duration of the function execution
-            if (_queueOptions.VisibilityTimeout > TimeSpan.Zero)
+            if (_queueOptions.VisibilityTimeout != default)
             {
                 _visibilityTimeout = _queueOptions.VisibilityTimeout;
             }


### PR DESCRIPTION
This PR solves Azure/azure-webjobs-sdk#2158. It includes a test to demonstrate the effect of the change.


In the QueueListener the VisibilityTimeout was always set to the default of 10 minutes, irrespective of the options set. This PR looks if the VisiblityTimeout in the options is not the default (TimeSpan.Zero) and if so updates the VisibilityTimeout to the value in the options.