### PR TITLE
Enable distributed tracing for Event Hubs trigger

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
@@ -104,6 +104,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
                     var includedActivities = dependencyCollector.IncludeDiagnosticSourceActivities;
                     includedActivities.Add("Microsoft.Azure.ServiceBus");
+                    includedActivities.Add("Microsoft.Azure.EventHubs");
 
                     return dependencyCollector;
                 }


### PR DESCRIPTION
Enabled distributed tracing for EventHubs.

This also needs some changes in EventHubs extension: https://github.com/Azure/azure-functions-eventhubs-extension/pull/20 for end-to-end to work. Without extensions changes, this PR will only enable tracking send and receive calls, but not correlation between producer and consumer.