### PR TITLE
ApplicationInsights: optimize link id - not include operation_id in it

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
@@ -532,8 +532,8 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
 
                 // avoiding json serializers for now for the sake of perf.
                 // serialization is trivial and looks like `_MS.links` property with json blob
-                // [{"operation_Id":"5eca8b153632494ba00f619d6877b134","id":"|5eca8b153632494ba00f619d6877b134.d4c1279b6e7b7c47."},
-                //  {"operation_Id":"ff28988d0776b44f9ca93352da126047","id":"|ff28988d0776b44f9ca93352da126047.bf4fa4855d161141."}]
+                // [{"operation_Id":"5eca8b153632494ba00f619d6877b134","id":"d4c1279b6e7b7c47"},
+                //  {"operation_Id":"ff28988d0776b44f9ca93352da126047","id":"bf4fa4855d161141"}]
                 linksJson
                     .Append('{')
                     .Append("\"operation_Id\":")
@@ -544,15 +544,17 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                 linksJson
                     .Append("\"id\":")
                     .Append('\"')
-                    .Append('|')
-                    .Append(linkTraceId)
-                    .Append('.')
                     .Append(link.ParentSpanId.ToHexString())
-                    .Append('.')
                     .Append('\"');
 
                 // we explicitly ignore sampling flag, tracestate and attributes at this point.
                 linksJson.Append("},");
+            }
+
+            if (linksJson.Length > 0)
+            {
+                // remove last comma - trailing commas are not allowed
+                linksJson.Remove(linksJson.Length - 1, 1); 
             }
 
             linksJson.Append("]");

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/ApplicationInsightsEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/ApplicationInsightsEndToEndTests.cs
@@ -740,11 +740,17 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 Assert.NotNull(actualLinks);
                 Assert.Equal(2, actualLinks.Length);
 
-                Assert.Equal(links[0].TraceId.ToHexString(), actualLinks[0].operation_Id);
-                Assert.Equal(links[1].TraceId.ToHexString(), actualLinks[1].operation_Id);
+                var linkTraceId0 = links[0].TraceId.ToHexString();
+                var linkTraceId1 = links[1].TraceId.ToHexString();
+                Assert.Equal(linkTraceId0, actualLinks[0].operation_Id);
+                Assert.Equal(linkTraceId1, actualLinks[1].operation_Id);
 
-                Assert.Equal($"|{links[0].TraceId.ToHexString()}.{links[0].ParentSpanId.ToHexString()}.", actualLinks[0].id);
-                Assert.Equal($"|{links[1].TraceId.ToHexString()}.{links[1].ParentSpanId.ToHexString()}.", actualLinks[1].id);
+                var linkSpanId0 = links[0].ParentSpanId.ToHexString();
+                var linkSpanId1 = links[1].ParentSpanId.ToHexString();
+                Assert.Equal(linkSpanId0, actualLinks[0].id);
+                Assert.Equal(linkSpanId1, actualLinks[1].id);
+
+                Assert.Equal($"[{{\"operation_Id\":\"{linkTraceId0}\",\"id\":\"{linkSpanId0}\"}},{{\"operation_Id\":\"{linkTraceId1}\",\"id\":\"{linkSpanId1}\"}}]", linksStr);
             }
         }
 


### PR DESCRIPTION
ApplicationInsights ingestion will start transforming Request and Dependency Id and parentId for optimization purposes as described here https://github.com/microsoft/ApplicationInsights-Announcements/issues/27

Links were introduced for EventHubs distributed tracing in https://github.com/Azure/azure-webjobs-sdk/pull/2335. They enable batching scenarios and looked like `|operation_id.unique_id.`. To work  with the above optimization, links ids should stop including operation_id.

This change is not breaking since UX that leverages links is not finalized and not publically available.
