### PR TITLE
Moving all ApplicationInsights nugets to 2.12.2

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
@@ -24,18 +24,18 @@
   </ItemGroup>
   
   <ItemGroup>
-  <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.12.0" />
-  <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.12.0" />
+  <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.12.2" />
+  <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.12.2" />
   <PackageReference Include="Microsoft.ApplicationInsights.SnapshotCollector" Version="1.3.4" />
-  <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.12.0" />
-  <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.12.0" />
+  <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.12.2" />
+  <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.12.2" />
   <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.1.0" />
   <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.0" />
   <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.12.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.12.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.12.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.12.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.0" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />


### PR DESCRIPTION
Taking fix for https://github.com/microsoft/ApplicationInsights-dotnet/issues/1702