### PR TITLE
Added "samplingExcludedTypes" configuration to AppInsightsLoggers

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
@@ -23,6 +23,16 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
         public SamplingPercentageEstimatorSettings SamplingSettings { get; set; }
 
         /// <summary>
+        /// Gets or sets excluded types for sampling.
+        /// </summary>
+        public string SamplingExcludedTypes { get; set; }
+
+        /// <summary>
+        /// Gets or sets included types for sampling.
+        /// </summary>
+        public string SamplingIncludedTypes { get; set; }
+
+        /// <summary>
         /// Gets or sets snapshot collection options.
         /// </summary>
         public SnapshotCollectorConfiguration SnapshotConfiguration { get; set; }
@@ -146,9 +156,11 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
             JObject options = new JObject
             {
                 { nameof(SamplingSettings), sampling },
+                { nameof(SamplingExcludedTypes), SamplingExcludedTypes },
+                { nameof(SamplingIncludedTypes), SamplingIncludedTypes },
                 { nameof(SnapshotConfiguration), snapshot },
-                { nameof(EnablePerformanceCountersCollection), EnablePerformanceCountersCollection},
-                { nameof(HttpAutoCollectionOptions), httpOptions},
+                { nameof(EnablePerformanceCountersCollection), EnablePerformanceCountersCollection },
+                { nameof(HttpAutoCollectionOptions), httpOptions },
                 { nameof(LiveMetricsInitializationDelay), LiveMetricsInitializationDelay },
                 { nameof(EnableLiveMetrics), EnableLiveMetrics },
                 { nameof(EnableDependencyTracking), EnableDependencyTracking }

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
@@ -292,7 +292,18 @@ namespace Microsoft.Extensions.DependencyInjection
             if (options.SamplingSettings != null)
             {
                 configuration.TelemetryProcessorChainBuilder.Use((next) =>
-                    new AdaptiveSamplingTelemetryProcessor(options.SamplingSettings, null, next));
+                {
+                    var processor = new AdaptiveSamplingTelemetryProcessor(options.SamplingSettings, null, next);
+                    if (options.SamplingExcludedTypes != null)
+                    {
+                        processor.ExcludedTypes = options.SamplingExcludedTypes;
+                    }
+                    if (options.SamplingIncludedTypes != null)
+                    {
+                        processor.IncludedTypes = options.SamplingIncludedTypes;
+                    }
+                    return processor;
+                });
             }
 
             if (options.SnapshotConfiguration != null)

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
@@ -119,6 +119,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
         public void DependencyInjectionConfiguration_ConfiguresSampling()
         {
             var samplingSettings = new SamplingPercentageEstimatorSettings { MaxTelemetryItemsPerSecond = 1 };
+            var samplingExcludedTypes = "PageView;Request";
+            var samplingIncludedTypes = "Trace";
             using (var host = new HostBuilder()
                 .ConfigureLogging(b =>
                 {
@@ -126,6 +128,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                     {
                         o.InstrumentationKey = "some key";
                         o.SamplingSettings = samplingSettings;
+                        o.SamplingExcludedTypes = samplingExcludedTypes;
+                        o.SamplingIncludedTypes = samplingIncludedTypes;
                     });
                 })
                 .Build())
@@ -138,6 +142,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                 Assert.IsType<AdaptiveSamplingTelemetryProcessor>(config.TelemetryProcessors[3]);
 
                 Assert.Equal(samplingSettings.MaxTelemetryItemsPerSecond, ((AdaptiveSamplingTelemetryProcessor)config.TelemetryProcessors[3]).MaxTelemetryItemsPerSecond);
+                Assert.Equal(samplingExcludedTypes, ((AdaptiveSamplingTelemetryProcessor)config.TelemetryProcessors[3]).ExcludedTypes);
+                Assert.Equal(samplingIncludedTypes, ((AdaptiveSamplingTelemetryProcessor)config.TelemetryProcessors[3]).IncludedTypes);
             }
         }
 


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-functions-host/issues/4753

I made the initial decision to create a new field `samplingExcludedTypes` at the `applicationInsights` level in host.json (as opposed to inside the `samplingSettings` object). I did this because it more closely mimics the way ApplicationInsights has `ExcludedTypes` outside of `SamplingPercentageEstimatorSettings`, so anyone with experience with AppInsights won't be thrown for a loop. Alternatively, this can be moved to be inside our `samplingSettings` object. I feel this might be more intuitive for someone with no prior experience -- it has to do with sampling, so it's in the `samplingSettings`. The only drawback to that approach -- and one reason I didn't put it there to start -- is that it requires a bit of special case code in azure-functions-host that would just move the value to outside the `samplingSettings` object (coincidentally to right where I put it to begin with). We are special casing to an extent already with `isEnabled`, but it's not quite the same since `isEnabled` is more of a switch on/off than a setting that flows through.

TL;DR -- A decision has to be made as to whether the potential benefit to usability would outweigh the cost of special casing the code.