### PR TITLE
Bump ApplicationInsights SDKs to latest stable patch

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
@@ -24,10 +24,10 @@
   </ItemGroup>
   
   <ItemGroup>
-  <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.8.0" />
-  <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.11.0" />
+  <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.8.2" />
+  <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.11.2" />
   <PackageReference Include="Microsoft.ApplicationInsights.SnapshotCollector" Version="1.3.4" />
-  <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.11.0" />
+  <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.11.2" />
   <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.11.0" />
   <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.1.0" />
   <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.0" />
@@ -35,7 +35,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.11.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.11.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.11.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.0" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />


### PR DESCRIPTION
AppInsights latest patch includes fixes for SQL calls tracing
- https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/1291
- https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/1277


Fixes #2302