### PR TITLE
Enable Request Telemetry suppression

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
@@ -16,7 +16,7 @@ using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
 {
-    public class ApplicationInsightsLogger : ILogger
+    internal class ApplicationInsightsLogger : ILogger
     {
         private readonly TelemetryClient _telemetryClient;
         private readonly ApplicationInsightsLoggerOptions _loggerOptions;

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Constants/LoggingConstants.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Constants/LoggingConstants.cs
@@ -8,5 +8,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
         public const string ZeroIpAddress = "0.0.0.0";
         public const string Unknown = "[Unknown]";
         public const string ClientIpKey = "ClientIp";
+        public const string IgnoreActivity = "MS_IgnoreActivity";
+        public const string IgnoreTracking = "MS_IgnoreTracking";
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsLoggerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsLoggerTests.cs
@@ -762,6 +762,22 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
         }
 
         [Fact]
+        public void ApplicationInsights_RequestIsNotTrackedIfIgnoreTrackingSpecified()
+        {
+            var result = CreateDefaultInstanceLogEntry();
+            var logger = CreateLogger(LogCategories.Results);
+            Activity parent = new Activity("foo").Start();
+            using (logger.BeginScope(new Dictionary<string, object> { ["MS_IgnoreActivity"] = null }))
+            using (logger.BeginScope(new Dictionary<string, object> { ["MS_IgnoreTracking"] = null }))
+            using (logger.BeginFunctionScope(CreateFunctionInstance(_invocationId), _hostInstanceId))
+            {
+                logger.LogFunctionResult(result);
+            }
+            // ApplicationInsights auto-tracks telemetry, functions do not track it.
+            Assert.Empty(_channel.Telemetries.OfType<RequestTelemetry>());
+        }
+
+        [Fact]
         public async Task ApplicationInsights_RequestHasSourceIfTriggerDetailsArePopulated()
         {
             var result = CreateDefaultInstanceLogEntry();


### PR DESCRIPTION
Hi @brettsam 

I wanted to suppress the request telemetry tracking on the Azure Functions Host side. Currently, there is no way to suppress the request telemetry. 

Suppression will happen when you configure this when you invoke a function. 

```
using (logger.BeginScope(new Dictionary<string, object> { ["MS_IgnoreTracking"] = null })) {
      // Function invocation 
}
```

NOTE: "MS_IgnoreActivity" will not suppress the tracking, it makes it tracking.

https://github.com/Azure/azure-webjobs-sdk/blob/dev/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsLoggerTests.cs#L736
 

