### PR TITLE
adds support for method injection using services registered in the IServiceProvider

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/ServiceProvider/ServiceProviderBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/ServiceProvider/ServiceProviderBinding.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.Protocols;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.Azure.WebJobs.Host.Bindings
+{
+    internal class ServiceProviderBinding : IBinding
+    {
+        private readonly ParameterInfo _parameter;
+        private readonly IServiceProvider _serviceProvider;
+
+        public ServiceProviderBinding(ParameterInfo parameter, IServiceProvider serviceProvider)
+        {
+            _parameter = parameter;
+            _serviceProvider = serviceProvider;
+        }
+
+        public Task<IValueProvider> BindAsync(object value, ValueBindingContext context)
+        {
+            return Task.FromResult<IValueProvider>(new ObjectValueProvider(value, _parameter.ParameterType));
+        }
+
+        public Task<IValueProvider> BindAsync(BindingContext context)
+        {
+            return BindAsync(_serviceProvider.GetRequiredService(_parameter.ParameterType), context.ValueContext);
+        }
+
+        public ParameterDescriptor ToParameterDescriptor()
+        {
+            return new ParameterDescriptor
+            {
+                Name = _parameter.Name
+            };
+        }
+
+        public bool FromAttribute => false;
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/ServiceProvider/ServiceProviderBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/ServiceProvider/ServiceProviderBindingProvider.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.WebJobs.Host.Bindings
+{
+    /// <summary>
+    /// Binding provider for registered services in <see cref="IServiceProvider"/>.
+    /// </summary>
+    internal class ServiceProviderBindingProvider : IBindingProvider
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        public ServiceProviderBindingProvider(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
+        public Task<IBinding> TryCreateAsync(BindingProviderContext context)
+        {
+            return Task.FromResult<IBinding>(new ServiceProviderBinding(context.Parameter, _serviceProvider));
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsBuilderExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsBuilderExtensions.cs
@@ -175,6 +175,9 @@ namespace Microsoft.Azure.WebJobs
             // arbitrary binding to binding data 
             builder.Services.AddSingleton<IBindingProvider, DataBindingProvider>();
 
+            // for any type registered as a service via dependency injection
+            builder.Services.AddSingleton<IBindingProvider, ServiceProviderBindingProvider>();
+
             return builder;
         }
     }

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/DependencyInjection/MethodDependencyInjectionTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/DependencyInjection/MethodDependencyInjectionTests.cs
@@ -1,0 +1,210 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Host.FunctionalTests.DependencyInjection
+{
+    public class MethodDependencyInjectionTests
+    {
+        [Fact]
+        public async Task AssertInvalidServiceConfiguration()
+        {
+            var expectedMessage = $"No service for type '{typeof(MethodDependencyInjectionTests).FullName}+{nameof(IServiceA)}' has been registered.";
+            var host = new HostBuilder()
+                .ConfigureDefaultTestHost<Program>()
+                .Build();
+            var jobHost = host.GetJobHost<Program>();
+            var functionInvocationException = await Assert.ThrowsAsync<FunctionInvocationException>(async () => await jobHost.CallAsync(nameof(Program.Func1), null));
+            var baseException = functionInvocationException.GetBaseException();
+
+            Assert.NotNull(baseException);
+            Assert.IsType<InvalidOperationException>(baseException);
+            Assert.Equal(expectedMessage, baseException.Message);
+        }
+
+        [Fact]
+        public async Task AssertSuccessfulMethodInjectionWithNoParameters()
+        {
+            var host = new HostBuilder()
+                .ConfigureDefaultTestHost<Program>()
+                .ConfigureServices(services => { services.AddSingleton<IServiceA, ServiceA1>(); })
+                .Build();
+            var jobHost = host.GetJobHost<Program>();
+            await jobHost.CallAsync(nameof(Program.Func0), null);
+        }
+
+        [Fact]
+        public async Task AssertSuccessfulMethodInjectionWithOneInjectedService()
+        {
+            var host = new HostBuilder()
+                .ConfigureDefaultTestHost<Program>()
+                .ConfigureServices(services => { services.AddSingleton<IServiceA, ServiceA1>(); })
+                .Build();
+            var jobHost = host.GetJobHost<Program>();
+            await jobHost.CallAsync(nameof(Program.Func1), null);
+        }
+
+        [Fact]
+        public async Task AssertSuccessfulMethodInjectionWithOneInjectedServiceAndARuntimeArgument()
+        {
+            var host = new HostBuilder()
+                .ConfigureDefaultTestHost<Program>()
+                .ConfigureServices(services => { services.AddSingleton<IServiceA, ServiceA1>(); })
+                .Build();
+            var jobHost = host.GetJobHost<Program>();
+            var arguments = new Dictionary<string, object>
+            {
+                {"valueB", 4}
+            };
+            await jobHost.CallAsync(nameof(Program.Func2), arguments);
+        }
+
+        [Fact]
+        public async Task AssertSuccessfulMethodInjectionWithTwoParametersOfTheSameService()
+        {
+            var host = new HostBuilder()
+                .ConfigureDefaultTestHost<Program>()
+                .ConfigureServices(services => { services.AddSingleton<IServiceA, ServiceA1>(); })
+                .Build();
+            var jobHost = host.GetJobHost<Program>();
+            await jobHost.CallAsync(nameof(Program.Func3), null);
+        }
+
+        [Fact]
+        public async Task AssertSuccessfulMethodInjectionWithIEnumerableOfService()
+        {
+            var host = new HostBuilder()
+                .ConfigureDefaultTestHost<Program>()
+                .ConfigureServices(services => { services.AddSingleton<IServiceA, ServiceA1>(); })
+                .ConfigureServices(services => { services.AddSingleton<IServiceA, ServiceA2>(); })
+                .Build();
+            var jobHost = host.GetJobHost<Program>();
+            await jobHost.CallAsync(nameof(Program.Func4), null);
+        }
+
+        [Fact]
+        public async Task AssertSuccessfulMethodInjectionWithRuntimeArgumentTakingPrecedenceOverInjectedService()
+        {
+            var host = new HostBuilder()
+                .ConfigureDefaultTestHost<Program>()
+                .ConfigureServices(services => { services.AddSingleton<IServiceA, ServiceA1>(); })
+                .Build();
+            var jobHost = host.GetJobHost<Program>();
+            var arguments = new Dictionary<string, object>
+            {
+                {"serviceA", new ServiceA2()}
+            };
+            await jobHost.CallAsync(nameof(Program.Func5), arguments);
+        }
+
+        [Fact]
+        public async Task AssertSuccessfulMethodInjectionWithServiceWhenRuntimeArgumentIsRightTypeButWrongName()
+        {
+            var host = new HostBuilder()
+                .ConfigureDefaultTestHost<Program>()
+                .ConfigureServices(services => { services.AddSingleton<IServiceA, ServiceA1>(); })
+                .Build();
+            var jobHost = host.GetJobHost<Program>();
+            var arguments = new Dictionary<string, object>
+            {
+                {"serviceA2", new ServiceA2()}
+            };
+            await jobHost.CallAsync(nameof(Program.Func6), arguments);
+        }
+
+        #region TestTypes
+
+        public class Program
+        {
+            [NoAutomaticTrigger]
+            [Singleton]
+            public void Func0()
+            {
+            }
+
+            [NoAutomaticTrigger]
+            [Singleton]
+            public void Func1(IServiceA serviceA)
+            {
+                Assert.NotNull(serviceA);
+                Assert.Equal("A1", serviceA.Run());
+            }
+
+            [NoAutomaticTrigger]
+            [Singleton]
+            public void Func2(IServiceA serviceA, int valueB)
+            {
+                Assert.NotNull(serviceA);
+                Assert.Equal(4, valueB);
+            }
+
+            [NoAutomaticTrigger]
+            [Singleton]
+            public void Func3(IServiceA service1, IServiceA service2)
+            {
+                Assert.NotNull(service1);
+                Assert.NotNull(service2);
+                Assert.Equal("A1", service1.Run());
+                Assert.Equal(service1, service2);
+            }
+
+            [NoAutomaticTrigger]
+            [Singleton]
+            public void Func4(IEnumerable<IServiceA> serviceAs)
+            {
+                Assert.NotNull(serviceAs);
+                var services = serviceAs.ToArray();
+                Assert.Equal(2, services.Length);
+                Assert.Equal("A1", services[0].Run());
+                Assert.Equal("A2", services[1].Run());
+            }
+
+            [NoAutomaticTrigger]
+            [Singleton]
+            public void Func5(IServiceA serviceA)
+            {
+                Assert.NotNull(serviceA);
+                Assert.Equal("A2", serviceA.Run());
+            }
+
+            [NoAutomaticTrigger]
+            [Singleton]
+            public void Func6(IServiceA serviceA)
+            {
+                Assert.NotNull(serviceA);
+                Assert.Equal("A1", serviceA.Run());
+            }
+        }
+
+        public interface IServiceA
+        {
+            string Run();
+        }
+
+        public class ServiceA1 : IServiceA
+        {
+            public string Run()
+            {
+                return "A1";
+            }
+        }
+
+        public class ServiceA2 : IServiceA
+        {
+            public string Run()
+            {
+                return "A2";
+            }
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-functions-host/issues/4538.

Addresses method injection without having to explicitly mark method parameters with an attribute as referenced in https://github.com/Azure/azure-functions-host/issues/3736.

@fabiocav @brettsam 