### PR TITLE
Passing timeout token down to host

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/ExecutionContext/ExecutionContext.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/ExecutionContext/ExecutionContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
 
 namespace Microsoft.Azure.WebJobs
 {
@@ -32,5 +33,10 @@ namespace Microsoft.Azure.WebJobs
         /// A host can set this via <see cref="CoreJobHostConfigurationExtensions.UseCore(JobHostConfiguration, string)"/>
         /// </remarks>
         public string FunctionAppDirectory { get; set; }
+
+        /// <summary>
+        /// Gets or sets the function timeout token source.
+        /// </summary>
+        public CancellationTokenSource TimeoutTokenSource { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionExecutor.cs
@@ -558,6 +558,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             CancellationTokenSource functionCancellationTokenSource, bool throwOnTimeout, TimeSpan timerInterval, IFunctionInstance instance)
         {
             object[] invokeParameters = parameterHelper.InvokeParameters;
+            invokeParameters.OfType<ExecutionContext>().First().TimeoutTokenSource = timeoutTokenSource;
 
             // There are three ways the function can complete:
             //   1. The invokeTask itself completes first.

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionExecutor.cs
@@ -558,7 +558,11 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             CancellationTokenSource functionCancellationTokenSource, bool throwOnTimeout, TimeSpan timerInterval, IFunctionInstance instance)
         {
             object[] invokeParameters = parameterHelper.InvokeParameters;
-            invokeParameters.OfType<ExecutionContext>().First().TimeoutTokenSource = timeoutTokenSource;
+            var executionContext = invokeParameters.OfType<ExecutionContext>().FirstOrDefault();
+            if (executionContext != null)
+            {
+                executionContext.TimeoutTokenSource = timeoutTokenSource;
+            }
 
             // There are three ways the function can complete:
             //   1. The invokeTask itself completes first.

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/FunctionExecutorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/FunctionExecutorTests.cs
@@ -117,6 +117,30 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
         }
 
         [Fact]
+        public async Task InvokeAsync_WithExecutionContext_PopulatesExecutionContextWithTimeoutTokenSource()
+        {
+
+            var timeoutSource = new CancellationTokenSource();
+            var shutdownSource = new CancellationTokenSource();
+            bool throwOnTimeout = true;
+            Mock<IFunctionInvoker> mockInvoker = new Mock<IFunctionInvoker>();
+            ExecutionContext execContext = new ExecutionContext();
+            var parameterHelper = NewArgs(new object[1] { execContext });
+
+            mockInvoker.Setup(i => i.InvokeAsync(It.IsAny<object>(), It.IsAny<object[]>()))
+                .Returns(() =>
+                {
+                    return Task.FromResult<object>(null);
+                });
+
+
+            await FunctionExecutor.InvokeAsync(mockInvoker.Object, parameterHelper, timeoutSource, shutdownSource,
+                throwOnTimeout, TimeSpan.MinValue, null);
+
+            Assert.Equal(execContext.TimeoutTokenSource, timeoutSource);
+        }
+
+        [Fact]
         public async Task InvokeAsync_NoCancellation()
         {
             bool called = false;


### PR DESCRIPTION
As part of the workitem here https://github.com/Azure/azure-functions-host/issues/5391 , one of the things we wanted to leverage for out-of-proc workers was the timeout token set in the webjobs . More specifically, to use the timeout cancellationToken here (https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script/Description/Workers/WorkerFunctionInvoker.cs#L79)