### PR TITLE
Enable Startup class ctors to receive IConfiguration

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Hosting/ISupportsStartupInstantiation.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Hosting/ISupportsStartupInstantiation.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs.Hosting;
+
+namespace Microsoft.Azure.WebJobs.Host.Hosting
+{
+    interface ISupportsStartupInstantiation
+    {
+        IWebJobsStartup CreateStartupInstance(Type startupType);
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsBuilderExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsBuilderExtensions.cs
@@ -11,6 +11,7 @@ using Microsoft.Azure.WebJobs.Host.Loggers;
 using Microsoft.Azure.WebJobs.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using System;
@@ -81,7 +82,9 @@ namespace Microsoft.Azure.WebJobs
                 throw new ArgumentException($"The {nameof(startupType)} argument must be an implementation of {typeof(IWebJobsStartup).FullName}");
             }
 
-            IWebJobsStartup startup = (IWebJobsStartup)Activator.CreateInstance(startupType);
+            IWebJobsStartup startup = builder is ISupportsStartupInstantiation startupInit
+                ? startupInit.CreateStartupInstance(startupType)
+                : (IWebJobsStartup)Activator.CreateInstance(startupType);
 
             if (loggerFactory == NullLoggerFactory.Instance)
             {

--- a/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsBuilderWithHostContext.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsBuilderWithHostContext.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Microsoft.Azure.WebJobs.Host.Hosting
+{
+    internal class WebJobsBuilderWithHostContext : WebJobsBuilder, ISupportsStartupInstantiation
+    {
+        private readonly HostBuilderContext _context;
+
+        public WebJobsBuilderWithHostContext(
+            IServiceCollection services,
+            HostBuilderContext context) : base(services)
+        {
+            this._context = context;
+        }
+
+        public IWebJobsStartup CreateStartupInstance(Type startupType)
+        {
+            return (IWebJobsStartup)ActivatorUtilities.CreateInstance(new HostServiceProvider(_context), startupType);
+        }
+
+        private class HostServiceProvider : IServiceProvider
+        {
+            private readonly HostBuilderContext _context;
+
+            public HostServiceProvider(HostBuilderContext context)
+            {
+                _context = context;
+            }
+
+            public object GetService(Type serviceType)
+            {
+                if (serviceType == typeof(Microsoft.Extensions.Hosting.IHostingEnvironment)
+                    // Would need this if targetting Microsoft.Extensions.Hosting v3.x
+                    //|| serviceType == typeof(IHostEnvironment)
+                    )
+                {
+                    return _context.HostingEnvironment;
+                }
+
+                if (serviceType == typeof(IConfiguration))
+                {
+                    return _context.Configuration;
+                }
+
+                return null;
+            }
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsHostBuilderExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsHostBuilderExtensions.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Extensions.Hosting
 
             builder.ConfigureServices((context, services) =>
             {
-                IWebJobsBuilder webJobsBuilder = services.AddWebJobs(configureOptions);
+                IWebJobsBuilder webJobsBuilder = services.AddWebJobs(configureOptions, context);
                 configure(context, webJobsBuilder);
 
                 services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, JobHostService>());

--- a/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsServiceCollectionExtensions.cs
@@ -8,6 +8,7 @@ using Microsoft.Azure.WebJobs.Host.Config;
 using Microsoft.Azure.WebJobs.Host.Configuration;
 using Microsoft.Azure.WebJobs.Host.Dispatch;
 using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Azure.WebJobs.Host.Hosting;
 using Microsoft.Azure.WebJobs.Host.Indexers;
 using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Azure.WebJobs.Host.Loggers;
@@ -38,6 +39,17 @@ namespace Microsoft.Azure.WebJobs
         /// <param name="services"></param>
         /// <returns></returns>
         public static IWebJobsBuilder AddWebJobs(this IServiceCollection services, Action<JobHostOptions> configure)
+        {
+            return services.AddWebJobs(configure, null);
+        }
+
+        /// <summary>
+        /// Adds the WebJobs services to the provided <see cref="IServiceCollection"/>.
+        /// </summary>
+        /// <param name="services">The service collection to populate.</param>
+        /// <param name="configure">Additional configuration callback.</param>
+        /// <param name="context">The host builder context. If non-null, this enables startup classes to receive the host IConfiguration and/or IHostingEnvironment as constructor arguments.</param>
+        public static IWebJobsBuilder AddWebJobs(this IServiceCollection services, Action<JobHostOptions> configure, HostBuilderContext context)
         {
             if (services == null)
             {
@@ -124,7 +136,9 @@ namespace Microsoft.Azure.WebJobs
                     section.Bind(options);
                 });
 
-            var builder = new WebJobsBuilder(services);
+            var builder = context == null
+                ? new WebJobsBuilder(services)
+                : new WebJobsBuilderWithHostContext(services, context);
             builder.AddBuiltInBindings();
 
             return builder;


### PR DESCRIPTION
In ASP.NET Core, startup classes can define a constructor that receives an `IConfiguration` argument, providing access to configuration settings before services are configured. This is useful because it enables the service configuration process to be driven by configuration settings.

The WebJobs startup class feature does not support this. And, as discussed in https://github.com/Azure/azure-functions-host/issues/4577 this means systems built on top of WebJobs such as the Azure Functions SDK for .NET, do not provide any documented way to get hold of the `IConfiguration` until after service configuration has finished.

This PR enables any startup class to define a constructor taking an `IConfiguration`, or an `IHostingEnvironment` (or both). This PR is loosely modelled on the way that ASP.NET Core does it: it relies on the builder having access to the `HostBuilderContext` (which provide the `IConfiguration`), along with a mechanism by which a builder can declare that it wants to participate in the startup class process.