### PR TITLE
Exposing App Insights endpoint configs

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Net;
 using Microsoft.ApplicationInsights.SnapshotCollector;
 using Microsoft.ApplicationInsights.WindowsServer.Channel.Implementation;
 using Microsoft.Azure.WebJobs.Hosting;
@@ -101,17 +100,17 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
         public bool EnableDependencyTracking { get; set; } = true;
 
         /// <summary>
-        /// 
+        /// Gets or sets the endpoint address for the telemetry channel
         /// </summary>
         public string EndpointAddress { get; set; }
 
         /// <summary>
-        /// 
+        /// Gets or sets the Profile Query Endpoint for the Application Id Provider
         /// </summary>
         public string ProfileQueryEndpoint { get; set; }
 
         /// <summary>
-        /// 
+        /// Gets or sets the Quick Pulse Service Endpoint for the Quick Pulse Telemetry Module
         /// </summary>
         public string QuickPulseServiceEndpoint { get; set; }
 

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Net;
 using Microsoft.ApplicationInsights.SnapshotCollector;
 using Microsoft.ApplicationInsights.WindowsServer.Channel.Implementation;
 using Microsoft.Azure.WebJobs.Hosting;
@@ -100,6 +101,21 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
         public bool EnableDependencyTracking { get; set; } = true;
 
         /// <summary>
+        /// 
+        /// </summary>
+        public string EndpointAddress { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public string ProfileQueryEndpoint { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public string QuickPulseServiceEndpoint { get; set; }
+
+        /// <summary>
         /// Gets or sets HTTP request collection options. 
         /// </summary>
         public HttpAutoCollectionOptions HttpAutoCollectionOptions { get; set; } = new HttpAutoCollectionOptions();
@@ -163,7 +179,10 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                 { nameof(HttpAutoCollectionOptions), httpOptions },
                 { nameof(LiveMetricsInitializationDelay), LiveMetricsInitializationDelay },
                 { nameof(EnableLiveMetrics), EnableLiveMetrics },
-                { nameof(EnableDependencyTracking), EnableDependencyTracking }
+                { nameof(EnableDependencyTracking), EnableDependencyTracking },
+                { nameof(EndpointAddress), EndpointAddress },
+                { nameof(ProfileQueryEndpoint), ProfileQueryEndpoint },
+                { nameof(QuickPulseServiceEndpoint), QuickPulseServiceEndpoint }
             };
 
             return options.ToString(Formatting.Indented);

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
@@ -57,7 +57,19 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<ITelemetryInitializer, WebJobsTelemetryInitializer>();
             services.AddSingleton<ITelemetryInitializer, MetricSdkVersionTelemetryInitializer>();
             services.AddSingleton<QuickPulseInitializationScheduler>();
-            services.AddSingleton<QuickPulseTelemetryModule>();
+
+            services.AddSingleton<QuickPulseTelemetryModule>(provider =>
+            {
+                ApplicationInsightsLoggerOptions options = provider.GetService<IOptions<ApplicationInsightsLoggerOptions>>().Value;
+                if (!string.IsNullOrEmpty(options.QuickPulseServiceEndpoint))
+                {
+                    return new QuickPulseTelemetryModule
+                    {
+                        QuickPulseServiceEndpoint = options.QuickPulseServiceEndpoint
+                    };
+                }
+                return new QuickPulseTelemetryModule();
+            });
 
             services.AddSingleton<ITelemetryModule>(provider =>
             {
@@ -85,7 +97,18 @@ namespace Microsoft.Extensions.DependencyInjection
                 return NullTelemetryModule.Instance;
             });
 
-            services.AddSingleton<IApplicationIdProvider, ApplicationInsightsApplicationIdProvider>();
+            services.AddSingleton<IApplicationIdProvider, ApplicationInsightsApplicationIdProvider>(provider =>
+            {
+                ApplicationInsightsLoggerOptions options = provider.GetService<IOptions<ApplicationInsightsLoggerOptions>>().Value;
+                if (!string.IsNullOrEmpty(options.ProfileQueryEndpoint))
+                {
+                    return new ApplicationInsightsApplicationIdProvider
+                    {
+                        ProfileQueryEndpoint = options.ProfileQueryEndpoint
+                    };
+                }
+                return new ApplicationInsightsApplicationIdProvider();
+            });
 
             services.AddSingleton<ITelemetryModule>(provider =>
             {
@@ -134,7 +157,19 @@ namespace Microsoft.Extensions.DependencyInjection
 
             services.AddSingleton<ITelemetryModule, AppServicesHeartbeatTelemetryModule>();
 
-            services.AddSingleton<ITelemetryChannel, ServerTelemetryChannel>();
+            services.AddSingleton<ITelemetryChannel, ServerTelemetryChannel>(provider =>
+            {
+                ApplicationInsightsLoggerOptions options = provider.GetService<IOptions<ApplicationInsightsLoggerOptions>>().Value;
+                if (!string.IsNullOrEmpty(options.EndpointAddress))
+                {
+                    return new ServerTelemetryChannel
+                    {
+                        EndpointAddress = options.EndpointAddress
+                    };
+                }
+                return new ServerTelemetryChannel();
+            });
+
             services.AddSingleton<TelemetryConfiguration>(provider =>
             {
                 ApplicationInsightsLoggerOptions options = provider.GetService<IOptions<ApplicationInsightsLoggerOptions>>().Value;

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/ApplicationInsightsEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/ApplicationInsightsEndToEndTests.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 })
                 .ConfigureServices(services =>
                 {
-                    ServiceDescriptor quickPulse = services.Single(s => s.ImplementationType == typeof(QuickPulseTelemetryModule));
+                    ServiceDescriptor quickPulse = services.Single(s => s.ServiceType.Name == nameof(QuickPulseTelemetryModule));
                     services.Remove(quickPulse);
                     services.AddSingleton<ITelemetryModule, QuickPulseTelemetryModule>(s => new QuickPulseTelemetryModule()
                     {


### PR DESCRIPTION
Resolves #2263 

Initially made the decision to not group the endpoints because they're each configs for different components of App Insights. Left them at the top "Application Insights" level because giving them each their own subcategory seemed cluttered.

This would also require changes to the host.json schema