### PR TITLE
Passing the scoped service provider to bindings and exposing a mechanism to instantiate objects using injected dependencies

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Config/BlobsExtensionConfigProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Config/BlobsExtensionConfigProvider.cs
@@ -186,6 +186,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
                     throw new InvalidOperationException($"Can't convert blob to {typeof(T).FullName}.");
                 }
             }
+
             public async Task<IEnumerable<T>> ConvertAsync(MultiBlobContext context, CancellationToken cancellationToken)
             {
                 // Query the blob container using the blob prefix (if specified)
@@ -209,7 +210,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
                 {
                     var src = (ICloudBlob)blobItem;
 
-                    var funcCtx = new FunctionBindingContext(Guid.Empty, CancellationToken.None, null);
+                    var funcCtx = new FunctionBindingContext(Guid.Empty, CancellationToken.None);
                     var valueCtx = new ValueBindingContext(funcCtx, CancellationToken.None);
 
                     var converted = await _converter(src, null, valueCtx);

--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/FunctionBindingContext.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/FunctionBindingContext.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading;
 using Microsoft.Azure.WebJobs.Host.Protocols;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Azure.WebJobs.Host.Bindings
 {
@@ -15,23 +16,40 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
     {
         private readonly Guid _functionInstanceId;
         private readonly CancellationToken _functionCancellationToken;
+        private readonly IServiceProvider _functionInvocationServices;
+        private static Lazy<IServiceProvider> _emptyServiceProvider = new Lazy<IServiceProvider>(CreateEmptyServiceProvider);
 
         /// <summary>
         /// Creates a new instance.
         /// </summary>
         /// <param name="functionInstanceId">The instance ID of the function being bound to.</param>
         /// <param name="functionCancellationToken">The <see cref="CancellationToken"/> to use.</param>
-        /// <param name="userLogger">The user logger.</param>
         /// <param name="functionDescriptor">Current function being executed. </param>
         public FunctionBindingContext(
             Guid functionInstanceId,
             CancellationToken functionCancellationToken,
             FunctionDescriptor functionDescriptor = null)
+            : this(functionInstanceId, functionCancellationToken, null, functionDescriptor)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance.
+        /// </summary>
+        /// <param name="functionInstanceId">The instance ID of the function being bound to.</param>
+        /// <param name="functionCancellationToken">The <see cref="CancellationToken"/> to use.</param>
+        /// <param name="functionInvocationServices">The user logger.</param>
+        /// <param name="functionDescriptor">Current function being executed. </param>
+        public FunctionBindingContext(
+            Guid functionInstanceId,
+            CancellationToken functionCancellationToken,
+            IServiceProvider functionInvocationServices,
+            FunctionDescriptor functionDescriptor)
         {
             _functionInstanceId = functionInstanceId;
             _functionCancellationToken = functionCancellationToken;
-
-            this.MethodName = functionDescriptor?.LogName;
+            _functionInvocationServices = functionInvocationServices ?? _emptyServiceProvider.Value;
+            MethodName = functionDescriptor?.LogName;
         }
 
         /// <summary>
@@ -48,5 +66,39 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
         /// The short name of the current function. 
         /// </summary>
         public string MethodName { get; private set; }
+
+        /// <summary>
+        /// The service provider for the current function invocation scope.
+        /// </summary>
+        public IServiceProvider InstanceServices { get; set; }
+
+        /// <summary>
+        /// Creates an object instance with constructor arguments provided in the
+        /// method call and from the current function context scoped services.
+        /// </summary>
+        /// <param name="type">The type to instantiate.</param>
+        /// <param name="parameters">Parameters not provided by the function service provider.</param>
+        /// <returns>An instance of the type specified.</returns>
+        public object CreateObjectInstance(Type type, params object[] parameters)
+        {
+            return ActivatorUtilities.CreateInstance(_functionInvocationServices, type, parameters);
+        }
+
+        /// <summary>
+        /// Creates an object instance with constructor arguments provided in the
+        /// method call and from the current function context scoped services.
+        /// </summary>
+        /// <typeparam name="T">The type to instantiate.</typeparam>
+        /// <param name="parameters">Parameters not provided by the function service provider.</param>
+        /// <returns>An instance of type T.</returns>
+        public T CreateObjectInstance<T>(params object[] parameters)
+        {
+            return ActivatorUtilities.CreateInstance<T>(_functionInvocationServices, parameters);
+        }
+
+        private static IServiceProvider CreateEmptyServiceProvider()
+        {
+            return new ServiceCollection().BuildServiceProvider();
+        }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionExecutor.cs
@@ -251,9 +251,10 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
                     FunctionOutputLogger.SetOutput(outputLog);
 
                     // Must bind before logging (bound invoke string is included in log message).
-                    FunctionBindingContext functionContext = new FunctionBindingContext(
+                    var functionContext = new FunctionBindingContext(
                         instance.Id,
                         functionCancellationTokenSource.Token,
+                        instance.InstanceServices,
                         instance.FunctionDescriptor);
                     var valueBindingContext = new ValueBindingContext(functionContext, cancellationToken);
 

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/DataBindingProviderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/DataBindingProviderTests.cs
@@ -8,6 +8,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Bindings.Data;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Host.UnitTests.Bindings.Data
@@ -30,7 +32,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Bindings.Data
             // Assert
             Assert.NotNull(binding);
 
-            var functionBindingContext = new FunctionBindingContext(Guid.NewGuid(), CancellationToken.None, null);
+            FunctionBindingContext functionBindingContext = new FunctionBindingContext(Guid.NewGuid(), CancellationToken.None);
             var valueBindingContext = new ValueBindingContext(functionBindingContext, CancellationToken.None);
             var bindingData = new Dictionary<string, object>
             {
@@ -64,7 +66,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Bindings.Data
             // Assert
             Assert.NotNull(binding);
 
-            var functionBindingContext = new FunctionBindingContext(Guid.NewGuid(), CancellationToken.None, null);
+            FunctionBindingContext functionBindingContext = new FunctionBindingContext(Guid.NewGuid(), CancellationToken.None);
             var valueBindingContext = new ValueBindingContext(functionBindingContext, CancellationToken.None);
             var bindingData = new Dictionary<string, object>
             {
@@ -98,7 +100,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Bindings.Data
             // Assert
             Assert.NotNull(binding);
 
-            var functionBindingContext = new FunctionBindingContext(Guid.NewGuid(), CancellationToken.None, null);
+            FunctionBindingContext functionBindingContext = new FunctionBindingContext(Guid.NewGuid(), CancellationToken.None);
             var valueBindingContext = new ValueBindingContext(functionBindingContext, CancellationToken.None);
             var bindingData = new Dictionary<string, object>
             {

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/ConverterManagerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/ConverterManagerTests.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             var cm = new ConverterManager(); // empty 
 
             Guid instance = Guid.NewGuid();
-            var testContext = new ValueBindingContext(new FunctionBindingContext(instance, CancellationToken.None, null), CancellationToken.None);
+            var testContext = new ValueBindingContext(new FunctionBindingContext(instance, CancellationToken.None), CancellationToken.None);
 
             FuncAsyncConverter converter = 
             (object obj, Attribute attr, ValueBindingContext ctx) => {


### PR DESCRIPTION
@pragnagopa these are the changes from https://github.com/Azure/azure-webjobs-sdk/pull/2270, updated based on feedback. Tests will be coming in a separate PR, just need to get this in to flow into the host.