### PR TITLE
Add support for generating batch param type for generic bindings

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingProviders/TriggerAdapterBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingProviders/TriggerAdapterBindingProvider.cs
@@ -43,7 +43,9 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
 
         public Type GetDefaultType(Attribute attribute, FileAccess access, Type requestedType)
         {
-            foreach (var target in _defaultTypes)
+            IEnumerable<Type> targets = (requestedType != typeof(object)) ? new Type[] { requestedType } : _defaultTypes;
+
+            foreach (var target in targets)
             {
                 if (_converterManager.HasConverter<TAttribute>(typeof(TTriggerValue), target))
                 {

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/Indexers/FunctionIndexerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/Indexers/FunctionIndexerTests.cs
@@ -214,11 +214,11 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Indexers
 
         [AttributeUsage(AttributeTargets.Parameter)]
         [Binding]
-        public class ExtensionTrigger : Attribute
+        public class ExtensionTriggerAttribute : Attribute
         {
             private string _path;
 
-            public ExtensionTrigger(string path)
+            public ExtensionTriggerAttribute(string path)
             {
                 _path = path;
             }
@@ -231,11 +231,11 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Indexers
 
         [AttributeUsage(AttributeTargets.Parameter)]
         [Binding]
-        public class Extension : Attribute
+        public class ExtensionAttribute : Attribute
         {
             private string _path;
 
-            public Extension(string path)
+            public ExtensionAttribute(string path)
             {
                 _path = path;
             }
@@ -303,7 +303,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Indexers
             throw new NotImplementedException();
         }
 
-        public static void MethodWithExtensionJobParameterAttributes([ExtensionTrigger("path")] string input, [@Extension("path")] TextWriter writer)
+        public static void MethodWithExtensionJobParameterAttributes([ExtensionTrigger("path")] string input, [Extension("path")] TextWriter writer)
         {
             throw new NotImplementedException();
         }

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/JobHostMetadataProviderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/JobHostMetadataProviderTests.cs
@@ -202,8 +202,11 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             Assert.Equal(typeof(IAsyncCollector<byte[]>), t3);
         }
 
-        [Fact]
-        public void TestBatchFluentDefaultType()
+        [Theory]
+        [InlineData(typeof(object[]))]
+        [InlineData(typeof(string[]))]
+        [InlineData(typeof(SomeData[]))]
+        public void TestBatchFluentDefaultType(Type requestedType)
         {
             IHost host = new HostBuilder()
                 .ConfigureDefaultTestHost(b =>
@@ -214,8 +217,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
 
             var metadataProvider = host.CreateMetadataProvider();
 
-            var dataType = metadataProvider.GetDefaultType(new TestAttribute(), FileAccess.Read, typeof(object[]));
-            Assert.Equal(typeof(object[]), dataType);
+            var dataType = metadataProvider.GetDefaultType(new TestAttribute(), FileAccess.Read, requestedType);
+            Assert.Equal(requestedType, dataType);
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/JobHostMetadataProviderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/JobHostMetadataProviderTests.cs
@@ -2,8 +2,17 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Description;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Azure.WebJobs.Host.Config;
+using Microsoft.Azure.WebJobs.Host.Listeners;
+using Microsoft.Azure.WebJobs.Host.Protocols;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Microsoft.Azure.WebJobs.Host.Triggers;
 using Microsoft.Extensions.Hosting;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -17,6 +26,58 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         {
             var attribute = metadataProvider.GetAttribute(typeof(T), JObject.FromObject(obj));
             return (T)attribute;
+        }
+
+        class MyTriggerBinding : ITriggerBinding
+        {
+            public Type TriggerValueType => typeof(SomeData);
+
+            public IReadOnlyDictionary<string, Type> BindingDataContract => new Dictionary<string, Type>(); // empty
+
+            public Task<ITriggerData> BindAsync(object value, ValueBindingContext context)
+            {
+                return Task.FromResult<ITriggerData>(new TriggerData(new Dictionary<string, object>()));
+            }
+
+            public Task<IListener> CreateListenerAsync(ListenerFactoryContext context)
+            {
+                return Task.FromResult<IListener>(new NullListener());
+            }
+
+            public ParameterDescriptor ToParameterDescriptor()
+            {
+                return new ParameterDescriptor();
+            }
+        }
+
+        class MyTriggerBindingProvider : ITriggerBindingProvider
+        {
+            public Task<ITriggerBinding> TryCreateAsync(TriggerBindingProviderContext context)
+            {
+                return Task.FromResult<ITriggerBinding>(new MyTriggerBinding());
+            }
+        }
+
+        [Binding]
+        public class TestAttribute : Attribute
+        {
+        }
+
+        public class SomeData
+        {
+            public string Message { get; set; }
+        }
+
+        class FluentExtensionConfig : IExtensionConfigProvider
+        {
+            public void Initialize(ExtensionConfigContext context)
+            {
+                var rule = context.AddBindingRule<TestAttribute>();
+                rule.BindToTrigger<SomeData[]>(new MyTriggerBindingProvider());
+
+                rule.AddConverter<SomeData[], string[]>(
+                    msgs => msgs.Select(m => m.Message).ToArray());
+            }
         }
 
         [Fact]
@@ -139,6 +200,22 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             // so byte[] is the safest default. 
             var t3 = metadataProvider.GetDefaultType(new QueueAttribute("q"), FileAccess.Write, null);
             Assert.Equal(typeof(IAsyncCollector<byte[]>), t3);
-        }      
+        }
+
+        [Fact]
+        public void TestBatchFluentDefaultType()
+        {
+            IHost host = new HostBuilder()
+                .ConfigureDefaultTestHost(b =>
+                {
+                    b.AddExtension<FluentExtensionConfig>();
+                })
+                .Build();
+
+            var metadataProvider = host.CreateMetadataProvider();
+
+            var dataType = metadataProvider.GetDefaultType(new TestAttribute(), FileAccess.Read, typeof(object[]));
+            Assert.Equal(typeof(object[]), dataType);
+        }
     }
 }


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-webjobs-sdk/issues/2287