### PR TITLE
Set role instance on QuickPulse module to distinguish linux consumption plan instances

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/IRoleInstanceProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/IRoleInstanceProvider.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+using System;
+
+namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
+{
+    internal interface IRoleInstanceProvider
+    {
+        string GetRoleInstanceName();
+    }
+
+    internal class WebJobsRoleInstanceProvider : IRoleInstanceProvider
+    {
+        internal const string ComputerNameKey = "COMPUTERNAME";
+        internal const string WebSiteInstanceIdKey = "WEBSITE_INSTANCE_ID";
+        internal const string ContainerNameKey = "CONTAINER_NAME";
+
+        private readonly string _roleInstanceName = GetRoleInstance();
+
+        public string GetRoleInstanceName()
+        {
+            return _roleInstanceName;
+        }
+
+        private static string GetRoleInstance()
+        {
+            string instanceName = Environment.GetEnvironmentVariable(WebSiteInstanceIdKey);
+            if (string.IsNullOrEmpty(instanceName))
+            {
+                instanceName = Environment.GetEnvironmentVariable(ComputerNameKey);
+                if (string.IsNullOrEmpty(instanceName))
+                {
+                    instanceName = Environment.GetEnvironmentVariable(ContainerNameKey);
+                }
+            }
+
+            return instanceName;
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/WebJobsTelemetryInitializer.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/WebJobsTelemetryInitializer.cs
@@ -15,22 +15,24 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
 {
     internal class WebJobsTelemetryInitializer : ITelemetryInitializer
     {
-        private const string ComputerNameKey = "COMPUTERNAME";
-        private const string WebSiteInstanceIdKey = "WEBSITE_INSTANCE_ID";
-        private const string ContainerNameKey = "CONTAINER_NAME";
-
-        private static readonly string _roleInstanceName = GetRoleInstanceName();
         private static readonly string _currentProcessId = Process.GetCurrentProcess().Id.ToString();
         private readonly string _sdkVersion;
+        private readonly string _roleInstanceName;
 
-        public WebJobsTelemetryInitializer(ISdkVersionProvider versionProvider)
+        public WebJobsTelemetryInitializer(ISdkVersionProvider versionProvider, IRoleInstanceProvider roleInstanceProvider)
         {
             if (versionProvider == null)
             {
                 throw new ArgumentNullException(nameof(versionProvider));
             }
 
+            if (roleInstanceProvider == null)
+            {
+                throw new ArgumentNullException(nameof(roleInstanceProvider));
+            }
+
             _sdkVersion = versionProvider.GetSdkVersion();
+            _roleInstanceName = roleInstanceProvider.GetRoleInstanceName();
         }
 
         public void Initialize(ITelemetry telemetry)
@@ -115,21 +117,6 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                     }
                 }
             }
-        }
-
-        private static string GetRoleInstanceName()
-        {
-            string instanceName = Environment.GetEnvironmentVariable(WebSiteInstanceIdKey);
-            if (string.IsNullOrEmpty(instanceName))
-            {
-                instanceName = Environment.GetEnvironmentVariable(ComputerNameKey);
-                if (string.IsNullOrEmpty(instanceName))
-                {
-                    instanceName = Environment.GetEnvironmentVariable(ContainerNameKey);
-                }
-            }
-
-            return instanceName;
         }
 
         /// <summary>

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/WebJobsRoleInstanceProviderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/WebJobsRoleInstanceProviderTests.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs.Logging.ApplicationInsights;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
+{
+    public class WebJobsRoleInstanceProviderTests : IDisposable
+    {
+        public WebJobsRoleInstanceProviderTests()
+        {
+            // make sure these are clear before each test
+            SetEnvironmentVariables(null, null, null);
+        }
+
+        [Fact]
+        public void RoleInstanceProvider_UsesWebsiteInstanceId()
+        {
+            SetEnvironmentVariables("instanceId", "computerName", "containerName");
+
+            var provider = new WebJobsRoleInstanceProvider();
+            Assert.Equal("instanceId", provider.GetRoleInstanceName());
+        }
+
+        [Fact]
+        public void RoleInstanceProvider_UsesComputerName()
+        {
+            SetEnvironmentVariables(null, "computerName", "containerName");
+
+            var provider = new WebJobsRoleInstanceProvider();
+            Assert.Equal("computerName", provider.GetRoleInstanceName());
+        }
+
+        [Fact]
+        public void RoleInstanceProvider_UsesContainerName()
+        {
+            SetEnvironmentVariables(null, null, "containerName");
+
+            var provider = new WebJobsRoleInstanceProvider();
+            Assert.Equal("containerName", provider.GetRoleInstanceName());
+        }
+
+        private static void SetEnvironmentVariables(string instanceId, string computerName, string containerName)
+        {
+            Environment.SetEnvironmentVariable(WebJobsRoleInstanceProvider.WebSiteInstanceIdKey, instanceId);
+            Environment.SetEnvironmentVariable(WebJobsRoleInstanceProvider.ComputerNameKey, computerName);
+            Environment.SetEnvironmentVariable(WebJobsRoleInstanceProvider.ContainerNameKey, containerName);
+        }
+
+        public void Dispose()
+        {
+            SetEnvironmentVariables(null, null, null);
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/WebJobsTelemetryInitializerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/WebJobsTelemetryInitializerTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             requestActivity.AddTag(LogConstants.NameKey, functionName);
             requestActivity.AddTag(LogConstants.SucceededKey, "true");
 
-            var initializer = new WebJobsTelemetryInitializer(new WebJobsSdkVersionProvider());
+            var initializer = new WebJobsTelemetryInitializer(new WebJobsSdkVersionProvider(), new WebJobsRoleInstanceProvider());
 
             initializer.Initialize(request);
             initializer.Initialize(request);
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             requestActivity.AddTag(LogConstants.NameKey, functionName);
             requestActivity.AddTag(LogConstants.SucceededKey, "true");
 
-            var initializer = new WebJobsTelemetryInitializer(new WebJobsSdkVersionProvider());
+            var initializer = new WebJobsTelemetryInitializer(new WebJobsSdkVersionProvider(), new WebJobsRoleInstanceProvider());
 
             initializer.Initialize(request);
             initializer.Initialize(request);
@@ -87,11 +87,37 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             Assert.DoesNotContain(request.Properties, p => p.Key == LogConstants.SucceededKey);
         }
 
+        [Fact]
+        public void Initializer_SetsRoleInstance()
+        {
+            var request = new RequestTelemetry { Name = "custom" };
+            var initializer = new WebJobsTelemetryInitializer(new WebJobsSdkVersionProvider(), new TestRoleInstanceProvider("my custom role instance"));
+
+            initializer.Initialize(request);
+
+            Assert.Equal("my custom role instance", request.Context.Cloud.RoleInstance);
+        }
+
         public void Dispose()
         {
             while (Activity.Current != null)
             {
                 Activity.Current.Stop();
+            }
+        }
+
+        class TestRoleInstanceProvider : IRoleInstanceProvider
+        {
+            private readonly string _roleInstance;
+
+            public TestRoleInstanceProvider(string roleInstance)
+            {
+                _roleInstance = roleInstance;
+            }
+
+            public string GetRoleInstanceName()
+            {
+                return _roleInstance;
             }
         }
     }


### PR DESCRIPTION
Fix #2321 

~~This change depends on #2326 and will be rebased after #2326 is merged.~~

~~The whole fix is in the https://github.com/Azure/azure-webjobs-sdk/commit/e7242896fed4331a87d1ba8241c8a82e293d718a commit~~
