### PR TITLE
Fixing "GetAwaiter().GetResult()" in BlobsExtensionConfigProvider whi…

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Queues/Config/QueuesExtensionConfigProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Queues/Config/QueuesExtensionConfigProvider.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Config
         // Multiple JobHost objects may share the same JobHostConfiguration.
         // But queues have per-host instance state (IMessageEnqueuedWatcher). 
         // so capture that and create new binding rules per host instance. 
-        private class PerHostConfig : IAsyncConverter<QueueAttribute, IAsyncCollector<CloudQueueMessage>>
+        private class PerHostConfig : IConverter<QueueAttribute, IAsyncCollector<CloudQueueMessage>>
         {
             // Fields that the various binding funcs need to close over. 
             private StorageAccountProvider _accountProvider;
@@ -186,29 +186,21 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Config
                 return new CloudQueueMessage(arg);
             }
 
-            public async Task<IAsyncCollector<CloudQueueMessage>> ConvertAsync(QueueAttribute attrResolved, CancellationToken cancellationToken)
+            public IAsyncCollector<CloudQueueMessage> Convert(QueueAttribute attrResolved)
             {
-                var queue = await GetQueueAsync(attrResolved);
+                var queue = GetQueue(attrResolved);
                 return new QueueAsyncCollector(queue, _messageEnqueuedWatcherGetter.Value);
             }
 
-            internal Task<CloudQueue> GetQueueAsync(QueueAttribute attrResolved)
+            internal CloudQueue GetQueue(QueueAttribute attrResolved)
             {
-                // var account = await _accountProvider.GetStorageAccountAsync(attrResolved, CancellationToken.None);
                 var account = _accountProvider.Get(attrResolved.Connection);
                 var client = account.CreateCloudQueueClient();
 
                 string queueName = attrResolved.QueueName.ToLowerInvariant();
                 QueueClient.ValidateQueueName(queueName);
 
-                var queue = client.GetQueueReference(queueName);
-                return Task.FromResult(queue);
-            }
-
-            internal CloudQueue GetQueue(QueueAttribute attrResolved)
-            {
-                var queue = Task.Run(() => GetQueueAsync(attrResolved)).GetAwaiter().GetResult();
-                return queue;
+                return client.GetQueueReference(queueName);
             }
         }
 
@@ -226,7 +218,7 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Config
                 QueueAttribute attrResolved,
                 CancellationToken cancellation)
             {
-                CloudQueue queue = await _bindingProvider.GetQueueAsync(attrResolved);
+                CloudQueue queue = _bindingProvider.GetQueue(attrResolved);
                 await queue.CreateIfNotExistsAsync(cancellation);
                 return queue;
             }


### PR DESCRIPTION
…ch causes deadlock.

Fixes: https://github.com/Azure/azure-functions-host/issues/5416

Language worker creates a binding on each execution:
https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script/Description/Workers/WorkerFunctionInvoker.cs#L123