### PR TITLE
[BlobTrigger] fixing bug with log scans

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Listeners/BlobLogListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Listeners/BlobLogListener.cs
@@ -175,7 +175,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
             foreach (var item in blobs)
             {
                 ICloudBlob log = item as ICloudBlob;
-                if (log != null)
+                if (log != null && log.Metadata.ContainsKey(LogType))
                 {
                     // we will exclude the file if the file does not have log entries in the interested time range.
                     string logType = log.Metadata[LogType];


### PR DESCRIPTION
Fixes #2413 and https://github.com/microsoft/vscode-azurefunctions/issues/1725

I'm guessing that there's some kind of race here where storage doesn't add this Metadata immediately so there's a chance it's missing. I see a lot of errors throughout kusto. Best thing to do here is just skip 
this file and we'll catch it during the next pass.

I'm a little nervous that people are trying Storage V2 and there'll be subtle issues: https://docs.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-known-issues#issues-and-limitations-with-using-blob-apis.