### PR TITLE
Populate extra EventHub data: time in queue and hub info

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/Constants/LogConstants.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/Constants/LogConstants.cs
@@ -158,5 +158,25 @@ namespace Microsoft.Azure.WebJobs.Logging
         ///  Get the name of the key to store the current process id.
         /// </summary>
         public const string ProcessIdKey = "ProcessId";
+
+        /// <summary>
+        /// Get the name of the key to store the time when queue message
+        /// was enqueued in <see cref="System.Diagnostics.Activity"/> tags.
+        /// </summary>
+        public const string MessageEnqueuedTimeKey = "EnqueuedTime";
+
+        /// <summary>
+        /// Get the name of the key to store the endpoint in trigger details
+        /// that represents endpoint or FQDN of the service (Storage account, EventHub,
+        /// or any other Azure or non-Azure service).
+        /// </summary>
+        public const string TriggerDetailsEndpointKey = "Endpoint";
+
+        /// <summary>
+        /// Get the name of the key to store the entity or path in trigger details
+        /// that represents name of the entity (EventHub entity, Azure Blob container or
+        /// Storage queue name).
+        /// </summary>
+        public const string TriggerDetailsEntityNameKey = "Entity";
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/Constants/ScopeKeys.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/Constants/ScopeKeys.cs
@@ -27,5 +27,10 @@ namespace Microsoft.Azure.WebJobs.Logging
         /// A key identifying the current host instance.
         /// </summary>
         public const string HostInstanceId = "MS_HostInstanceId";
+
+        /// <summary>
+        /// A key identifying the current invocation trigger details.
+        /// </summary>
+        public const string TriggerDetails = "MS_TriggerDetails";
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/LoggerExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/LoggerExtensions.cs
@@ -67,7 +67,8 @@ namespace Microsoft.Extensions.Logging
                     [ScopeKeys.FunctionInvocationId] = functionInstance?.Id.ToString(),
                     [ScopeKeys.FunctionName] = functionInstance?.FunctionDescriptor?.LogName,
                     [ScopeKeys.Event] = LogConstants.FunctionStartEvent,
-                    [ScopeKeys.HostInstanceId] = hostInstanceId.ToString()
+                    [ScopeKeys.HostInstanceId] = hostInstanceId.ToString(),
+                    [ScopeKeys.TriggerDetails] = functionInstance?.TriggerDetails
                 });
         }
     }


### PR DESCRIPTION
This change enables custom metrics on time in queue for EventHubs messages and populates EventHub info on trigger request telemetry (this will allow to show AppMap properly and navigate to EventHub resource from AI views.

This relies on https://github.com/Azure/azure-functions-eventhubs-extension/pull/52 changes in eventhub extensions to populate necessary information. Please share your feeback on the extension as well. 
