### PR TITLE
Add options to disable telemetry modules

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
@@ -30,10 +30,42 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
         /// <summary>
         /// Gets or sets authentication key for Quick Pulse (Live Metrics).
         /// </summary>
-        public string QuickPulseAuthenticationApiKey { get; set; }
+        [Obsolete("Use LiveMetricsAuthenticationApiKey instead.")]
+        public string QuickPulseAuthenticationApiKey
+        {
+            get
+            {
+                return LiveMetricsAuthenticationApiKey;
+            }
+            set
+            {
+                LiveMetricsAuthenticationApiKey = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets authentication key for Live Metrics.
+        /// </summary>
+        public string LiveMetricsAuthenticationApiKey { get; set; }
 
         /// <summary>
         /// Gets or sets the time to delay Quick Pulse (Live Metrics) initialization. Delaying this initialization
+        /// can result in decreased application startup time. Default value is 15 seconds.
+        /// </summary>
+        [Obsolete("Use LiveMetricsInitializationDelay instead.")]
+        public TimeSpan QuickPulseInitializationDelay {
+            get
+            {
+                return LiveMetricsInitializationDelay;
+            }
+            set
+            {
+                LiveMetricsInitializationDelay = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the time to delay Live Metrics initialization. Delaying this initialization
         /// can result in decreased application startup time. Default value is 15 seconds.
         /// </summary>
         public TimeSpan LiveMetricsInitializationDelay { get; set; } = TimeSpan.FromSeconds(15);
@@ -46,7 +78,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
         public bool EnablePerformanceCountersCollection { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets the flag that enables quick pulse collection.
+        /// Gets or sets the flag that enables live metrics collection.
         /// Enabled by default.
         /// </summary>
         public bool EnableLiveMetrics { get; set; } = true;

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
@@ -46,6 +46,18 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
         public bool EnablePerformanceCountersCollection { get; set; } = true;
 
         /// <summary>
+        /// Gets or sets the flag that enables quick pulse collection.
+        /// Enabled by default.
+        /// </summary>
+        public bool EnableQuickPulse { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the flag that enables dependency tracking.
+        /// Enabled by default.
+        /// </summary>
+        public bool EnableDependencyTracking { get; set; } = true;
+
+        /// <summary>
         /// Gets or sets HTTP request collection options. 
         /// </summary>
         public HttpAutoCollectionOptions HttpAutoCollectionOptions { get; set; } = new HttpAutoCollectionOptions();
@@ -105,7 +117,9 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                 { nameof(SnapshotConfiguration), snapshot },
                 { nameof(EnablePerformanceCountersCollection), EnablePerformanceCountersCollection},
                 { nameof(HttpAutoCollectionOptions), httpOptions},
-                { nameof(QuickPulseInitializationDelay), QuickPulseInitializationDelay }
+                { nameof(QuickPulseInitializationDelay), QuickPulseInitializationDelay },
+                { nameof(EnableQuickPulse), EnableQuickPulse },
+                { nameof(EnableDependencyTracking), EnableDependencyTracking }
             };
 
             return options.ToString(Formatting.Indented);

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
         /// Gets or sets the flag that enables quick pulse collection.
         /// Enabled by default.
         /// </summary>
-        public bool EnableQuickPulse { get; set; } = true;
+        public bool EnableLiveMetrics { get; set; } = true;
 
         /// <summary>
         /// Gets or sets the flag that enables dependency tracking.
@@ -118,7 +118,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                 { nameof(EnablePerformanceCountersCollection), EnablePerformanceCountersCollection},
                 { nameof(HttpAutoCollectionOptions), httpOptions},
                 { nameof(QuickPulseInitializationDelay), QuickPulseInitializationDelay },
-                { nameof(EnableQuickPulse), EnableQuickPulse },
+                { nameof(EnableLiveMetrics), EnableLiveMetrics },
                 { nameof(EnableDependencyTracking), EnableDependencyTracking }
             };
 

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
         /// Gets or sets the time to delay Quick Pulse (Live Metrics) initialization. Delaying this initialization
         /// can result in decreased application startup time. Default value is 15 seconds.
         /// </summary>
-        public TimeSpan QuickPulseInitializationDelay { get; set; } = TimeSpan.FromSeconds(15);
+        public TimeSpan LiveMetricsInitializationDelay { get; set; } = TimeSpan.FromSeconds(15);
 
         /// <summary>
         /// Gets or sets flag that enables Kudu performance counters collection.
@@ -117,7 +117,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                 { nameof(SnapshotConfiguration), snapshot },
                 { nameof(EnablePerformanceCountersCollection), EnablePerformanceCountersCollection},
                 { nameof(HttpAutoCollectionOptions), httpOptions},
-                { nameof(QuickPulseInitializationDelay), QuickPulseInitializationDelay },
+                { nameof(LiveMetricsInitializationDelay), LiveMetricsInitializationDelay },
                 { nameof(EnableLiveMetrics), EnableLiveMetrics },
                 { nameof(EnableDependencyTracking), EnableDependencyTracking }
             };

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
@@ -271,7 +271,7 @@ namespace Microsoft.Extensions.DependencyInjection
                     }
 
                     // QuickPulse can have a startup performance hit, so delay its initialization.
-                    delayer.ScheduleInitialization(() => module.Initialize(configuration), options.QuickPulseInitializationDelay);
+                    delayer.ScheduleInitialization(() => module.Initialize(configuration), options.LiveMetricsInitializationDelay);
                 }
                 else if (module != null)
                 {

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
@@ -265,9 +265,9 @@ namespace Microsoft.Extensions.DependencyInjection
                 if (module is QuickPulseTelemetryModule telemetryModule)
                 {
                     quickPulseModule = telemetryModule;
-                    if (options.QuickPulseAuthenticationApiKey != null)
+                    if (options.LiveMetricsAuthenticationApiKey != null)
                     {
-                        quickPulseModule.AuthenticationApiKey = options.QuickPulseAuthenticationApiKey;
+                        quickPulseModule.AuthenticationApiKey = options.LiveMetricsAuthenticationApiKey;
                     }
 
                     // QuickPulse can have a startup performance hit, so delay its initialization.

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
@@ -56,13 +56,14 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<ITelemetryInitializer, WebJobsTelemetryInitializer>();
             services.AddSingleton<ITelemetryInitializer, MetricSdkVersionTelemetryInitializer>();
             services.AddSingleton<QuickPulseInitializationScheduler>();
+            services.AddSingleton<QuickPulseTelemetryModule>();
 
             services.AddSingleton<ITelemetryModule>(provider =>
             {
                 ApplicationInsightsLoggerOptions options = provider.GetService<IOptions<ApplicationInsightsLoggerOptions>>().Value;
-                if (options.EnableQuickPulse)
+                if (options.EnableLiveMetrics)
                 {
-                    return new QuickPulseTelemetryModule();
+                    return provider.GetService<QuickPulseTelemetryModule>();
                 }
                 return NullTelemetryModule.Instance;
             });
@@ -272,7 +273,7 @@ namespace Microsoft.Extensions.DependencyInjection
                     // QuickPulse can have a startup performance hit, so delay its initialization.
                     delayer.ScheduleInitialization(() => module.Initialize(configuration), options.QuickPulseInitializationDelay);
                 }
-                else
+                else if (module != null)
                 {
                     module.Initialize(configuration);
                 }

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/ApplicationInsightsEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/ApplicationInsightsEndToEndTests.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     {
                         o.InstrumentationKey = _mockApplicationInsightsKey;
                         o.HttpAutoCollectionOptions = httpOptions;
-                        o.QuickPulseInitializationDelay = TimeSpan.FromSeconds(1);
+                        o.LiveMetricsInitializationDelay = TimeSpan.FromSeconds(1);
                     });
                 })
                 .ConfigureServices(services =>

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
@@ -236,6 +236,64 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
         }
 
         [Fact]
+        public void DependencyInjectionConfiguration_DisablesDependencyTracking()
+        {
+            using (var host = new HostBuilder()
+                .ConfigureLogging(b =>
+                {
+                    b.AddApplicationInsights(o =>
+                    {
+                        o.InstrumentationKey = "KI";
+                        o.EnableDependencyTracking = false;
+                    });
+                })
+                .Build())
+            {
+                var modules = host.Services.GetServices<ITelemetryModule>();
+                Assert.True(modules.Count(m => m is DependencyTrackingTelemetryModule) == 0);
+            }
+        }
+
+        [Fact]
+        public void DependencyInjectionConfiguration_DisablesQuickPulseTelemetry()
+        {
+            using (var host = new HostBuilder()
+                .ConfigureLogging(b =>
+                {
+                    b.AddApplicationInsights(o =>
+                    {
+                        o.InstrumentationKey = "LOKI";
+                        o.EnableQuickPulse = false;
+                    });
+                })
+                .Build())
+            {
+                var modules = host.Services.GetServices<ITelemetryModule>();
+                Assert.True(modules.Count(m => m is QuickPulseTelemetryModule) == 0);
+            }
+        }
+
+        [Fact]
+        public void DependencyInjectionConfiguration_EnableTelemetryModulesByDefault()
+        {
+            using (var host = new HostBuilder()
+                .ConfigureLogging(b =>
+                {
+                    b.AddApplicationInsights(o =>
+                    {
+                        o.InstrumentationKey = "LOKI";
+                    });
+                })
+                .Build())
+            {
+                var modules = host.Services.GetServices<ITelemetryModule>();
+                Assert.True(modules.Count(m => m is QuickPulseTelemetryModule) == 1);
+                Assert.True(modules.Count(m => m is DependencyTrackingTelemetryModule) == 1);
+                Assert.True(modules.Count(m => m is PerformanceCollectorModule) == 1);
+            }
+        }
+
+        [Fact]
         public void DependencyInjectionConfiguration_ConfiguresQuickPulseAuthApiKey()
         {
             using (var host = new HostBuilder()

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
@@ -294,7 +294,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
         }
 
         [Fact]
-        public void DependencyInjectionConfiguration_ConfiguresQuickPulseAuthApiKey()
+        public void DependencyInjectionConfiguration_ConfiguresQuickPulseAuthApiKeyDeprecated()
         {
             using (var host = new HostBuilder()
                 .ConfigureLogging(b =>
@@ -302,7 +302,27 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                     b.AddApplicationInsightsWebJobs(o =>
                     {
                         o.InstrumentationKey = "some key";
-                        o.QuickPulseAuthenticationApiKey = "some auth key";
+                        o.QuickPulseAuthenticationApiKey = "some auth key";  // This is deprecated, but still supported
+                    });
+                })
+                .Build())
+            {
+                var modules = host.Services.GetServices<ITelemetryModule>().ToList();
+                var quickPulseTelemetryModule = modules.OfType<QuickPulseTelemetryModule>().Single();
+                Assert.Equal("some auth key", quickPulseTelemetryModule.AuthenticationApiKey);
+            }
+        }
+
+        [Fact]
+        public void DependencyInjectionConfiguration_ConfiguresLiveMetricsAuthApiKey()
+        {
+            using (var host = new HostBuilder()
+                .ConfigureLogging(b =>
+                {
+                    b.AddApplicationInsightsWebJobs(o =>
+                    {
+                        o.InstrumentationKey = "some key";
+                        o.LiveMetricsAuthenticationApiKey = "some auth key";
                     });
                 })
                 .Build())

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
@@ -263,7 +263,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                     b.AddApplicationInsights(o =>
                     {
                         o.InstrumentationKey = "LOKI";
-                        o.EnableQuickPulse = false;
+                        o.EnableLiveMetrics = false;
                     });
                 })
                 .Build())


### PR DESCRIPTION
Helps with #2123 

I still need to test this out in a private site extensions.

The issue talks about allowing selection of perf counters to use. For now, I didn't make that change. As we should discuss if we want to allow users to have a black-list or a white-list. And counter names are like `"\\Process(??APP_WIN32_PROC??)\\% Processor Time Normalized"`. Not sure if we want users to have strings like that in the `host.json` to configure that. They seem too specific to do a string mapping.

@brettsam, thoughts? 