### PR TITLE
Add binding and tests for IMessageReceiver in ServiceBusTrigger

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/Triggers/ServiceBusTriggerBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/Triggers/ServiceBusTriggerBinding.cs
@@ -126,6 +126,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
             contract.Add("CorrelationId", typeof(string));
             contract.Add("UserProperties", typeof(IDictionary<string, object>));
             contract.Add("MessageReceiver", typeof(MessageReceiver));
+            contract.Add("IMessageReceiver", typeof(MessageReceiver));
 
             if (argumentBindingContract != null)
             {
@@ -157,6 +158,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
             SafeAddValue(() => bindingData.Add(nameof(value.CorrelationId), value.CorrelationId));
             SafeAddValue(() => bindingData.Add(nameof(value.UserProperties), value.UserProperties));
             SafeAddValue(() => bindingData.Add("MessageReceiver", receiver));
+            SafeAddValue(() => bindingData.Add("IMessageReceiver", receiver));
 
             if (bindingDataFromValueType != null)
             {

--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/Data/ConverterArgumentBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/Data/ConverterArgumentBindingProvider.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Reflection;
 using System.Threading.Tasks;
-using Microsoft.Azure.WebJobs.Host.Converters;
 
 namespace Microsoft.Azure.WebJobs.Host.Bindings.Data
 {
@@ -24,7 +23,8 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings.Data
                 throw new ArgumentNullException("parameter");
             }
 
-            if (parameter.ParameterType != typeof(T))
+            if (parameter.ParameterType != typeof(T)
+                && !parameter.ParameterType.IsAssignableFrom(typeof(T)))
             {
                 return null;
             }

--- a/test/Microsoft.Azure.WebJobs.Extensions.ServiceBus.UnitTests/Bindings/ServiceBusTriggerBindingTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.ServiceBus.UnitTests/Bindings/ServiceBusTriggerBindingTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Bindings
         {
             IReadOnlyDictionary<string, Type> argumentContract = null;
             var bindingDataContract = ServiceBusTriggerBinding.CreateBindingDataContract(argumentContract);
-            Assert.Equal(14, bindingDataContract.Count);
+            Assert.Equal(15, bindingDataContract.Count);
             Assert.Equal(bindingDataContract["DeliveryCount"], typeof(int));
             Assert.Equal(bindingDataContract["DeadLetterSource"], typeof(string));
             Assert.Equal(bindingDataContract["LockToken"], typeof(string));
@@ -34,6 +34,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Bindings
             Assert.Equal(bindingDataContract["CorrelationId"], typeof(string));
             Assert.Equal(bindingDataContract["UserProperties"], typeof(IDictionary<string, object>));
             Assert.Equal(bindingDataContract["MessageReceiver"], typeof(MessageReceiver));
+            Assert.Equal(bindingDataContract["IMessageReceiver"], typeof(MessageReceiver));
 
             // verify that argument binding values override built ins
             argumentContract = new Dictionary<string, Type>
@@ -42,7 +43,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Bindings
                 { "NewProperty", typeof(decimal) }
             };
             bindingDataContract = ServiceBusTriggerBinding.CreateBindingDataContract(argumentContract);
-            Assert.Equal(15, bindingDataContract.Count);
+            Assert.Equal(16, bindingDataContract.Count);
             Assert.Equal(bindingDataContract["DeliveryCount"], typeof(string));
             Assert.Equal(bindingDataContract["NewProperty"], typeof(decimal));
         }
@@ -68,7 +69,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Bindings
 
             var messageReceiver = new MessageReceiver(config.ConnectionString, "test");
             var bindingData = ServiceBusTriggerBinding.CreateBindingData(message, messageReceiver, valueBindingData);
-            Assert.Equal(9, bindingData.Count);
+            Assert.Equal(10, bindingData.Count);
             Assert.Equal(message.ReplyTo, bindingData["ReplyTo"]);
             Assert.Equal(string.Empty, bindingData["lockToken"]);
             Assert.Equal(message.To, bindingData["To"]);
@@ -78,6 +79,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Bindings
             Assert.Equal(message.CorrelationId, bindingData["CorrelationId"]);
             Assert.Same(message.UserProperties, bindingData["UserProperties"]);
             Assert.Same(messageReceiver, bindingData["MessageReceiver"]);
+            Assert.Same(messageReceiver, bindingData["IMessageReceiver"]);
 
             // verify that value binding data overrides built ins
             valueBindingData = new Dictionary<string, object>
@@ -86,7 +88,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Bindings
                 { "NewProperty", 123 }
             };
             bindingData = ServiceBusTriggerBinding.CreateBindingData(message, messageReceiver, valueBindingData);
-            Assert.Equal(10, bindingData.Count);
+            Assert.Equal(11, bindingData.Count);
             Assert.Equal("override", bindingData["ReplyTo"]);
             Assert.Equal(123, bindingData["NewProperty"]);
         }


### PR DESCRIPTION
By enabling support for the IMessageReceiver to be injected into the ServiceBusTrigger, this makes setting up unit tests for a trigger much easier.