### PR TITLE
[Storage] changing WebJobs ref to depend on a public nuget package rather than project

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/WebJobs.Extensions.Storage.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/WebJobs.Extensions.Storage.csproj
@@ -96,12 +96,9 @@
     <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.5" />
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.1.0" />
     <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="11.1.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.14" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\Microsoft.Azure.WebJobs.Host\WebJobs.Host.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Having the storage extension use a project ref means that we cannot release it until the corresponding WebJobs nuget is public, which can take weeks. We rarely (if ever) need to depend on something that has been added to the host, so I'm severing that dependency and instead relying on the public nuget version of WebJobs like our other extensions do. This will allow us to release this as-needed.