### PR TITLE
bumping build version

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -1,9 +1,8 @@
 <Project>
   <PropertyGroup>
     <!-- Extensions can have independent versions and only increment when released -->
-    <Version>3.0.10$(VersionSuffix)</Version>
+    <Version>3.0.11$(VersionSuffix)</Version>
     <ExtensionsEventHubsVersion>3.0.6$(VersionSuffix)</ExtensionsEventHubsVersion>
-    <ExtensionsServiceBusVersion>3.0.6$(VersionSuffix)</ExtensionsServiceBusVersion>
     <ExtensionsStorageVersion>3.0.7$(VersionSuffix)</ExtensionsStorageVersion>
 
     <TargetFramework>netstandard2.0</TargetFramework>


### PR DESCRIPTION
Moving core nugets to 3.0.11; ~~trying to debug a nuget restore issue that happens intermittently.~~ Figured out the issue -- we had a rogue package in azure-appservice and nuget doesn't respect ordering in nuget.config. Instead, it loads the first one that replies back! So we were getting a bunch of random build failures. I've hidden the rogue package.