### PR TITLE
adding additional queue logging

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Listeners/SharedBlobQueueListenerFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Listeners/SharedBlobQueueListenerFactory.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Listeners;
+using Microsoft.Azure.WebJobs.Host.Protocols;
 using Microsoft.Azure.WebJobs.Host.Queues;
 using Microsoft.Azure.WebJobs.Host.Queues.Listeners;
 using Microsoft.Azure.WebJobs.Host.Timers;
@@ -21,6 +22,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
         private readonly QueuesOptions _queueOptions;
         private readonly IWebJobsExceptionHandler _exceptionHandler;
         private readonly IBlobWrittenWatcher _blobWrittenWatcher;
+        private readonly FunctionDescriptor _functionDescriptor;
         private readonly StorageAccount _hostAccount;
         private readonly ILoggerFactory _loggerFactory;
 
@@ -31,7 +33,8 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
             QueuesOptions queueOptions,
             IWebJobsExceptionHandler exceptionHandler,
             ILoggerFactory loggerFactory,
-            IBlobWrittenWatcher blobWrittenWatcher)
+            IBlobWrittenWatcher blobWrittenWatcher,
+            FunctionDescriptor functionDescriptor)
         {
             _hostAccount = hostAccount ?? throw new ArgumentNullException(nameof(hostAccount));
             _sharedQueueWatcher = sharedQueueWatcher ?? throw new ArgumentNullException(nameof(sharedQueueWatcher));
@@ -40,6 +43,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
             _exceptionHandler = exceptionHandler ?? throw new ArgumentNullException(nameof(exceptionHandler));
             _loggerFactory = loggerFactory;
             _blobWrittenWatcher = blobWrittenWatcher ?? throw new ArgumentNullException(nameof(blobWrittenWatcher));
+            _functionDescriptor = functionDescriptor;
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]
@@ -59,7 +63,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
             // So we define our own custom queue processor factory for this listener
             var queueProcessorFactory = new SharedBlobQueueProcessorFactory(triggerExecutor, _hostBlobTriggerQueue, _loggerFactory, _queueOptions, defaultPoisonQueue);
             IListener listener = new QueueListener(_hostBlobTriggerQueue, defaultPoisonQueue, triggerExecutor, _exceptionHandler, _loggerFactory,
-                _sharedQueueWatcher, _queueOptions, queueProcessorFactory);
+                _sharedQueueWatcher, _queueOptions, queueProcessorFactory, functionDescriptor: _functionDescriptor);
 
             return new SharedBlobQueueListener(listener, triggerExecutor);
         }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Triggers/BlobTriggerBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Triggers/BlobTriggerBinding.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Triggers
 
             var factory = new BlobListenerFactory(_hostIdProvider, _queueOptions, _blobsOptions, _exceptionHandler,
                 _blobWrittenWatcherSetter, _messageEnqueuedWatcherSetter, _sharedContextProvider, _loggerFactory,
-                context.Descriptor.Id, _hostAccount, _dataAccount, container, _path, context.Executor, _singletonManager);
+                context.Descriptor, _hostAccount, _dataAccount, container, _path, context.Executor, _singletonManager);
 
             return factory.CreateAsync(context.CancellationToken);
         }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Queues/Listeners/QueueListener.Logger.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Queues/Listeners/QueueListener.Logger.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Host.Queues.Listeners
+{
+    internal sealed partial class QueueListener
+    {
+        private static class Logger
+        {
+            private static readonly Action<ILogger, string, string, string, int, long, Exception> _getMessages =
+                LoggerMessage.Define<string, string, string, int, long>(LogLevel.Debug, new EventId(1, nameof(GetMessages)),
+                    "Poll for function '{functionName}' on queue '{queueName}' with ClientRequestId '{clientRequestId}' found {messageCount} messages in {pollLatency} ms.");
+
+            private static readonly Action<ILogger, string, double, string, Exception> _backoffDelay =
+                LoggerMessage.Define<string, double, string>(LogLevel.Debug, new EventId(2, nameof(BackoffDelay)),
+                    "Function '{functionName}' will wait {pollDelay} ms before polling queue '{queueName}'.");
+
+            public static void GetMessages(ILogger logger, string functionName, string queueName, string clientRequestId, int messageCount, long pollLatency) =>
+                _getMessages(logger, functionName, queueName, clientRequestId, messageCount, pollLatency, null);
+
+            public static void BackoffDelay(ILogger logger, string functionName, string queueName, double pollDelay) =>
+                _backoffDelay(logger, functionName, pollDelay, queueName, null);
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Queues/Triggers/QueueTriggerBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Queues/Triggers/QueueTriggerBinding.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Triggers
             }
 
             var factory = new QueueListenerFactory(_queue, _queueOptions, _exceptionHandler,
-                    _messageEnqueuedWatcherSetter, _loggerFactory, context.Executor, _queueProcessorFactory);
+                    _messageEnqueuedWatcherSetter, _loggerFactory, context.Executor, _queueProcessorFactory, context.Descriptor);
 
             return factory.CreateAsync(context.CancellationToken);
         }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/StorageLoadBalancerQueue.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/StorageLoadBalancerQueue.cs
@@ -33,7 +33,7 @@ namespace WebJobs.Extensions.Storage
             StorageAccountProvider storageAccountProvider,
                IOptions<QueuesOptions> queueOptions,
                IWebJobsExceptionHandler exceptionHandler,
-               SharedQueueWatcher sharedWatcher, 
+               SharedQueueWatcher sharedWatcher,
                ILoggerFactory loggerFactory,
                IQueueProcessorFactory queueProcessorFactory)
         {
@@ -44,7 +44,7 @@ namespace WebJobs.Extensions.Storage
             _loggerFactory = loggerFactory;
             _queueProcessorFactory = queueProcessorFactory;
         }
-        
+
         public IAsyncCollector<T> GetQueueWriter<T>(string queue)
         {
             return new QueueWriter<T>(this, Convert(queue));
@@ -65,7 +65,7 @@ namespace WebJobs.Extensions.Storage
             public async Task AddAsync(T item, CancellationToken cancellationToken = default(CancellationToken))
             {
                 string contents = JsonConvert.SerializeObject(
-                    item, 
+                    item,
                     JsonSerialization.Settings);
 
                 var msg = new CloudQueueMessage(contents);
@@ -91,7 +91,7 @@ namespace WebJobs.Extensions.Storage
         public IListener CreateQueueListenr(
             string queue,
             string poisonQueue,
-            Func<string, CancellationToken,  Task<FunctionResult>> callback
+            Func<string, CancellationToken, Task<FunctionResult>> callback
             )
         {
             // Provide an upper bound on the maximum polling interval for run/abort from dashboard.
@@ -111,6 +111,7 @@ namespace WebJobs.Extensions.Storage
                 sharedWatcher: _sharedWatcher,
                 queueOptions: _queueOptions,
                 queueProcessorFactory: _queueProcessorFactory,
+                functionDescriptor: new FunctionDescriptor(),
                 maxPollingInterval: maxPollingInterval);
 
             return listener;

--- a/src/Microsoft.Azure.WebJobs.Protocols/FunctionDescriptor.cs
+++ b/src/Microsoft.Azure.WebJobs.Protocols/FunctionDescriptor.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 #if PUBLICPROTOCOL
 namespace Microsoft.Azure.WebJobs.Protocols
 #else
-using Microsoft.Azure.WebJobs.Host;
 using Newtonsoft.Json;
 namespace Microsoft.Azure.WebJobs.Host.Protocols
 #endif
@@ -35,7 +34,7 @@ namespace Microsoft.Azure.WebJobs.Host.Protocols
 #else
         /// <summary>Gets or sets the name used for logging. This is 'Method' or the value overwritten by [FunctionName] </summary>
         [JsonIgnore]
-        internal string LogName { get; set; }
+        public string LogName { get; set; }
 
         /// <summary>Gets or sets whether this method is disabled. </summary>
         [JsonIgnore]


### PR DESCRIPTION
We're getting a lot of CRIs that require us to figure out why queue messages are being missed or why they're taking longer than expected. We don't really have any insight into this today. I'm adding two new logs that will help us be able to diagnose these problems.

@FinVamp1 FYI... this may be useful for you.