### PR TITLE
Modified metric telemetry to have f_ prefix to identify the source of telemetry as functions.

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<ITelemetryInitializer, WebJobsRoleEnvironmentTelemetryInitializer>();
             services.AddSingleton<ITelemetryInitializer, WebJobsSanitizingInitializer>();
             services.AddSingleton<ITelemetryInitializer, WebJobsTelemetryInitializer>();
+            services.AddSingleton<ITelemetryInitializer, MetricSdkVersionTelemetryInitializer>();
 
             services.AddSingleton<ITelemetryModule, QuickPulseTelemetryModule>();
             

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/MetricSdkVersionTelemetryInitializer.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/MetricSdkVersionTelemetryInitializer.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.ApplicationInsights.Extensibility.Implementation;
+using System;
+
+namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
+{
+    internal class MetricSdkVersionTelemetryInitializer : ITelemetryInitializer
+    {
+        private const string Prefix = "f_";
+        public void Initialize(ITelemetry telemetry)
+        {
+            if (telemetry == null)
+            {
+                return;
+            }
+            
+            if (telemetry is MetricTelemetry)
+            {
+                var internalContext = telemetry.Context?.GetInternalContext();
+                if (internalContext != null && internalContext.SdkVersion != null && !internalContext.SdkVersion.StartsWith(Prefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    internalContext.SdkVersion = Prefix + internalContext.SdkVersion;
+                }
+            }
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/ApplicationInsightsEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/ApplicationInsightsEndToEndTests.cs
@@ -742,7 +742,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             Assert.Equal("100", telemetry.Properties[$"{LogConstants.CustomPropertyPrefix}MyCustomMetricProperty"]);
             ValidateCustomScopeProperty(telemetry);
 
-            ValidateSdkVersion(telemetry);
+            ValidateSdkVersion(telemetry, "f_");
         }
 
         private static void ValidateCustomScopeProperty(ISupportProperties telemetry)
@@ -1011,9 +1011,9 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 success ? LogLevel.Information : LogLevel.Error, success, statusCode);
         }
 
-        private static void ValidateSdkVersion(ITelemetry telemetry)
-        {
-            Assert.StartsWith("webjobs: ", telemetry.Context.GetInternalContext().SdkVersion);
+        private static void ValidateSdkVersion(ITelemetry telemetry, string prefix = null)
+        {            
+            Assert.StartsWith($"{prefix}webjobs:", telemetry.Context.GetInternalContext().SdkVersion);
         }
 
         private class QuickPulsePayload

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
@@ -59,13 +59,14 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                 var config = host.Services.GetService<TelemetryConfiguration>();
 
                 // Verify Initializers
-                Assert.Equal(6, config.TelemetryInitializers.Count);
+                Assert.Equal(7, config.TelemetryInitializers.Count);
                 // These will throw if there are not exactly one
                 Assert.Single(config.TelemetryInitializers.OfType<OperationCorrelationTelemetryInitializer>());
                 Assert.Single(config.TelemetryInitializers.OfType<HttpDependenciesParsingTelemetryInitializer>());
                 Assert.Single(config.TelemetryInitializers.OfType<WebJobsRoleEnvironmentTelemetryInitializer>());
                 Assert.Single(config.TelemetryInitializers.OfType<WebJobsTelemetryInitializer>());
                 Assert.Single(config.TelemetryInitializers.OfType<WebJobsSanitizingInitializer>());
+                Assert.Single(config.TelemetryInitializers.OfType<MetricSdkVersionTelemetryInitializer>());
                 Assert.Single(config.TelemetryInitializers.OfType<W3COperationCorrelationTelemetryInitializer>());
 
                 var sdkVersionProvider = host.Services.GetServices<ISdkVersionProvider>().ToList();

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/PerfCounterSdkVersionTelemetryInitializerTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/PerfCounterSdkVersionTelemetryInitializerTest.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility.Implementation;
+using Microsoft.Azure.WebJobs.Logging;
+using Microsoft.Azure.WebJobs.Logging.ApplicationInsights;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
+{
+    public class MetricSdkVersionTelemetryInitializerTest
+    {
+        [Fact]
+        public void Initializer_OnlyModifiedMetricTelemetry()
+        {
+            // Create a RequestTelemetry with SDKVersion.
+            var request = new RequestTelemetry
+            {
+                ResponseCode = "200",
+                Name = "POST /api/somemethod",
+            };
+
+            string originalSdkVersion = "azurefunctions:2.9.1-26132";
+            request.Context.GetInternalContext().SdkVersion = originalSdkVersion;
+
+            // Apply initializer
+            var initializer = new MetricSdkVersionTelemetryInitializer();
+            initializer.Initialize(request);
+
+            // Validate that original version is un-touched, as this initializer is only expected to modify Metric telemetry
+            Assert.Equal(originalSdkVersion, request.Context.GetInternalContext().SdkVersion);
+        }
+
+        [Fact]
+        public void Initializer_AddsPrefix_MetricTelemetry()
+        {
+            // Create a Metric telemetry with some SDK version
+            string originalVersion = "azwapccore:2.9.1-26132";
+            var metricTelemetry = new MetricTelemetry("metric", 100.00);
+            metricTelemetry.Context.GetInternalContext().SdkVersion = originalVersion;
+
+            // Apply Initializer
+            var initializer = new MetricSdkVersionTelemetryInitializer();
+            initializer.Initialize(metricTelemetry);
+            
+            var actualSdkVersion = metricTelemetry.Context.GetInternalContext().SdkVersion;
+            // Validate that "f_" is prefixed
+            Assert.StartsWith("f_", actualSdkVersion);
+            // And validate that original version is kept after "f_"
+            Assert.EndsWith(originalVersion, actualSdkVersion);
+        }
+
+        [Fact]
+        public void Initializer_IsIdempotent()
+        {
+            // Create a Metric telemetry with SDK version starting with "f_"
+            string originalVersion = "f_azwapccore:2.9.1-26132";
+            var metricTelemetry = new MetricTelemetry("metric", 100.00);
+            metricTelemetry.Context.GetInternalContext().SdkVersion = originalVersion;
+
+            // Apply Initializer, more than once.
+            var initializer = new MetricSdkVersionTelemetryInitializer();
+            initializer.Initialize(metricTelemetry);
+            initializer.Initialize(metricTelemetry);
+
+            // Validate that initializer does not modify the SDKVersion as it is already prefixed with "f_"
+            var actualSdkVersion = metricTelemetry.Context.GetInternalContext().SdkVersion;
+            Assert.Equal(originalVersion, actualSdkVersion);
+        }
+
+        [Fact]
+        public void Initializer_DoesNotThrowOnEmptyOrNullVersion_MetricTelemetry()
+        {
+            // Create a Metric telemetry.
+            var metricTelemetry = new MetricTelemetry("metric", 100.00);
+            var initializer = new MetricSdkVersionTelemetryInitializer();
+
+            // Assign Empty Version
+            metricTelemetry.Context.GetInternalContext().SdkVersion = string.Empty;
+
+            // Apply Initializer            
+            initializer.Initialize(metricTelemetry);
+
+            // Assign Null Version
+            metricTelemetry.Context.GetInternalContext().SdkVersion = null;
+
+            // Apply Initializer            
+            initializer.Initialize(metricTelemetry);
+
+            // Nothing to validate. If an exception was thrown, test would fail.
+        }
+
+        [Fact]
+        public void Initializer_DoesNotThrowOnNull_MetricTelemetry()
+        {            
+            // Apply Initializer
+            var initializer = new MetricSdkVersionTelemetryInitializer();
+            initializer.Initialize(null);
+            // Nothing to validate. If an exception was thrown, test would fail.
+        }
+    }
+}


### PR DESCRIPTION
This is repeat of https://github.com/Azure/azure-webjobs-sdk/pull/2183, as the old one git branch got into a state I am not sure how to recover from :(