### PR TITLE
Upgrade webjobs dashboard to target .net 4.6

### DIFF
--- a/src/Dashboard/Web.config
+++ b/src/Dashboard/Web.config
@@ -24,7 +24,7 @@
   <system.web>
     <customErrors mode="RemoteOnly" />
     <compilation debug="true" targetFramework="4.6" />
-    <httpRuntime targetFramework="4.5" />
+    <httpRuntime targetFramework="4.6" />
     <authentication mode="None" />
   </system.web>
   <system.webServer>


### PR DESCRIPTION
This should enable TLS 1.2 in terms of outbound calls made by the dashboard to services such as azure storage.