### PR TITLE
[Storage] raise an unhandled exception if we detect a hang in a storage operation

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Listeners/CloudBlobClientExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Listeners/CloudBlobClientExtensions.cs
@@ -5,6 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Extensions.Storage;
+using Microsoft.Azure.WebJobs.Host.Timers;
+using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
 
 namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
@@ -12,8 +15,8 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
     internal static class CloudBlobClientExtensions
     {
         public static async Task<IEnumerable<IListBlobItem>> ListBlobsAsync(this CloudBlobClient client,
-            string prefix, bool useFlatBlobListing, BlobListingDetails blobListingDetails,
-            CancellationToken cancellationToken)
+            string prefix, bool useFlatBlobListing, BlobListingDetails blobListingDetails, string operationName,
+            IWebJobsExceptionHandler exceptionHandler, CancellationToken cancellationToken)
         {
             if (client == null)
             {
@@ -26,8 +29,12 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
 
             do
             {
-                result = await client.ListBlobsSegmentedAsync(prefix, useFlatBlobListing, blobListingDetails,
-                    maxResults: null, currentToken: continuationToken, options: null, operationContext: null);
+                OperationContext context = new OperationContext { ClientRequestID = Guid.NewGuid().ToString() };
+                result = await TimeoutHandler.ExecuteWithTimeout(operationName, context.ClientRequestID, exceptionHandler, () =>
+                {
+                    return client.ListBlobsSegmentedAsync(prefix, useFlatBlobListing, blobListingDetails,
+                        maxResults: null, currentToken: continuationToken, options: null, operationContext: context);
+                });
 
                 if (result != null)
                 {

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/TimeoutHandler.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/TimeoutHandler.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.Timers;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Storage
+{
+    internal static class TimeoutHandler
+    {
+        private static readonly TimeSpan DefaultTimeout = TimeSpan.FromMinutes(2);
+
+        public static async Task<T> ExecuteWithTimeout<T>(string operationName, string clientRequestId, IWebJobsExceptionHandler exceptionHandler, Func<Task<T>> operation)
+        {
+            using (var cts = new CancellationTokenSource())
+            {
+                Task timeoutTask = Task.Delay(DefaultTimeout, cts.Token);
+                Task<T> operationTask = operation();
+
+                Task completedTask = await Task.WhenAny(timeoutTask, operationTask);
+
+                if (Equals(timeoutTask, completedTask))
+                {
+                    ExceptionDispatchInfo exceptionDispatchInfo;
+                    try
+                    {
+                        throw new TimeoutException($"The operation '{operationName}' with id '{clientRequestId}' did not complete in '{DefaultTimeout}'.");
+                    }
+                    catch (TimeoutException ex)
+                    {
+                        exceptionDispatchInfo = ExceptionDispatchInfo.Capture(ex);
+                    }
+
+                    await exceptionHandler.OnUnhandledExceptionAsync(exceptionDispatchInfo);
+
+                    return default(T);
+                }
+
+                // Cancel the Delay.
+                cts.Cancel();
+
+                return await operationTask;
+            }
+        }
+    }
+}

--- a/test/FakeStorage/Blob/FakeStorageBlobClient.cs
+++ b/test/FakeStorage/Blob/FakeStorageBlobClient.cs
@@ -122,12 +122,7 @@ namespace FakeStorage
             if (options != null)
             {
                 throw new NotImplementedException();
-            }
-
-            if (operationContext != null)
-            {
-                throw new NotImplementedException();
-            }
+            }           
 
             Func<string, FakeStorageBlobContainer> containerFactory = (n) => new FakeStorageBlobContainer(this, n);
             BlobResultSegment segment = _store.ListBlobsSegmented(containerFactory, prefix, useFlatBlobListing,

--- a/test/FakeStorage/Blob/FakeStorageBlobContainer.cs
+++ b/test/FakeStorage/Blob/FakeStorageBlobContainer.cs
@@ -230,12 +230,7 @@ namespace FakeStorage
             if (options != null)
             {
                 throw new NotImplementedException();
-            }
-
-            if (operationContext != null)
-            {
-                throw new NotImplementedException();
-            }
+            }            
 
             string fullPrefix;
 

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/TestExceptionHandler.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/TestExceptionHandler.cs
@@ -15,25 +15,24 @@ namespace Microsoft.Azure.WebJobs.Host.TestCommon
         private TestExceptionHandler _handler = new TestExceptionHandler();
 
         public IWebJobsExceptionHandler Create(IHost jobHost) => _handler;
+    }
 
-
-        private class TestExceptionHandler : IWebJobsExceptionHandler
+    public class TestExceptionHandler : IWebJobsExceptionHandler
+    {
+        public void Initialize(JobHost host)
         {
-            public void Initialize(JobHost host)
-            {
-            }
+        }
 
-            public Task OnTimeoutExceptionAsync(ExceptionDispatchInfo exceptionInfo, TimeSpan timeoutGracePeriod)
-            {
-                Assert.True(false, $"Timeout exception in test exception handler: {exceptionInfo.SourceException}");
-                return Task.CompletedTask;
-            }
+        public Task OnTimeoutExceptionAsync(ExceptionDispatchInfo exceptionInfo, TimeSpan timeoutGracePeriod)
+        {
+            Assert.True(false, $"Timeout exception in test exception handler: {exceptionInfo.SourceException}");
+            return Task.CompletedTask;
+        }
 
-            public Task OnUnhandledExceptionAsync(ExceptionDispatchInfo exceptionInfo)
-            {
-                Assert.True(false, $"Error in test exception handler: {exceptionInfo.SourceException}");
-                return Task.CompletedTask;
-            }
+        public Task OnUnhandledExceptionAsync(ExceptionDispatchInfo exceptionInfo)
+        {
+            Assert.True(false, $"Error in test exception handler: {exceptionInfo.SourceException}");
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/Microsoft.Azure.Webjobs.Extensions.Storage.UnitTests/Blobs/Listeners/ScanBlobScanLogHybridPollingStrategyTests.cs
+++ b/test/Microsoft.Azure.Webjobs.Extensions.Storage.UnitTests/Blobs/Listeners/ScanBlobScanLogHybridPollingStrategyTests.cs
@@ -13,6 +13,8 @@ using FakeStorage;
 using Microsoft.Azure.WebJobs.Host.Blobs.Listeners;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Listeners;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Microsoft.Azure.WebJobs.Host.Timers;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
 using Xunit;
@@ -21,13 +23,15 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests.Blobs.Listeners
 {
     public class ScanBlobScanLogHybridPollingStrategyTests
     {
+        private IWebJobsExceptionHandler _exceptionHandler = new TestExceptionHandler();
+
         [Fact]
         public async Task ScanBlobScanLogHybridPollingStrategyTestBlobListener()
         {
             string containerName = Path.GetRandomFileName();
             var account = CreateFakeStorageAccount();
             var container = account.CreateCloudBlobClient().GetContainerReference(containerName);
-            IBlobListenerStrategy product = new ScanBlobScanLogHybridPollingStrategy(new TestBlobScanInfoManager());
+            IBlobListenerStrategy product = new ScanBlobScanLogHybridPollingStrategy(new TestBlobScanInfoManager(), _exceptionHandler);
             LambdaBlobTriggerExecutor executor = new LambdaBlobTriggerExecutor();
             product.Register(container, executor);
             product.Start();
@@ -49,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests.Blobs.Listeners
             string containerName = Path.GetRandomFileName();
             var account = CreateFakeStorageAccount();
             var container = account.CreateCloudBlobClient().GetContainerReference(containerName);
-            IBlobListenerStrategy product = new ScanBlobScanLogHybridPollingStrategy(new TestBlobScanInfoManager());
+            IBlobListenerStrategy product = new ScanBlobScanLogHybridPollingStrategy(new TestBlobScanInfoManager(), _exceptionHandler);
             LambdaBlobTriggerExecutor executor = new LambdaBlobTriggerExecutor();
             typeof(ScanBlobScanLogHybridPollingStrategy)
                    .GetField("_scanBlobLimitPerPoll", BindingFlags.Instance | BindingFlags.NonPublic)
@@ -80,7 +84,7 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests.Blobs.Listeners
             var account = CreateFakeStorageAccount();
             var firstContainer = account.CreateCloudBlobClient().GetContainerReference(firstContainerName);
             var secondContainer = account.CreateCloudBlobClient().GetContainerReference(secondContainerName);
-            IBlobListenerStrategy product = new ScanBlobScanLogHybridPollingStrategy(new TestBlobScanInfoManager());
+            IBlobListenerStrategy product = new ScanBlobScanLogHybridPollingStrategy(new TestBlobScanInfoManager(), _exceptionHandler);
             LambdaBlobTriggerExecutor executor = new LambdaBlobTriggerExecutor();
             typeof(ScanBlobScanLogHybridPollingStrategy)
                    .GetField("_scanBlobLimitPerPoll", BindingFlags.Instance | BindingFlags.NonPublic)
@@ -133,7 +137,7 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests.Blobs.Listeners
                         blob.Properties.SetLastModified(timeMap[blob.Name]);
                     }
                 });
-            IBlobListenerStrategy product = new ScanBlobScanLogHybridPollingStrategy(new TestBlobScanInfoManager());
+            IBlobListenerStrategy product = new ScanBlobScanLogHybridPollingStrategy(new TestBlobScanInfoManager(), _exceptionHandler);
             LambdaBlobTriggerExecutor executor = new LambdaBlobTriggerExecutor();
             typeof(ScanBlobScanLogHybridPollingStrategy)
                    .GetField("_scanBlobLimitPerPoll", BindingFlags.Instance | BindingFlags.NonPublic)
@@ -180,7 +184,7 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests.Blobs.Listeners
                     }
                 });
 
-            IBlobListenerStrategy product = new ScanBlobScanLogHybridPollingStrategy(new TestBlobScanInfoManager());
+            IBlobListenerStrategy product = new ScanBlobScanLogHybridPollingStrategy(new TestBlobScanInfoManager(), _exceptionHandler);
             LambdaBlobTriggerExecutor executor = new LambdaBlobTriggerExecutor();
             typeof(ScanBlobScanLogHybridPollingStrategy)
                    .GetField("_scanBlobLimitPerPoll", BindingFlags.Instance | BindingFlags.NonPublic)
@@ -210,7 +214,7 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests.Blobs.Listeners
             var account = CreateFakeStorageAccount();
             var container = account.CreateCloudBlobClient().GetContainerReference(containerName);
             TestBlobScanInfoManager scanInfoManager = new TestBlobScanInfoManager();
-            IBlobListenerStrategy product = new ScanBlobScanLogHybridPollingStrategy(scanInfoManager);
+            IBlobListenerStrategy product = new ScanBlobScanLogHybridPollingStrategy(scanInfoManager, _exceptionHandler);
             LambdaBlobTriggerExecutor executor = new LambdaBlobTriggerExecutor();
 
             // Create a few blobs.
@@ -244,7 +248,7 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests.Blobs.Listeners
             string accountName = account.Name;
             testScanInfoManager.SetScanInfo(accountName, firstContainerName, DateTime.MinValue);
             testScanInfoManager.SetScanInfo(accountName, secondContainerName, DateTime.MinValue);
-            IBlobListenerStrategy product = new ScanBlobScanLogHybridPollingStrategy(testScanInfoManager);
+            IBlobListenerStrategy product = new ScanBlobScanLogHybridPollingStrategy(testScanInfoManager, _exceptionHandler);
             LambdaBlobTriggerExecutor executor = new LambdaBlobTriggerExecutor();
             typeof(ScanBlobScanLogHybridPollingStrategy)
                   .GetField("_scanBlobLimitPerPoll", BindingFlags.Instance | BindingFlags.NonPublic)
@@ -307,7 +311,7 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests.Blobs.Listeners
             TestBlobScanInfoManager testScanInfoManager = new TestBlobScanInfoManager();
             string accountName = account.Name;
             testScanInfoManager.SetScanInfo(accountName, containerName, DateTime.MinValue);
-            IBlobListenerStrategy product = new ScanBlobScanLogHybridPollingStrategy(testScanInfoManager);
+            IBlobListenerStrategy product = new ScanBlobScanLogHybridPollingStrategy(testScanInfoManager, _exceptionHandler);
             LambdaBlobTriggerExecutor executor = new LambdaBlobTriggerExecutor();
             typeof(ScanBlobScanLogHybridPollingStrategy)
                   .GetField("_scanBlobLimitPerPoll", BindingFlags.Instance | BindingFlags.NonPublic)

--- a/test/Microsoft.Azure.Webjobs.Extensions.Storage.UnitTests/Blobs/Listeners/StorageBlobClientExtensionsTests.cs
+++ b/test/Microsoft.Azure.Webjobs.Extensions.Storage.UnitTests/Blobs/Listeners/StorageBlobClientExtensionsTests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Blobs.Listeners;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
 using Moq;
@@ -60,7 +61,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Blobs.Listeners
             // Mock the List function to return the correct blob page
             HashSet<BlobContinuationToken> seenTokens = new HashSet<BlobContinuationToken>();
             BlobResultSegment resultSegment = null;
-            mockClient.Setup(p => p.ListBlobsSegmentedAsync("test", true, BlobListingDetails.None, null, It.IsAny<BlobContinuationToken>(), null, null))
+            mockClient.Setup(p => p.ListBlobsSegmentedAsync("test", true, BlobListingDetails.None, null, It.IsAny<BlobContinuationToken>(), null, It.IsAny<OperationContext>()))
                 .Callback<string, bool, BlobListingDetails, int?, BlobContinuationToken, BlobRequestOptions, OperationContext>(
                     (prefix, useFlatBlobListing, blobListingDetails, maxResultsValue, currentToken, options, operationContext) =>
                     {
@@ -81,7 +82,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Blobs.Listeners
                     })
                 .Returns(() => { return Task.FromResult(resultSegment); });
 
-            IEnumerable<IListBlobItem> results = await mockClient.Object.ListBlobsAsync("test", true, BlobListingDetails.None, CancellationToken.None);
+            IEnumerable<IListBlobItem> results = await mockClient.Object.ListBlobsAsync("test", true, BlobListingDetails.None, "test", new TestExceptionHandler(), CancellationToken.None);
 
             Assert.Equal(blobCount, results.Count());
         }


### PR DESCRIPTION
We're seeing issues with network connections that can cause certain storage operations to deadlock. There's no easy fix as it happens much lower down than we can control. Attempting a fix here where we simply restart the process if this happens.