### PR TITLE
BlobTrigger uses Event Grid subscription

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/BlobTriggerAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/BlobTriggerAttribute.cs
@@ -59,5 +59,10 @@ namespace Microsoft.Azure.WebJobs
         {
             get { return _blobPath; }
         }
+
+        /// <summary>
+        /// Returns a bool value that indicates whether EventGrid is used.
+        /// </summary>
+        public bool UseEventGrid { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Listeners/SharedQueueBlobListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Listeners/SharedQueueBlobListener.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Azure.WebJobs.Host.Listeners;
+using Microsoft.Azure.WebJobs.Host.Dispatch;
+using Microsoft.Azure.Storage.Blob;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
+{
+    internal class SharedQueueBlobListener : IListener
+    {
+        public SharedQueueBlobListener(ListenerFactoryContext context, StorageAccount dataAccount)
+        {
+            // register SharedQueueBlobHandler handler
+            context.GetDispatchQueue(new SharedQueueBlobHandler(context.Executor, dataAccount));
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            return Task.FromResult(true);
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            return Task.FromResult(true);
+        }
+
+        public void Dispose()
+        {
+        }
+
+        public void Cancel()
+        {
+        }
+
+        internal class SharedQueueBlobHandler : IMessageHandler
+        {
+            private ITriggeredFunctionExecutor _executor;
+            private CloudBlobClient _blobClient;
+
+            public SharedQueueBlobHandler(ITriggeredFunctionExecutor executor, StorageAccount dataAccount)
+            {
+                _executor = executor;
+                _blobClient = dataAccount.CreateCloudBlobClient();
+            }
+            public async Task<FunctionResult> TryExecuteAsync(JObject data, CancellationToken cancellationToken)
+            {
+                // Both Event Grid schema and Cloud Event schema define blob uri in ["data"]["url"]
+                ICloudBlob blob = await _blobClient.GetBlobReferenceFromServerAsync(new Uri(data["data"]["url"].ToString()));
+
+                TriggeredFunctionData input = new TriggeredFunctionData
+                {
+                    TriggerValue = blob
+                };
+                return await _executor.TryExecuteAsync(input, cancellationToken);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Triggers/BlobTriggerAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Triggers/BlobTriggerAttributeBindingProvider.cs
@@ -79,7 +79,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Triggers
 
             ITriggerBinding binding = new BlobTriggerBinding(parameter, hostAccount, dataAccount, path,
                 _hostIdProvider, _queueOptions, _blobsOptions, _exceptionHandler, _blobWrittenWatcherSetter,
-                _messageEnqueuedWatcherSetter, _sharedContextProvider, _singletonManager, _loggerFactory);
+                _messageEnqueuedWatcherSetter, _sharedContextProvider, _singletonManager,
+                blobTriggerAttribute.UseEventGrid, _loggerFactory);
 
             return Task.FromResult(binding);
         }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/StorageLoadBalancerQueue.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/StorageLoadBalancerQueue.cs
@@ -68,11 +68,7 @@ namespace WebJobs.Extensions.Storage
 
             public async Task AddAsync(T item, CancellationToken cancellationToken = default(CancellationToken))
             {
-                string contents = JsonConvert.SerializeObject(
-                    item,
-                    JsonSerialization.Settings);
-
-                var msg = new CloudQueueMessage(contents);
+                var msg = new CloudQueueMessage(item.ToString());
                 await _queue.AddMessageAndCreateIfNotExistsAsync(msg, cancellationToken);
 
                 _parent._sharedWatcher.Notify(_queue.Name);
@@ -87,7 +83,7 @@ namespace WebJobs.Extensions.Storage
         private CloudQueue Convert(string queueMoniker)
         {
             // $$$ Review
-            var account = _storageAccountProvider.Get(ConnectionStringNames.Dashboard);
+            var account = _storageAccountProvider.Get(ConnectionStringNames.Storage);
             var queue = account.CreateCloudQueueClient().GetQueueReference(queueMoniker);
             return queue;
         }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/StorageWebJobsBuilderExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/StorageWebJobsBuilderExtensions.cs
@@ -36,7 +36,8 @@ namespace Microsoft.Extensions.Hosting
             };
 
             // $$$ Move to Host.Storage? 
-            builder.Services.TryAddSingleton<ILoadBalancerQueue, StorageLoadBalancerQueue>();
+            // Replace existing runtime InMemoryLoadBalancerQueue with storage-backed implementations.
+            builder.Services.AddSingleton<ILoadBalancerQueue, StorageLoadBalancerQueue>();
 
             builder.Services.TryAddSingleton<SharedQueueWatcher>();
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/WebJobs.Extensions.Storage.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/WebJobs.Extensions.Storage.csproj
@@ -96,12 +96,9 @@
     <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.5" />
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.1.0" />
     <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="11.1.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.18" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\Microsoft.Azure.WebJobs.Host\WebJobs.Host.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/WebJobs.Extensions.Storage.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/WebJobs.Extensions.Storage.csproj
@@ -96,9 +96,12 @@
     <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.5" />
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.1.0" />
     <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="11.1.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.14" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Azure.WebJobs.Host\WebJobs.Host.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Azure.WebJobs.Host/Dispatch/HttpRequestProcessor.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Dispatch/HttpRequestProcessor.cs
@@ -1,0 +1,121 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Linq;
+using System.Web;
+using Microsoft.Azure.WebJobs.Logging;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using System.Threading;
+using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Azure.WebJobs.Host.Timers;
+using Microsoft.Azure.WebJobs.Host.Listeners;
+using Microsoft.Azure.WebJobs.Host.Config;
+
+namespace Microsoft.Azure.WebJobs.Host.Dispatch
+{
+    public interface IHttpEndpointManager
+    {
+        void RegisterHttpEnpoint(ExtensionConfigContext context);
+
+        Task<HttpResponseMessage> ProcessHttpRequestAsync(HttpRequestMessage req, CancellationToken cancellationToken);
+    }
+
+    /// <summary>
+    /// Hadles HttpRequests that comes to extension http endpoint.
+    /// </summary>
+    internal class HttpEndpointManager : IHttpEndpointManager
+    {
+        private readonly ILogger _logger;
+        private readonly SharedQueueHandler _sharedQueue;
+
+        public HttpEndpointManager(SharedQueueHandler sharedQueue, ILoggerFactory loggerFactory)
+        {
+            _sharedQueue = sharedQueue;
+            _logger = loggerFactory.CreateLogger(LogCategories.CreateTriggerCategory("HttpRequestProcessor"));
+        }
+
+        public void RegisterHttpEnpoint(ExtensionConfigContext context)
+        {
+            Uri url = context.GetWebhookHandler();
+            _logger.LogInformation($"registered http endpoint = {url?.GetLeftPart(UriPartial.Path)}");
+        }
+
+        public async Task<HttpResponseMessage> ProcessHttpRequestAsync(HttpRequestMessage req, CancellationToken cancellationToken)
+        {
+            var functionId = HttpUtility.ParseQueryString(req.RequestUri.Query)[SharedQueueHandler.FunctionId];
+            IEnumerable<string> eventTypeHeaders = null;
+            string eventTypeHeader = null;
+            if (req.Headers.TryGetValues("aeg-event-type", out eventTypeHeaders))
+            {
+                eventTypeHeader = eventTypeHeaders.First();
+            }
+
+            if (String.Equals(eventTypeHeader, "SubscriptionValidation", StringComparison.OrdinalIgnoreCase))
+            {
+                string jsonArray = await req.Content.ReadAsStringAsync();
+                SubscriptionValidationEvent validationEvent = null;
+                List<JObject> events = JsonConvert.DeserializeObject<List<JObject>>(jsonArray);
+                // TODO remove unnecessary serialization
+                validationEvent = ((JObject)events[0]["data"]).ToObject<SubscriptionValidationEvent>();
+                SubscriptionValidationResponse validationResponse = new SubscriptionValidationResponse { ValidationResponse = validationEvent.ValidationCode };
+                var returnMessage = new HttpResponseMessage(HttpStatusCode.OK);
+                returnMessage.Content = new StringContent(JsonConvert.SerializeObject(validationResponse));
+                _logger.LogInformation($"perform handshake with eventGrid for function: {functionId}");
+                return returnMessage;
+            }
+            else if (String.Equals(eventTypeHeader, "Notification", StringComparison.OrdinalIgnoreCase))
+            {
+                JArray events = null;
+                string requestContent = await req.Content.ReadAsStringAsync();
+                var token = JToken.Parse(requestContent);
+                if (token.Type == JTokenType.Array)
+                {
+                    // eventgrid schema
+                    events = (JArray)token;
+                }
+                else if (token.Type == JTokenType.Object)
+                {
+                    // cloudevent schema
+                    events = new JArray
+                    {
+                        token
+                    };
+                }
+
+                foreach (JObject jo in events)
+                {
+                    // TODO ALROD - Azure Queues do not suport batch sending. Sending in parallel? ServiceBus?
+                    await _sharedQueue.EnqueueAsync(jo, functionId, cancellationToken);
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.Accepted);
+            }
+            else if (String.Equals(eventTypeHeader, "Unsubscribe", StringComparison.OrdinalIgnoreCase))
+            {
+                // TODO disable function?
+                return new HttpResponseMessage(HttpStatusCode.Accepted);
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.BadRequest);
+        }
+    }
+
+    internal class SubscriptionValidationResponse
+    {
+        [JsonProperty(PropertyName = "validationResponse")]
+        public string ValidationResponse { get; set; }
+    }
+
+    internal class SubscriptionValidationEvent
+    {
+        [JsonProperty(PropertyName = "validationCode")]
+        public string ValidationCode { get; set; }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Dispatch/IDispatchQueueHandler.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Dispatch/IDispatchQueueHandler.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.WebJobs.Host.Dispatch
     /// these messages will be distributed to multiple worker instance
     /// for later processing
     /// </summary>
-    internal interface IDispatchQueueHandler
+    public interface IDispatchQueueHandler
     {
         /// <summary> Add a message to the shared queue.</summary>
         /// <param name="message"> A JObject to be later processed by IMessageHandler </param>

--- a/src/Microsoft.Azure.WebJobs.Host/Dispatch/IMessageHandler.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Dispatch/IMessageHandler.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.WebJobs.Host.Dispatch
     /// Defines the contract for executing a triggered function using a dispatch queue.
     /// <see cref="ListenerFactoryContext.GetDispatchQueue(IMessageHandler)"/>
     /// </summary>
-    internal interface IMessageHandler
+    public interface IMessageHandler
     {
         /// <summary>
         /// Try to invoke the triggered function using the values specified.

--- a/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsServiceCollectionExtensions.cs
@@ -59,6 +59,7 @@ namespace Microsoft.Azure.WebJobs
             services.TryAddSingleton<SingletonManager>();
             services.TryAddSingleton<IHostSingletonManager>(provider => provider.GetRequiredService<SingletonManager>());
             services.TryAddSingleton<SharedQueueHandler>();
+            services.TryAddSingleton<IHttpEndpointManager, HttpEndpointManager>();
             services.TryAddSingleton<IFunctionExecutor, FunctionExecutor>();
             services.TryAddSingleton<IJobHostContextFactory, JobHostContextFactory>();
 

--- a/src/Microsoft.Azure.WebJobs.Host/Listeners/ListenerFactoryContext.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Listeners/ListenerFactoryContext.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.WebJobs.Host.Listeners
         /// If you have registered once, you can retrieve the same queue by passing a null to this function
         /// </param>
         /// <returns> The <see cref="IDispatchQueueHandler"/> is used to enqueue messages </returns>
-        internal IDispatchQueueHandler GetDispatchQueue(IMessageHandler handler)
+        public IDispatchQueueHandler GetDispatchQueue(IMessageHandler handler)
         {
             if (_dispatchQueue == null)
             {

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncChainEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncChainEndToEndTests.cs
@@ -126,6 +126,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     "Microsoft.Azure.WebJobs.Host.EndToEndTests.AsyncChainEndToEndTests.BlobToBlobAsync",
                     "Microsoft.Azure.WebJobs.Host.EndToEndTests.AsyncChainEndToEndTests.ReadResultBlob",
                     "Microsoft.Azure.WebJobs.Host.EndToEndTests.AsyncChainEndToEndTests.SystemParameterBindingOutput",
+                    "registered http endpoint =",
                     "Function 'AsyncChainEndToEndTests.DisabledJob' is disabled",
                     "Job host started",
                     "Executing 'AsyncChainEndToEndTests.WriteStartDataMessageToQueue' (Reason='This function was programmatically called via the host APIs.', Id=",

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/JobHostTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/JobHostTests.cs
@@ -591,25 +591,25 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 Assert.Equal("BindingErrorsProgram.Invalid", fex.MethodName);
 
                 // verify that the binding error was logged
-                Assert.Equal(10, errorLogger.GetLogMessages().Count);
+                Assert.Equal(11, errorLogger.GetLogMessages().Count);
 
                 // Skip validating the initial 'Starting JobHost' message and the OptionsFormatters
                 
-                LogMessage logMessage = errorLogger.GetLogMessages()[6];
+                LogMessage logMessage = errorLogger.GetLogMessages()[7];
                 Assert.Equal("Error indexing method 'BindingErrorsProgram.Invalid'", logMessage.FormattedMessage);
                 Assert.Same(fex, logMessage.Exception);
                 Assert.Equal("Invalid container name: invalid$=+1", logMessage.Exception.InnerException.Message);
 
-                logMessage = errorLogger.GetLogMessages()[7];
+                logMessage = errorLogger.GetLogMessages()[8];
                 Assert.Equal("Function 'BindingErrorsProgram.Invalid' failed indexing and will be disabled.", logMessage.FormattedMessage);
 
                 // verify that the valid function was still indexed
-                logMessage = errorLogger.GetLogMessages()[8];
+                logMessage = errorLogger.GetLogMessages()[9];
                 Assert.True(logMessage.FormattedMessage.Contains("Found the following functions"));
                 Assert.True(logMessage.FormattedMessage.Contains("BindingErrorsProgram.Valid"));
 
                 // verify that the job host was started successfully
-                logMessage = errorLogger.GetLogMessages()[9];
+                logMessage = errorLogger.GetLogMessages()[10];
                 Assert.Equal("Job host started", logMessage.FormattedMessage);
 
                 await host.StopAsync();

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
@@ -256,7 +256,10 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 "ScaleStatusContext",
                 "ScaleStatusContext`1",
                 "ScaleVote",
-                "ScaleMonitorDescriptor"
+                "ScaleMonitorDescriptor",
+                "IHttpEndpointManager",
+                "IDispatchQueueHandler",
+                "IMessageHandler"
             };
 
             TestHelpers.AssertPublicTypes(expected, assembly);


### PR DESCRIPTION
Using:
1. EventGrid subscription with HTTP endpoint should be pre-created as we do not have a tool for the EventGrid subscription creation yet.
https://[function app uri]/runtime/webhooks/blobs?functionId=[function id in format namespace.class.method]&code=[blob_extension key]
Also you can specify a filter to get the blobs only from specified container/path.
2. Blob trigger definition:
`public static async Task Run([BlobTrigger("test/{name2}", UseEventGrid = true, Connection = "Storage1")]string myBlob, ILogger log)`

How it works:
Blob uploaded/created -> EventGrid sends a HTTP request to function app extension endpoint -> Function runtime receives the HTTP request and adds the message to internal queue -> internal queue listener processes new messages (poison queue supported)