### PR TITLE
ServiceBusListener - MessageReceiver should be created no matter if sessions are enabled or not

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/Listeners/ServiceBusListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/Listeners/ServiceBusListener.cs
@@ -59,6 +59,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
                 throw new InvalidOperationException("The listener has already been started.");
             }
 
+            _receiver = _messagingProvider.CreateMessageReceiver(_entity.EntityPath, _serviceBusAccount.ConnectionString);
+
             if (_entity.IsSessionsEnabled)
             {
                 _clientEntity = _messagingProvider.CreateClientEntity(_entity.EntityPath, _serviceBusAccount.ConnectionString);
@@ -76,7 +78,6 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
             }
             else
             {
-                _receiver = _messagingProvider.CreateMessageReceiver(_entity.EntityPath, _serviceBusAccount.ConnectionString);
                 _receiver.RegisterMessageHandler(ProcessMessageAsync, _serviceBusOptions.MessageHandlerOptions);
             }
             _started = true;


### PR DESCRIPTION
Fixed the issue when ServiceBusListener uses a queue with sessions; MessageReceiver should be created
Issue described at this link: https://github.com/Azure/azure-webjobs-sdk/issues/529#issuecomment-490029402