### PR TITLE
CLA link fixed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ For details on development prereqs and running tests see [here](https://github.c
 
 ## Submitting Pull Requests
 
-Before we can accept your pull-request you'll need to sign a [Contribution License Agreement (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement). You can sign ours [here](https://cla2.dotnetfoundation.org). However, you don't have to do this up-front. You can simply clone, fork, and submit your pull-request as usual.
+Before we can accept your pull-request you'll need to sign a [Contribution License Agreement (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement). You can review the CLA [here](https://cla.opensource.microsoft.com/). However, you don't have to do this up-front. You can simply clone, fork, and submit your pull-request as usual.
 
 When your pull-request is created, we classify it. If the change is trivial, i.e. you just fixed a typo, then the PR is labelled with `cla-not-required`. Otherwise it's classified as `cla-required`. In that case, the system will also also tell you how you can sign the CLA. Once you signed a CLA, the current and all future pull-requests will be labelled as `cla-signed`. Signing the CLA might sound scary but it's actually super simple and can be done in less than a minute.
 


### PR DESCRIPTION
https://cla2.opensource.microsoft.com/ does not exist, but https://cla.opensource.microsoft.com/ does.
Also, the ability to sign at that site does not exist, but the PDF of the CLA does, hence the text change to "review the CLA".