### PR TITLE
[BlobTrigger] include blobs at previous timestamp to account for rounding

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Listeners/ScanBlobScanLogHybridPollingStrategy.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Listeners/ScanBlobScanLogHybridPollingStrategy.cs
@@ -238,7 +238,9 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
                     containerScanInfo.CurrentSweepCycleLatestModified = lastModifiedTimestamp;
                 }
 
-                if (lastModifiedTimestamp > containerScanInfo.LastSweepCycleLatestModified)
+                // Blob timestamps are rounded to the nearest second, so make sure we continue to check
+                // the previous timestamp to catch any blobs that came in slightly after our previous poll.
+                if (lastModifiedTimestamp >= containerScanInfo.LastSweepCycleLatestModified)
                 {
                     newBlobs.Add(currentBlob);
                 }


### PR DESCRIPTION
Fixes #2194.

This means we'll be hitting the blob receipts more than previously as we'll always be re-checking the previous timestamp. But the alternative is missing blobs, so it's worth it.

Tests needed tweaking b/c they didn't expect to see a blob a second time. Had to introduce some receipt logic in the unit tests to account for this.

I'm creating this as a draft because I want some early eyes on it -- but I want to add some more logging to this flow before committing this.