### PR TITLE
synchronizing the FastTable output logger

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/FastTableLoggerProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/FastTableLoggerProvider.cs
@@ -16,9 +16,9 @@ namespace Microsoft.Azure.WebJobs.Host.Loggers
 {
     // Disable most SDK logging. Useful when we don't have a storage account and Fast-logging is enabled. 
     // This wires in an output logger to aide in capturing the TextWriter log output in memory and saving to the fast tables. 
-    internal class FastTableLoggerProvider : 
-        IHostInstanceLoggerProvider, 
-        IFunctionInstanceLoggerProvider, 
+    internal class FastTableLoggerProvider :
+        IHostInstanceLoggerProvider,
+        IFunctionInstanceLoggerProvider,
         IFunctionOutputLoggerProvider,
         IFunctionOutputLogger
     {
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.WebJobs.Host.Loggers
 
             public PerFunc()
             {
-                _writer = new StreamWriter(_ms);
+                _writer = TextWriter.Synchronized(new StreamWriter(_ms));
             }
 
             public TextWriter Output
@@ -111,7 +111,7 @@ namespace Microsoft.Azure.WebJobs.Host.Loggers
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2213:DisposableFieldsShouldBeDisposed", MessageId = "_writer")]
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2213:DisposableFieldsShouldBeDisposed", MessageId = "_ms")]
             public void Dispose()
-            {                
+            {
             }
 
             public Task SaveAndCloseAsync(FunctionInstanceLogEntry item, CancellationToken cancellationToken)
@@ -122,7 +122,7 @@ namespace Microsoft.Azure.WebJobs.Host.Loggers
 
                     // Truncate. 
                     if (str.Length > FunctionInstanceLogEntry.MaxLogOutputLength)
-                    {                        
+                    {
                         // 0123456789
                         // abcdefghij
                         str = str.Substring(0, FunctionInstanceLogEntry.MaxLogOutputLength - 1) + "…";

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/FastTableLoggerProviderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/FastTableLoggerProviderTests.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Azure.WebJobs.Host.Loggers;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Host.UnitTests
+{
+    public class FastTableLoggerProviderTests
+    {
+        [Fact]
+        public void Output_IsSynchronized()
+        {
+            IFunctionOutputLogger provider = new FastTableLoggerProvider(new TestTraceWriter(TraceLevel.Verbose));
+            var instanceMock = new Mock<IFunctionInstance>();
+            var outputDef = provider.CreateAsync(instanceMock.Object, CancellationToken.None).Result;
+            var output = outputDef.CreateOutput();
+
+            ExceptionDispatchInfo exception = null;
+
+            List<Thread> threads = new List<Thread>();
+            for (int i = 0; i < 5; i++)
+            {
+                var t = new Thread(() =>
+                {
+                    for (int j = 0; j < 1000; j++)
+                    {
+                        try
+                        {
+                            output.Output.WriteLine($"{i};{j}");
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            throw;
+                        }
+                    }
+                });
+
+                threads.Add(t);
+            }
+
+            foreach (var t in threads)
+            {
+                t.Start();
+            }
+
+            foreach (var t in threads)
+            {
+                t.Join();
+            }
+
+            if (exception != null)
+            {
+                exception.Throw();
+            }
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
@@ -258,6 +258,7 @@
     <Compile Include="Blobs\WatchableReadStreamTests.cs" />
     <Compile Include="Common\BindingPathAttribute.cs" />
     <Compile Include="Executors\CompositeFunctionEventCollectorTests.cs" />
+    <Compile Include="FastTableLoggerProviderTests.cs" />
     <Compile Include="Filters\FunctionFilterTests.cs" />
     <Compile Include="Executors\TriggeredFunctionExecutorTests.cs" />
     <Compile Include="ExtensionConfigContextTests.cs" />


### PR DESCRIPTION
Fixes #2354.
Fixes #1861. 

I tried to search through our code again for any usage of TextWriter that's not synchronized... it's a tough thing to analyze. I didn't see anything else, but I also didn't catch this one last time, either.