### PR TITLE
Raise HostInitialized callback AFTER listeners are created

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Executors/IJobHostContextFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/IJobHostContextFactory.cs
@@ -11,6 +11,6 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
 {
     public interface IJobHostContextFactory
     {
-        Task<JobHostContext> Create(CancellationToken shutdownToken, CancellationToken cancellationToken);
+        Task<JobHostContext> Create(JobHost host, CancellationToken shutdownToken, CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/JobHost.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/JobHost.cs
@@ -355,11 +355,7 @@ namespace Microsoft.Azure.WebJobs
         {
             try
             {
-                var context = await _jobHostContextFactory.Create(_shutdownTokenSource.Token, cancellationToken);
-
-                // must call this BEFORE setting the results below
-                // since listener startup is blocking on those members
-                OnHostInitialized();
+                var context = await _jobHostContextFactory.Create(this, _shutdownTokenSource.Token, cancellationToken);
 
                 _context = context;
                 _listener = context.Listener;
@@ -377,7 +373,7 @@ namespace Microsoft.Azure.WebJobs
         /// Called when host initialization has been completed, but before listeners
         /// are started.
         /// </summary>
-        protected virtual void OnHostInitialized()
+        protected internal virtual void OnHostInitialized()
         {
         }
 

--- a/src/Microsoft.Azure.WebJobs.Host/Listeners/HostListenerFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Listeners/HostListenerFactory.cs
@@ -27,10 +27,11 @@ namespace Microsoft.Azure.WebJobs.Host.Listeners
         private readonly ILoggerFactory _loggerFactory;
         private readonly ILogger _logger;
         private readonly bool _allowPartialHostStartup;
+        private readonly Action _listenersCreatedCallback;
         private readonly IScaleMonitorManager _monitorManager;
 
         public HostListenerFactory(IEnumerable<IFunctionDefinition> functionDefinitions, SingletonManager singletonManager, IJobActivator activator,
-            INameResolver nameResolver, ILoggerFactory loggerFactory, IScaleMonitorManager monitorManager, bool allowPartialHostStartup = false)
+            INameResolver nameResolver, ILoggerFactory loggerFactory, IScaleMonitorManager monitorManager, Action listenersCreatedCallback, bool allowPartialHostStartup = false)
         {
             _functionDefinitions = functionDefinitions;
             _singletonManager = singletonManager;
@@ -40,6 +41,7 @@ namespace Microsoft.Azure.WebJobs.Host.Listeners
             _logger = _loggerFactory?.CreateLogger(LogCategories.Startup);
             _allowPartialHostStartup = allowPartialHostStartup;
             _monitorManager = monitorManager;
+            _listenersCreatedCallback = listenersCreatedCallback;
         }
 
         public async Task<IListener> CreateAsync(CancellationToken cancellationToken)
@@ -77,6 +79,8 @@ namespace Microsoft.Azure.WebJobs.Host.Listeners
                 listener = new FunctionListener(listener, functionDefinition.Descriptor, _loggerFactory, _allowPartialHostStartup);
                 listeners.Add(listener);
             }
+
+            _listenersCreatedCallback?.Invoke();
 
             return new CompositeListener(listeners);
         }

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/HostListenerFactoryTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/HostListenerFactoryTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Listeners
             functions.Add(definition);
 
             var monitorManager = new ScaleMonitorManager();
-            HostListenerFactory factory = new HostListenerFactory(functions, singletonManager, _jobActivator, null, loggerFactory, monitorManager);
+            HostListenerFactory factory = new HostListenerFactory(functions, singletonManager, _jobActivator, null, loggerFactory, monitorManager, () => {});
             IListener listener = await factory.CreateAsync(CancellationToken.None);
 
             var innerListeners = ((IEnumerable<IListener>)listener).ToArray();
@@ -130,7 +130,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Listeners
             // Create the composite listener - this will fail if any of the
             // function definitions indicate that they are not disabled
             var monitorManagerMock = new Mock<IScaleMonitorManager>(MockBehavior.Strict);
-            HostListenerFactory factory = new HostListenerFactory(functions, singletonManager, _jobActivator, null, loggerFactory, monitorManagerMock.Object);
+            HostListenerFactory factory = new HostListenerFactory(functions, singletonManager, _jobActivator, null, loggerFactory, monitorManagerMock.Object, () => { });
+
             IListener listener = await factory.CreateAsync(CancellationToken.None);
 
             string expectedMessage = $"Function '{descriptor.ShortName}' is disabled";

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/JobHostTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/JobHostTests.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             // Arrange
             // Create a way to block StartAsync.
             TaskCompletionSource<JobHostContext> createTaskSource = new TaskCompletionSource<JobHostContext>();
-            var provider = new LambdaJobHostContextFactory((a, b) => createTaskSource.Task);
+            var provider = new LambdaJobHostContextFactory((a, b, c) => createTaskSource.Task);
 
             var host = new HostBuilder()
                 .ConfigureDefaultTestHost()
@@ -222,7 +222,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             // Arrange
             // Create a way to block StartAsync.
             TaskCompletionSource<JobHostContext> createTaskSource = new TaskCompletionSource<JobHostContext>();
-            var provider = new LambdaJobHostContextFactory((a, b) => createTaskSource.Task);
+            var provider = new LambdaJobHostContextFactory((a, b, c) => createTaskSource.Task);
 
             var host = new HostBuilder()
                 .ConfigureDefaultTestHost()
@@ -641,16 +641,16 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
 
         private class LambdaJobHostContextFactory : IJobHostContextFactory
         {
-            private readonly Func<CancellationToken, CancellationToken, Task<JobHostContext>> _create;
+            private readonly Func<JobHost, CancellationToken, CancellationToken, Task<JobHostContext>> _create;
 
-            public LambdaJobHostContextFactory(Func<CancellationToken, CancellationToken, Task<JobHostContext>> create)
+            public LambdaJobHostContextFactory(Func<JobHost, CancellationToken, CancellationToken, Task<JobHostContext>> create)
             {
                 _create = create;
             }
 
-            public Task<JobHostContext> Create(CancellationToken shutdownToken, CancellationToken cancellationToken)
+            public Task<JobHostContext> Create(JobHost host, CancellationToken shutdownToken, CancellationToken cancellationToken)
             {
-                return _create.Invoke(shutdownToken, cancellationToken);
+                return _create.Invoke(host, shutdownToken, cancellationToken);
             }
         }
 


### PR DESCRIPTION
We made this fix in v2, but never merged to v3. See https://github.com/Azure/azure-webjobs-sdk/pull/2104