### PR TITLE
updating AppInsights nugets

### DIFF
--- a/sample/SampleHost/Program.cs
+++ b/sample/SampleHost/Program.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using System.Threading.Tasks;
-using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -38,7 +36,7 @@ namespace SampleHost
                     string appInsightsKey = context.Configuration["APPINSIGHTS_INSTRUMENTATIONKEY"];
                     if (!string.IsNullOrEmpty(appInsightsKey))
                     {
-                        b.AddApplicationInsights(o => o.InstrumentationKey = appInsightsKey);
+                        b.AddApplicationInsightsWebJobs(o => o.InstrumentationKey = appInsightsKey);
                     }
                 })
                 .ConfigureServices(services =>

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsLoggingBuilderExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsLoggingBuilderExtensions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Extensions.Logging
         public static ILoggingBuilder AddApplicationInsights(
             this ILoggingBuilder builder)
         {
-            return builder.AddApplicationInsights(null);
+            return AddApplicationInsights(builder, null);
         }
 
         /// <summary>

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsLoggingBuilderExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsLoggingBuilderExtensions.cs
@@ -15,19 +15,34 @@ namespace Microsoft.Extensions.Logging
     /// </summary>
     public static class ApplicationInsightsLoggingBuilderExtensions
     {
-        /// <summary>
-        /// Registers Application Insights and <see cref="ApplicationInsightsLoggerProvider"/> with an <see cref="ILoggingBuilder"/>.
-        /// </summary>        
+        [Obsolete("Use " + nameof(AddApplicationInsightsWebJobs) + " instead.", false)]
         public static ILoggingBuilder AddApplicationInsights(
             this ILoggingBuilder builder)
         {
-            return AddApplicationInsights(builder, null);
+            return AddApplicationInsightsWebJobs(builder);
+        }
+
+        [Obsolete("Use " + nameof(AddApplicationInsightsWebJobs) + " instead.", false)]
+        public static ILoggingBuilder AddApplicationInsights(
+           this ILoggingBuilder builder,
+           Action<ApplicationInsightsLoggerOptions> configure)
+        {
+            return AddApplicationInsightsWebJobs(builder, configure);
         }
 
         /// <summary>
         /// Registers Application Insights and <see cref="ApplicationInsightsLoggerProvider"/> with an <see cref="ILoggingBuilder"/>.
         /// </summary>        
-        public static ILoggingBuilder AddApplicationInsights(
+        public static ILoggingBuilder AddApplicationInsightsWebJobs(
+            this ILoggingBuilder builder)
+        {
+            return builder.AddApplicationInsightsWebJobs(null);
+        }
+
+        /// <summary>
+        /// Registers Application Insights and <see cref="ApplicationInsightsLoggerProvider"/> with an <see cref="ILoggingBuilder"/>.
+        /// </summary>        
+        public static ILoggingBuilder AddApplicationInsightsWebJobs(
             this ILoggingBuilder builder,
             Action<ApplicationInsightsLoggerOptions> configure)
         {

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
@@ -24,18 +24,18 @@
   </ItemGroup>
   
   <ItemGroup>
-  <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.6.1" />
-  <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.9.1" />
-  <PackageReference Include="Microsoft.ApplicationInsights.SnapshotCollector" Version="1.3.0" />
-  <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.9.1" />
-  <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.9.1" />
+  <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.7.0" />
+  <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.10.0" />
+  <PackageReference Include="Microsoft.ApplicationInsights.SnapshotCollector" Version="1.3.4" />
+  <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.10.0" />
+  <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.10.0" />
   <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.1.0" />
   <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.0" />
   <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.9.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.9.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.10.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.10.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.0" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/ApplicationInsightsEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/ApplicationInsightsEndToEndTests.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 .ConfigureLogging(b =>
                 {
                     b.SetMinimumLevel(minLevel);
-                    b.AddApplicationInsights(o =>
+                    b.AddApplicationInsightsWebJobs(o =>
                     {
                         o.InstrumentationKey = _mockApplicationInsightsKey;
                         o.HttpAutoCollectionOptions = httpOptions;

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/HttpDependencyCollectionTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/HttpDependencyCollectionTests.cs
@@ -385,7 +385,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
                 .ConfigureLogging(b =>
                 {
                     b.SetMinimumLevel(logLevel);
-                    b.AddApplicationInsights(o => o.InstrumentationKey = _mockApplicationInsightsKey);
+                    b.AddApplicationInsightsWebJobs(o => o.InstrumentationKey = _mockApplicationInsightsKey);
                 })
                 .Build();
 

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/ServiceBusRequestAndDependencyCollectionTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/ServiceBusRequestAndDependencyCollectionTests.cs
@@ -294,7 +294,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
                 .ConfigureLogging(b =>
                 {
                     b.SetMinimumLevel(LogLevel.Information);
-                    b.AddApplicationInsights(o => o.InstrumentationKey = _mockApplicationInsightsKey);
+                    b.AddApplicationInsightsWebJobs(o => o.InstrumentationKey = _mockApplicationInsightsKey);
                 })
                 .Build();
 

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             var builder = new HostBuilder()
                 .ConfigureLogging(b =>
                 {
-                    b.AddApplicationInsights(o => o.InstrumentationKey = "some key");
+                    b.AddApplicationInsightsWebJobs(o => o.InstrumentationKey = "some key");
                 });
 
             using (var host = builder.Build())
@@ -122,7 +122,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             using (var host = new HostBuilder()
                 .ConfigureLogging(b =>
                 {
-                    b.AddApplicationInsights(o =>
+                    b.AddApplicationInsightsWebJobs(o =>
                     {
                         o.InstrumentationKey = "some key";
                         o.SamplingSettings = samplingSettings;
@@ -148,7 +148,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             using (var host = new HostBuilder()
                 .ConfigureLogging(b =>
                 {
-                    b.AddApplicationInsights(o =>
+                    b.AddApplicationInsightsWebJobs(o =>
                     {
                         o.InstrumentationKey = "some key";
                     });
@@ -172,7 +172,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             using (var host = new HostBuilder()
                 .ConfigureLogging(b =>
                 {
-                    b.AddApplicationInsights(o =>
+                    b.AddApplicationInsightsWebJobs(o =>
                     {
                         o.InstrumentationKey = "some key";
                         o.HttpAutoCollectionOptions.EnableW3CDistributedTracing = false;
@@ -198,7 +198,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             using (var host = new HostBuilder()
                 .ConfigureLogging(b =>
                 {
-                    b.AddApplicationInsights(o =>
+                    b.AddApplicationInsightsWebJobs(o =>
                     {
                         o.InstrumentationKey = "some key";
                         o.HttpAutoCollectionOptions.EnableHttpTriggerExtendedInfoCollection = false;
@@ -222,7 +222,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             using (var host = new HostBuilder()
                 .ConfigureLogging(b =>
                 {
-                    b.AddApplicationInsights(o =>
+                    b.AddApplicationInsightsWebJobs(o =>
                     {
                         o.InstrumentationKey = "some key";
                         o.EnablePerformanceCountersCollection = false;
@@ -241,7 +241,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             using (var host = new HostBuilder()
                 .ConfigureLogging(b =>
                 {
-                    b.AddApplicationInsights(o =>
+                    b.AddApplicationInsightsWebJobs(o =>
                     {
                         o.InstrumentationKey = "some key";
                         o.QuickPulseAuthenticationApiKey = "some auth key";
@@ -262,7 +262,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             using (var host = new HostBuilder()
                 .ConfigureLogging(b =>
                 {
-                    b.AddApplicationInsights(o =>
+                    b.AddApplicationInsightsWebJobs(o =>
                     {
                         o.InstrumentationKey = "some key";
                         o.SamplingSettings = samplingSettings;
@@ -287,7 +287,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             using (var host = new HostBuilder()
                 .ConfigureLogging(b =>
                 {
-                    b.AddApplicationInsights(o =>
+                    b.AddApplicationInsightsWebJobs(o =>
                     {
                         o.InstrumentationKey = "some key";
                         o.SnapshotConfiguration = snapshotConfiguration;
@@ -309,7 +309,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             using (var host = new HostBuilder()
                 .ConfigureLogging(b =>
                 {
-                    b.AddApplicationInsights(o =>
+                    b.AddApplicationInsightsWebJobs(o =>
                     {
                         o.InstrumentationKey = "some key";
                     });
@@ -336,7 +336,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             using (new HostBuilder()
                 .ConfigureLogging(b =>
                 {
-                    b.AddApplicationInsights(o =>
+                    b.AddApplicationInsightsWebJobs(o =>
                     {
                         o.InstrumentationKey = "some key";
                     });
@@ -359,7 +359,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             using (var _ = new HostBuilder()
                 .ConfigureLogging(b =>
                 {
-                    b.AddApplicationInsights(o =>
+                    b.AddApplicationInsightsWebJobs(o =>
                     {
                         o.InstrumentationKey = "some key";
                     });
@@ -372,7 +372,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             using (var host2 = new HostBuilder()
                 .ConfigureLogging(b =>
                 {
-                    b.AddApplicationInsights(o =>
+                    b.AddApplicationInsightsWebJobs(o =>
                     {
                         o.InstrumentationKey = "some key";
                     });
@@ -511,7 +511,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                 .ConfigureWebJobs()
                 .ConfigureLogging((c, b) =>
                 {
-                    b.AddApplicationInsights(o =>
+                    b.AddApplicationInsightsWebJobs(o =>
                     {
                         o.InstrumentationKey = "some key";
                     });

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsLoggerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsLoggerTests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                 .ConfigureLogging(b =>
                 {
                     b.SetMinimumLevel(LogLevel.Trace);
-                    b.AddApplicationInsights(o =>
+                    b.AddApplicationInsightsWebJobs(o =>
                     {
                         o.InstrumentationKey = "some key";
                     });


### PR DESCRIPTION
Updating App Insights nugets -- which also brought along a new extension method `AddApplicationInsights()`, which conflicts with ours. To make this more straightforward, I've marked this obsolete and renamed it `AddApplicationInsightsWebJobs`.