### PR TITLE
Update ApplicationInsights SDK version

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
-using Microsoft.ApplicationInsights.Extensibility.W3C;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
@@ -467,15 +466,6 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
 
                     // We'll need to store this operation context so we can stop it when the function completes
                     IOperationHolder<RequestTelemetry> operation = _telemetryClient.StartOperation(request);
-
-                    if (_loggerOptions.HttpAutoCollectionOptions.EnableW3CDistributedTracing)
-                    {
-                        // currently ApplicationInsights supports 2 parallel correlation schemes:
-                        // legacy and W3C, they both appear in telemetry. UX handles all differences in operation Ids. 
-                        // This will be resolved in next .NET SDK on Activity level.
-                        // This ensures W3C context is set on the Activity.
-                        Activity.Current?.GenerateW3CContext();
-                    }
 
                     stateValues[OperationContext] = operation;
                 }

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/WebJobsTelemetryInitializer.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/WebJobsTelemetryInitializer.cs
@@ -106,7 +106,6 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                         // Apply well-known tags and custom properties, 
                         // but ignore internal ai tags
                         if (!TryApplyProperty(request, tag) &&
-                            !tag.Key.StartsWith("w3c_") &&
                             !tag.Key.StartsWith("ai_"))
                         {
                             request.Properties[tag.Key] = tag.Value;

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
@@ -24,18 +24,18 @@
   </ItemGroup>
   
   <ItemGroup>
-  <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.7.0" />
-  <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.10.0" />
+  <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.8.0" />
+  <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.11.0" />
   <PackageReference Include="Microsoft.ApplicationInsights.SnapshotCollector" Version="1.3.4" />
-  <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.10.0" />
-  <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.10.0" />
+  <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.11.0" />
+  <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.11.0" />
   <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.1.0" />
   <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.0" />
   <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.10.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.10.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.11.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.11.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.0" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsLoggerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsLoggerTests.cs
@@ -11,7 +11,6 @@ using System.Threading.Tasks;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
-using Microsoft.ApplicationInsights.Extensibility.W3C;
 using Microsoft.ApplicationInsights.SnapshotCollector;
 using Microsoft.ApplicationInsights.WindowsServer.Channel.Implementation;
 using Microsoft.AspNetCore.Http;
@@ -88,8 +87,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             string expectedOperationId, expectedRequestId;
             using (logger.BeginFunctionScope(CreateFunctionInstance(_invocationId), _hostInstanceId))
             {
-                expectedRequestId = $"|{Activity.Current.GetTraceId()}.{Activity.Current.GetSpanId()}.";
-                expectedOperationId = Activity.Current.GetTraceId();
+                expectedRequestId = $"|{Activity.Current.TraceId.ToHexString()}.{Activity.Current.SpanId.ToHexString()}.";
+                expectedOperationId = Activity.Current.TraceId.ToHexString();
 
                 // sleep briefly to provide a non-zero Duration
                 await Task.Delay(100);
@@ -123,8 +122,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             string expectedOperationId, expectedRequestId;
             using (logger.BeginFunctionScope(CreateFunctionInstance(_invocationId), _hostInstanceId))
             {
-                expectedRequestId = $"|{Activity.Current.GetTraceId()}.{Activity.Current.GetSpanId()}.";
-                expectedOperationId = Activity.Current.GetTraceId();
+                expectedRequestId = $"|{Activity.Current.TraceId.ToHexString()}.{Activity.Current.SpanId.ToHexString()}.";
+                expectedOperationId = Activity.Current.TraceId.ToHexString();
 
                 logger.LogFunctionResult(result);
             }
@@ -214,8 +213,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                 logger.LogTrace("Trace");
                 logger.LogWarning("Warning");
 
-                expectedRequestId = $"|{Activity.Current.GetTraceId()}.{Activity.Current.GetSpanId()}.";
-                expectedOperationId = Activity.Current.GetTraceId();
+                expectedRequestId = $"|{Activity.Current.TraceId.ToHexString()}.{Activity.Current.SpanId.ToHexString()}.";
+                expectedOperationId = Activity.Current.TraceId.ToHexString();
             }
 
             Assert.Equal(6, _channel.Telemetries.Count);
@@ -281,8 +280,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             {
                 logger.LogError(0, ex, "Error with customer: {customer}.", "John Doe");
 
-                expectedRequestId = $"|{Activity.Current.GetTraceId()}.{Activity.Current.GetSpanId()}.";
-                expectedOperationId = Activity.Current.GetTraceId();
+                expectedRequestId = $"|{Activity.Current.TraceId.ToHexString()}.{Activity.Current.SpanId.ToHexString()}.";
+                expectedOperationId = Activity.Current.TraceId.ToHexString();
             }
 
             void ValidateProperties(ISupportProperties telemetry)
@@ -331,8 +330,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             {
                 logger.LogMetric("CustomMetric", 44.9);
 
-                expectedRequestId = $"|{Activity.Current.GetTraceId()}.{Activity.Current.GetSpanId()}.";
-                expectedOperationId = Activity.Current.GetTraceId();
+                expectedRequestId = $"|{Activity.Current.TraceId.ToHexString()}.{Activity.Current.SpanId.ToHexString()}.";
+                expectedOperationId = Activity.Current.TraceId.ToHexString();
             }
 
             var telemetry = _channel.Telemetries.Single() as MetricTelemetry;
@@ -394,8 +393,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             string expectedOperationId, expectedRequestId;
             using (logger.BeginFunctionScope(CreateFunctionInstance(scopeGuid), _hostInstanceId))
             {
-                expectedRequestId = $"|{Activity.Current.GetTraceId()}.{Activity.Current.GetSpanId()}.";
-                expectedOperationId = Activity.Current.GetTraceId();
+                expectedRequestId = $"|{Activity.Current.TraceId.ToHexString()}.{Activity.Current.SpanId.ToHexString()}.";
+                expectedOperationId = Activity.Current.TraceId.ToHexString();
 
                 var props = new Dictionary<string, object>
                 {
@@ -453,8 +452,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                 };
                 logger.LogMetric("CustomMetric", 1.1, props);
 
-                expectedRequestId = $"|{Activity.Current.GetTraceId()}.{Activity.Current.GetSpanId()}.";
-                expectedOperationId = Activity.Current.GetTraceId();
+                expectedRequestId = $"|{Activity.Current.TraceId.ToHexString()}.{Activity.Current.SpanId.ToHexString()}.";
+                expectedOperationId = Activity.Current.TraceId.ToHexString();
             }
 
             var telemetry = _channel.Telemetries.Single() as MetricTelemetry;


### PR DESCRIPTION
This change updated AppInsights SDKs to the new version and removes AI-specific redundant code around W3C trace-context - it was implemented in .NET (System.Diagnostics.DiagnosticSource package)

This is draft (uses preview AppInsights and DiagnosticSource) PR and should be merged after stable version ships in ~1 week.