### PR TITLE
Fix batch type handling for Fluent type

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingProviders/TriggerAdapterBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingProviders/TriggerAdapterBindingProvider.cs
@@ -41,9 +41,19 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
             typeof(string)
         };
 
+        // Listed in precedence for providing via DefaultType.
+        // Precedence is more important than how we produce the default type (a direct conversion vs. a converter)
+        private static readonly Type[] _defaultBatchTypes = new Type[] {
+            typeof(byte[][]),
+            typeof(JObject[]),
+            typeof(JArray),
+            typeof(string[])
+        };
+
         public Type GetDefaultType(Attribute attribute, FileAccess access, Type requestedType)
         {
-            IEnumerable<Type> targets = (requestedType != typeof(object)) ? new Type[] { requestedType } : _defaultTypes;
+            // If the requestedType is a batch type, we need to return the batch version of default types
+            IEnumerable<Type> targets = requestedType.IsArray ? _defaultBatchTypes : _defaultTypes;
 
             foreach (var target in targets)
             {
@@ -51,6 +61,11 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
                 {
                     return target;
                 }
+            }
+
+            if (requestedType.IsArray)
+            {
+                return typeof(object[]);
             }
 
             return typeof(object);

--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingProviders/TriggerAdapterBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingProviders/TriggerAdapterBindingProvider.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Config;
@@ -53,7 +54,9 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
         public Type GetDefaultType(Attribute attribute, FileAccess access, Type requestedType)
         {
             // If the requestedType is a batch type, we need to return the batch version of default types
-            IEnumerable<Type> targets = requestedType.IsArray ? _defaultBatchTypes : _defaultTypes;
+            IEnumerable<Type> targets = requestedType.IsArray && !_defaultTypes.Contains(requestedType) 
+                ? _defaultBatchTypes
+                : _defaultTypes;
 
             foreach (var target in targets)
             {

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/JobHostMetadataProviderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/JobHostMetadataProviderTests.cs
@@ -108,6 +108,20 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             }
         }
 
+        class FluentExtensionConfigBytesSingle : IExtensionConfigProvider
+        {
+            public void Initialize(ExtensionConfigContext context)
+            {
+                var rule = context.AddBindingRule<TestAttribute>();
+                rule.BindToTrigger<SomeData>(new MyTriggerBindingProvider());
+
+                rule.AddConverter<SomeData, byte[]>(msg => Encoding.ASCII.GetBytes(msg.Message));
+
+                rule.AddConverter<SomeData[], byte[][]>(
+                    msgs => msgs.Select(m => Encoding.ASCII.GetBytes(m.Message)).ToArray());
+            }
+        }
+
         class FluentExtensionConfigDefaultBatch : IExtensionConfigProvider
         {
             public void Initialize(ExtensionConfigContext context)
@@ -259,6 +273,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         [InlineData(typeof(FluentExtensionConfigDefaultBatch), typeof(byte[][]), typeof(object[]))]
         [InlineData(typeof(FluentExtensionConfigDefaultBatch), typeof(JObject[]), typeof(object[]))]
         [InlineData(typeof(FluentExtensionConfigDefaultBatch), typeof(object[]), typeof(object[]))]
+        [InlineData(typeof(FluentExtensionConfigBytesSingle), typeof(byte[]), typeof(byte[]))]
         public void TestBatchFluentDefaultType(Type extensionConfigProvider, Type requestedType, Type expectedType)
         {
             IHost host = new HostBuilder()


### PR DESCRIPTION
For extensions using Fluent registration pattern, we need to update `TriggerAdapterBindingProvider` to handle all the batch cases properly.

While I had made this https://github.com/Azure/azure-webjobs-sdk/commit/23e6c6bbc488ed581fcbd29f541ce8fea2b61459 change, it was not enough to take care of all possible batch scenarios. In that change, no matter the type requested, if a converter was available, the type was allowed. However, as with non-batch events, we can only support a few restricted data types due to communication with out of proc languages. And it makes sense to keep it consistent with non-batch events.

Additionally, it was unreasonable to expect extensions to provide a converter to generic `object[]` as that did not always make this. For example -- 
`EventGridExtension` provides a converter for `string` type only, out of all default types, and that is what the events are converted to. 
If `EventGridExtension` added an `object[]` converter to be able to support batch events (which is what I had initially thought), it would break the non-batch events (at least be a breaking change). This is because `byte[]` has a higher precedence than `string`. So, now for non-batch events, `EventGridExtension` unknowingly provided a converter for `byte[]` through `object[]`.
This means that for all events for non-batch would be converted to `byte[]` instead of `string`. We don't want to do that. And moreover, this would cause an error because likely the converter for `object[]` probably was a generic converter unable to convert to `byte[]`.

I have added several tests, and did test locally with out of proc languages with EventGridExtension. It all looks good to me with this PR.
