### PR TITLE
Prefix PerformanceCounter telemetry with f_, to indicate telemetry is from functions

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<ITelemetryInitializer, WebJobsRoleEnvironmentTelemetryInitializer>();
             services.AddSingleton<ITelemetryInitializer, WebJobsSanitizingInitializer>();
             services.AddSingleton<ITelemetryInitializer, WebJobsTelemetryInitializer>();
+            services.AddSingleton<ITelemetryInitializer, PerfCounterSdkVersionTelemetryInitializer>();
 
             services.AddSingleton<ITelemetryModule, QuickPulseTelemetryModule>();
             

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<ITelemetryInitializer, WebJobsRoleEnvironmentTelemetryInitializer>();
             services.AddSingleton<ITelemetryInitializer, WebJobsSanitizingInitializer>();
             services.AddSingleton<ITelemetryInitializer, WebJobsTelemetryInitializer>();
-            services.AddSingleton<ITelemetryInitializer, PerfCounterSdkVersionTelemetryInitializer>();
+            services.AddSingleton<ITelemetryInitializer, MetricSdkVersionTelemetryInitializer>();
 
             services.AddSingleton<ITelemetryModule, QuickPulseTelemetryModule>();
             

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/MetricSdkVersionTelemetryInitializer.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/MetricSdkVersionTelemetryInitializer.cs
@@ -9,7 +9,7 @@ using System;
 
 namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
 {
-    internal class PerfCounterSdkVersionTelemetryInitializer : ITelemetryInitializer
+    internal class MetricSdkVersionTelemetryInitializer : ITelemetryInitializer
     {
         private const string Prefix = "f_";
         public void Initialize(ITelemetry telemetry)

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/PerfCounterSdkVersionTelemetryInitializer.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/PerfCounterSdkVersionTelemetryInitializer.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.ApplicationInsights.Extensibility.Implementation;
+
+namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
+{
+    internal class PerfCounterSdkVersionTelemetryInitializer : ITelemetryInitializer
+    {
+        public void Initialize(ITelemetry telemetry)
+        {
+            if (telemetry == null)
+            {
+                return;
+            }
+            
+            if (telemetry is PerformanceCounterTelemetry)
+            {
+                var internalContext = telemetry.Context != null ? telemetry.Context.GetInternalContext() : null;
+                if (internalContext != null && internalContext.SdkVersion != null)
+                {
+                    internalContext.SdkVersion = "f_" + telemetry.Context.GetInternalContext().SdkVersion;
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/PerfCounterSdkVersionTelemetryInitializer.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/PerfCounterSdkVersionTelemetryInitializer.cs
@@ -5,11 +5,13 @@ using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.Extensibility.Implementation;
+using System;
 
 namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
 {
     internal class PerfCounterSdkVersionTelemetryInitializer : ITelemetryInitializer
     {
+        private const string Prefix = "f_";
         public void Initialize(ITelemetry telemetry)
         {
             if (telemetry == null)
@@ -20,9 +22,9 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
             if (telemetry is PerformanceCounterTelemetry)
             {
                 var internalContext = telemetry.Context != null ? telemetry.Context.GetInternalContext() : null;
-                if (internalContext != null && internalContext.SdkVersion != null)
+                if (internalContext != null && internalContext.SdkVersion != null && !internalContext.SdkVersion.StartsWith(Prefix, StringComparison.OrdinalIgnoreCase))
                 {
-                    internalContext.SdkVersion = "f_" + telemetry.Context.GetInternalContext().SdkVersion;
+                    internalContext.SdkVersion = Prefix + telemetry.Context.GetInternalContext().SdkVersion;
                 }
             }
         }

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/PerfCounterSdkVersionTelemetryInitializer.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/PerfCounterSdkVersionTelemetryInitializer.cs
@@ -21,10 +21,10 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
             
             if (telemetry is PerformanceCounterTelemetry)
             {
-                var internalContext = telemetry.Context != null ? telemetry.Context.GetInternalContext() : null;
+                var internalContext = telemetry.Context?.GetInternalContext();
                 if (internalContext != null && internalContext.SdkVersion != null && !internalContext.SdkVersion.StartsWith(Prefix, StringComparison.OrdinalIgnoreCase))
                 {
-                    internalContext.SdkVersion = Prefix + telemetry.Context.GetInternalContext().SdkVersion;
+                    internalContext.SdkVersion = Prefix + internalContext.SdkVersion;
                 }
             }
         }

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/PerfCounterSdkVersionTelemetryInitializer.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/PerfCounterSdkVersionTelemetryInitializer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                 return;
             }
             
-            if (telemetry is PerformanceCounterTelemetry)
+            if (telemetry is MetricTelemetry)
             {
                 var internalContext = telemetry.Context?.GetInternalContext();
                 if (internalContext != null && internalContext.SdkVersion != null && !internalContext.SdkVersion.StartsWith(Prefix, StringComparison.OrdinalIgnoreCase))

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/ApplicationInsightsEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/ApplicationInsightsEndToEndTests.cs
@@ -1013,7 +1013,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
         private static void ValidateSdkVersion(ITelemetry telemetry)
         {
-            Assert.StartsWith("webjobs: ", telemetry.Context.GetInternalContext().SdkVersion);
+            Assert.StartsWith("f_webjobs: ", telemetry.Context.GetInternalContext().SdkVersion);
         }
 
         private class QuickPulsePayload

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/ApplicationInsightsEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/ApplicationInsightsEndToEndTests.cs
@@ -742,7 +742,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             Assert.Equal("100", telemetry.Properties[$"{LogConstants.CustomPropertyPrefix}MyCustomMetricProperty"]);
             ValidateCustomScopeProperty(telemetry);
 
-            ValidateSdkVersion(telemetry);
+            ValidateSdkVersion(telemetry, "f_");
         }
 
         private static void ValidateCustomScopeProperty(ISupportProperties telemetry)
@@ -1011,9 +1011,9 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 success ? LogLevel.Information : LogLevel.Error, success, statusCode);
         }
 
-        private static void ValidateSdkVersion(ITelemetry telemetry)
-        {
-            Assert.StartsWith("f_webjobs: ", telemetry.Context.GetInternalContext().SdkVersion);
+        private static void ValidateSdkVersion(ITelemetry telemetry, string prefix = null)
+        {            
+            Assert.StartsWith($"{prefix}webjobs: ", telemetry.Context.GetInternalContext().SdkVersion);
         }
 
         private class QuickPulsePayload

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                 Assert.Single(config.TelemetryInitializers.OfType<WebJobsRoleEnvironmentTelemetryInitializer>());
                 Assert.Single(config.TelemetryInitializers.OfType<WebJobsTelemetryInitializer>());
                 Assert.Single(config.TelemetryInitializers.OfType<WebJobsSanitizingInitializer>());
-                Assert.Single(config.TelemetryInitializers.OfType<PerfCounterSdkVersionTelemetryInitializer>());
+                Assert.Single(config.TelemetryInitializers.OfType<MetricSdkVersionTelemetryInitializer>());
                 Assert.Single(config.TelemetryInitializers.OfType<W3COperationCorrelationTelemetryInitializer>());
 
                 var sdkVersionProvider = host.Services.GetServices<ISdkVersionProvider>().ToList();

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
@@ -59,13 +59,14 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                 var config = host.Services.GetService<TelemetryConfiguration>();
 
                 // Verify Initializers
-                Assert.Equal(6, config.TelemetryInitializers.Count);
+                Assert.Equal(7, config.TelemetryInitializers.Count);
                 // These will throw if there are not exactly one
                 Assert.Single(config.TelemetryInitializers.OfType<OperationCorrelationTelemetryInitializer>());
                 Assert.Single(config.TelemetryInitializers.OfType<HttpDependenciesParsingTelemetryInitializer>());
                 Assert.Single(config.TelemetryInitializers.OfType<WebJobsRoleEnvironmentTelemetryInitializer>());
                 Assert.Single(config.TelemetryInitializers.OfType<WebJobsTelemetryInitializer>());
                 Assert.Single(config.TelemetryInitializers.OfType<WebJobsSanitizingInitializer>());
+                Assert.Single(config.TelemetryInitializers.OfType<PerfCounterSdkVersionTelemetryInitializer>());
                 Assert.Single(config.TelemetryInitializers.OfType<W3COperationCorrelationTelemetryInitializer>());
 
                 var sdkVersionProvider = host.Services.GetServices<ISdkVersionProvider>().ToList();

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/PerfCounterSdkVersionTelemetryInitializerTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/PerfCounterSdkVersionTelemetryInitializerTest.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
         {
             // Create a PerfCounter telemetry with some SDK version
             string originalVersion = "azwapccore:2.9.1-26132";
-            var performanceCounterTelemetry = new PerformanceCounterTelemetry("cat", "counter", "instance", 100.00);
+            var performanceCounterTelemetry = new MetricTelemetry("metric", 100.00);
             performanceCounterTelemetry.Context.GetInternalContext().SdkVersion = originalVersion;
 
             // Apply Initializer
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
         {
             // Create a PerfCounter telemetry with SDK version starting with "f_"
             string originalVersion = "f_azwapccore:2.9.1-26132";
-            var performanceCounterTelemetry = new PerformanceCounterTelemetry("cat", "counter", "instance", 100.00);            
+            var performanceCounterTelemetry = new MetricTelemetry("metric", 100.00);
             performanceCounterTelemetry.Context.GetInternalContext().SdkVersion = originalVersion;
 
             // Apply Initializer, more than once.
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
         public void Initializer_DoesNotThrowOnEmptyOrNullVersion_PerfCounterTelemetry()
         {
             // Create a PerfCounter telemetry.
-            var performanceCounterTelemetry = new PerformanceCounterTelemetry("cat", "counter", "instance", 100.00);
+            var performanceCounterTelemetry = new MetricTelemetry("metric", 100.00);
             var initializer = new PerfCounterSdkVersionTelemetryInitializer();
 
             // Assign Empty Version

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/PerfCounterSdkVersionTelemetryInitializerTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/PerfCounterSdkVersionTelemetryInitializerTest.cs
@@ -11,10 +11,10 @@ using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
 {
-    public class PerfCounterSdkVersionTelemetryInitializerTest
+    public class MetricSdkVersionTelemetryInitializerTest
     {
         [Fact]
-        public void Initializer_OnlyModifiedPerfCounterTelemetry()
+        public void Initializer_OnlyModifiedMetricTelemetry()
         {
             // Create a RequestTelemetry with SDKVersion.
             var request = new RequestTelemetry
@@ -27,26 +27,26 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             request.Context.GetInternalContext().SdkVersion = originalSdkVersion;
 
             // Apply initializer
-            var initializer = new PerfCounterSdkVersionTelemetryInitializer();
+            var initializer = new MetricSdkVersionTelemetryInitializer();
             initializer.Initialize(request);
 
-            // Validate that original version is un-touched, as this initializer is only expected to modify PerfCounter telemetry
+            // Validate that original version is un-touched, as this initializer is only expected to modify Metric telemetry
             Assert.Equal(originalSdkVersion, request.Context.GetInternalContext().SdkVersion);
         }
 
         [Fact]
-        public void Initializer_AddsPrefix_PerfCounterTelemetry()
+        public void Initializer_AddsPrefix_MetricTelemetry()
         {
-            // Create a PerfCounter telemetry with some SDK version
+            // Create a Metric telemetry with some SDK version
             string originalVersion = "azwapccore:2.9.1-26132";
-            var performanceCounterTelemetry = new MetricTelemetry("metric", 100.00);
-            performanceCounterTelemetry.Context.GetInternalContext().SdkVersion = originalVersion;
+            var metricTelemetry = new MetricTelemetry("metric", 100.00);
+            metricTelemetry.Context.GetInternalContext().SdkVersion = originalVersion;
 
             // Apply Initializer
-            var initializer = new PerfCounterSdkVersionTelemetryInitializer();
-            initializer.Initialize(performanceCounterTelemetry);
+            var initializer = new MetricSdkVersionTelemetryInitializer();
+            initializer.Initialize(metricTelemetry);
             
-            var actualSdkVersion = performanceCounterTelemetry.Context.GetInternalContext().SdkVersion;
+            var actualSdkVersion = metricTelemetry.Context.GetInternalContext().SdkVersion;
             // Validate that "f_" is prefixed
             Assert.StartsWith("f_", actualSdkVersion);
             // And validate that original version is kept after "f_"
@@ -56,48 +56,48 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
         [Fact]
         public void Initializer_IsIdempotent()
         {
-            // Create a PerfCounter telemetry with SDK version starting with "f_"
+            // Create a Metric telemetry with SDK version starting with "f_"
             string originalVersion = "f_azwapccore:2.9.1-26132";
-            var performanceCounterTelemetry = new MetricTelemetry("metric", 100.00);
-            performanceCounterTelemetry.Context.GetInternalContext().SdkVersion = originalVersion;
+            var metricTelemetry = new MetricTelemetry("metric", 100.00);
+            metricTelemetry.Context.GetInternalContext().SdkVersion = originalVersion;
 
             // Apply Initializer, more than once.
-            var initializer = new PerfCounterSdkVersionTelemetryInitializer();
-            initializer.Initialize(performanceCounterTelemetry);
-            initializer.Initialize(performanceCounterTelemetry);
+            var initializer = new MetricSdkVersionTelemetryInitializer();
+            initializer.Initialize(metricTelemetry);
+            initializer.Initialize(metricTelemetry);
 
             // Validate that initializer does not modify the SDKVersion as it is already prefixed with "f_"
-            var actualSdkVersion = performanceCounterTelemetry.Context.GetInternalContext().SdkVersion;
+            var actualSdkVersion = metricTelemetry.Context.GetInternalContext().SdkVersion;
             Assert.Equal(originalVersion, actualSdkVersion);
         }
 
         [Fact]
-        public void Initializer_DoesNotThrowOnEmptyOrNullVersion_PerfCounterTelemetry()
+        public void Initializer_DoesNotThrowOnEmptyOrNullVersion_MetricTelemetry()
         {
-            // Create a PerfCounter telemetry.
-            var performanceCounterTelemetry = new MetricTelemetry("metric", 100.00);
-            var initializer = new PerfCounterSdkVersionTelemetryInitializer();
+            // Create a Metric telemetry.
+            var metricTelemetry = new MetricTelemetry("metric", 100.00);
+            var initializer = new MetricSdkVersionTelemetryInitializer();
 
             // Assign Empty Version
-            performanceCounterTelemetry.Context.GetInternalContext().SdkVersion = string.Empty;
+            metricTelemetry.Context.GetInternalContext().SdkVersion = string.Empty;
 
             // Apply Initializer            
-            initializer.Initialize(performanceCounterTelemetry);
+            initializer.Initialize(metricTelemetry);
 
             // Assign Null Version
-            performanceCounterTelemetry.Context.GetInternalContext().SdkVersion = null;
+            metricTelemetry.Context.GetInternalContext().SdkVersion = null;
 
             // Apply Initializer            
-            initializer.Initialize(performanceCounterTelemetry);
+            initializer.Initialize(metricTelemetry);
 
             // Nothing to validate. If an exception was thrown, test would fail.
         }
 
         [Fact]
-        public void Initializer_DoesNotThrowOnNull_PerfCounterTelemetry()
+        public void Initializer_DoesNotThrowOnNull_MetricTelemetry()
         {            
             // Apply Initializer
-            var initializer = new PerfCounterSdkVersionTelemetryInitializer();
+            var initializer = new MetricSdkVersionTelemetryInitializer();
             initializer.Initialize(null);
             // Nothing to validate. If an exception was thrown, test would fail.
         }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/PerfCounterSdkVersionTelemetryInitializerTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/PerfCounterSdkVersionTelemetryInitializerTest.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility.Implementation;
+using Microsoft.Azure.WebJobs.Logging;
+using Microsoft.Azure.WebJobs.Logging.ApplicationInsights;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
+{
+    public class PerfCounterSdkVersionTelemetryInitializerTest
+    {
+        [Fact]
+        public void Initializer_OnlyModifiedPerfCounterTelemetry()
+        {
+            // Create a RequestTelemetry with SDKVersion.
+            var request = new RequestTelemetry
+            {
+                ResponseCode = "200",
+                Name = "POST /api/somemethod",
+            };
+
+            string originalSdkVersion = "azurefunctions:2.9.1-26132";
+            request.Context.GetInternalContext().SdkVersion = originalSdkVersion;
+
+            // Apply initializer
+            var initializer = new PerfCounterSdkVersionTelemetryInitializer();
+            initializer.Initialize(request);
+
+            // Validate that original version is un-touched, as this initializer is only expected to modify PerfCounter telemetry
+            Assert.Equal(originalSdkVersion, request.Context.GetInternalContext().SdkVersion);
+        }
+
+        [Fact]
+        public void Initializer_AddsPrefix_PerfCounterTelemetry()
+        {
+            // Create a PerfCounter telemetry with some SDK version
+            string originalVersion = "azwapccore:2.9.1-26132";
+            var performanceCounterTelemetry = new PerformanceCounterTelemetry("cat", "counter", "instance", 100.00);
+            performanceCounterTelemetry.Context.GetInternalContext().SdkVersion = originalVersion;
+
+            // Apply Initializer
+            var initializer = new PerfCounterSdkVersionTelemetryInitializer();
+            initializer.Initialize(performanceCounterTelemetry);
+            
+            var actualSdkVersion = performanceCounterTelemetry.Context.GetInternalContext().SdkVersion;
+            // Validate that "f_" is prefixed
+            Assert.StartsWith("f_", actualSdkVersion);
+            // And validate that original version is kept after "f_"
+            Assert.EndsWith(originalVersion, actualSdkVersion);
+        }
+
+        [Fact]
+        public void Initializer_IsIdempotent()
+        {
+            // Create a PerfCounter telemetry with SDK version starting with "f_"
+            string originalVersion = "f_azwapccore:2.9.1-26132";
+            var performanceCounterTelemetry = new PerformanceCounterTelemetry("cat", "counter", "instance", 100.00);            
+            performanceCounterTelemetry.Context.GetInternalContext().SdkVersion = originalVersion;
+
+            // Apply Initializer, more than once.
+            var initializer = new PerfCounterSdkVersionTelemetryInitializer();
+            initializer.Initialize(performanceCounterTelemetry);
+            initializer.Initialize(performanceCounterTelemetry);
+
+            // Validate that initializer does not modify the SDKVersion as it is already prefixed with "f_"
+            var actualSdkVersion = performanceCounterTelemetry.Context.GetInternalContext().SdkVersion;
+            Assert.Equal(originalVersion, actualSdkVersion);
+        }
+
+        [Fact]
+        public void Initializer_DoesNotThrowOnEmptyOrNullVersion_PerfCounterTelemetry()
+        {
+            // Create a PerfCounter telemetry.
+            var performanceCounterTelemetry = new PerformanceCounterTelemetry("cat", "counter", "instance", 100.00);
+            var initializer = new PerfCounterSdkVersionTelemetryInitializer();
+
+            // Assign Empty Version
+            performanceCounterTelemetry.Context.GetInternalContext().SdkVersion = string.Empty;
+
+            // Apply Initializer            
+            initializer.Initialize(performanceCounterTelemetry);
+
+            // Assign Null Version
+            performanceCounterTelemetry.Context.GetInternalContext().SdkVersion = null;
+
+            // Apply Initializer            
+            initializer.Initialize(performanceCounterTelemetry);
+
+            // Nothing to validate. If an exception was thrown, test would fail.
+        }
+
+        [Fact]
+        public void Initializer_DoesNotThrowOnNull_PerfCounterTelemetry()
+        {            
+            // Apply Initializer
+            var initializer = new PerfCounterSdkVersionTelemetryInitializer();
+            initializer.Initialize(null);
+            // Nothing to validate. If an exception was thrown, test would fail.
+        }
+    }
+}


### PR DESCRIPTION
"azwapccore" is the default SDK Version reported for PerfCounters from App Service. This PR modifies the SDKVersion to prefix "f_", so that telemetry from Azure Functions can be distinguished from App Service for Web Apps.

Will update (https://github.com/Microsoft/ApplicationInsights-Home/blob/master/EndpointSpecs/SDK-VERSIONS.md) once this is merged.