### PR TITLE
[BlobTrigger] when logs cannot be parsed, log warning instead of throwing

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Listeners/BlobLogListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Listeners/BlobLogListener.cs
@@ -7,9 +7,10 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.WebJobs.Host.Timers;
 using Microsoft.Azure.Storage.Blob;
 using Microsoft.Azure.Storage.Shared.Protocol;
+using Microsoft.Azure.WebJobs.Host.Timers;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
 {
@@ -22,13 +23,19 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
 
         private readonly CloudBlobClient _blobClient;
         private readonly HashSet<string> _scannedBlobNames = new HashSet<string>();
-        private readonly StorageAnalyticsLogParser _parser = new StorageAnalyticsLogParser();
+        private readonly StorageAnalyticsLogParser _parser;
         private readonly IWebJobsExceptionHandler _exceptionHandler;
 
-        private BlobLogListener(CloudBlobClient blobClient, IWebJobsExceptionHandler exceptionHandler)
+        private BlobLogListener(CloudBlobClient blobClient, IWebJobsExceptionHandler exceptionHandler, ILogger<BlobListener> logger)
         {
             _blobClient = blobClient;
             _exceptionHandler = exceptionHandler ?? throw new ArgumentNullException(nameof(exceptionHandler));
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+            _parser = new StorageAnalyticsLogParser(logger);
         }
 
         public CloudBlobClient Client
@@ -38,10 +45,10 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
 
         // This will throw if the client credentials are not valid. 
         public static async Task<BlobLogListener> CreateAsync(CloudBlobClient blobClient,
-           IWebJobsExceptionHandler exceptionHandler, CancellationToken cancellationToken)
+           IWebJobsExceptionHandler exceptionHandler, ILogger<BlobListener> logger, CancellationToken cancellationToken)
         {
             await EnableLoggingAsync(blobClient, cancellationToken);
-            return new BlobLogListener(blobClient, exceptionHandler);
+            return new BlobLogListener(blobClient, exceptionHandler, logger);
         }
 
         public async Task<IEnumerable<ICloudBlob>> GetRecentBlobWritesAsync(CancellationToken cancellationToken,

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Listeners/PollLogsStrategy.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Listeners/PollLogsStrategy.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
 
             if (!_logListeners.ContainsKey(client))
             {
-                BlobLogListener logListener = await BlobLogListener.CreateAsync(client, _exceptionHandler, cancellationToken);
+                BlobLogListener logListener = await BlobLogListener.CreateAsync(client, _exceptionHandler, _logger, cancellationToken);
                 _logListeners.Add(client, logListener);
             }
         }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Listeners/StorageAnalyticsLogParser.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Listeners/StorageAnalyticsLogParser.cs
@@ -12,6 +12,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Storage.Blob;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
 {
@@ -50,10 +51,12 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
         private readonly Version supportedVersion = new Version(1, 0);
 
         private readonly Regex _compiledRegex;
+        private readonly ILogger<BlobListener> _logger;
 
-        public StorageAnalyticsLogParser()
+        public StorageAnalyticsLogParser(ILogger<BlobListener> logger)
         {
             _compiledRegex = new Regex(FieldPattern, RegexOptions.Compiled);
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         /// <summary>
@@ -94,7 +97,8 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
                         string message = String.Format(CultureInfo.CurrentCulture,
                             "Unable to detect a version of log entry on line {1} of Storage Analytics log file '{0}'.",
                             blob.Name, lineNumber);
-                        throw new FormatException(message);
+
+                        _logger.LogWarning(message);
                     }
 
                     if (version == supportedVersion)
@@ -105,7 +109,8 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
                             string message = String.Format(CultureInfo.CurrentCulture,
                                 "Unable to parse the log entry on line {1} of Storage Analytics log file '{0}'.",
                                 blob.Name, lineNumber);
-                            throw new FormatException(message);
+
+                            _logger.LogWarning(message);
                         }
 
                         entries.Add(entry);

--- a/test/Microsoft.Azure.Webjobs.Extensions.Storage.UnitTests/Blobs/Listeners/StorageAnalyticsLogParserTests.cs
+++ b/test/Microsoft.Azure.Webjobs.Extensions.Storage.UnitTests/Blobs/Listeners/StorageAnalyticsLogParserTests.cs
@@ -3,8 +3,8 @@
 
 using System;
 using Microsoft.Azure.WebJobs.Host.Blobs.Listeners;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Microsoft.Azure.WebJobs.Host.UnitTests.Blobs.Listeners
 {
@@ -18,8 +18,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Blobs.Listeners
         [InlineData(@"1.0;2014-09-08T18:49:25.5834856Z;PutBlob;Success;201;7;7;authenticated;storagesample;storagesample;blob;""https://storagesample.blob.core.windows.net/input//&quot;;&quot;?timeout=90"";""/storagesample/input//&quot;;&quot;"";9e9c90bc-0001-0052-2acc-abdcc9000000;0;192.100.0.102:4362;2011-08-18;325;0;225;0;0;""1B2M2Y8AsgTpgAmY7PhCfg=="";""1B2M2Y8AsgTpgAmY7PhCfg=="";""&quot;0x8D199ACBF198B4E&quot;"";Monday, 08-Sep-14 18:49:25 GMT;;""WA-Storage/1.7.0"";;", @"/storagesample/input//"";""")]
         public void TryParseLogEntry_IfValidLogEnry_ReturnsEntryInstance(string line, string blobPath)
         {
-            StorageAnalyticsLogParser parser = new StorageAnalyticsLogParser();
-            
+            StorageAnalyticsLogParser parser = new StorageAnalyticsLogParser(NullLogger<BlobListener>.Instance);
+
             StorageAnalyticsLogEntry entry = parser.TryParseLogEntry(line);
 
             Assert.NotNull(entry);
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Blobs.Listeners
         [InlineData(@"1.0;2014-09-08T18:49:25.5834856Z;CopyBlob;Success;202;13;13;authenticated;storagesample;storagesample;blob;""https://storagesample.blob.core.windows.net/sample-container/Copy-sample-blob.txt"";""/storagesample/sample-container/Copy-sample-blob.txt"";4;5;6;7;8;9;0;1;2;3;4;5;6;7;8;9;0;")]
         public void TryParseLogEntry_IfMalformedInput_ReturnsNull(string line)
         {
-            StorageAnalyticsLogParser parser = new StorageAnalyticsLogParser();
+            StorageAnalyticsLogParser parser = new StorageAnalyticsLogParser(NullLogger<BlobListener>.Instance);
 
             StorageAnalyticsLogEntry entry = parser.TryParseLogEntry(line);
 


### PR DESCRIPTION
We currently have an incident where some component is producing malformed blob logs -- it appears to be a SQL Backup (the user agent is SQLBLOBACCESS). It looks like the recorded URL has a newline character in it, which splits the log lines in the wrong place, causing failure.

We're trying to investigate this with them, but it doesn't seem necessary for us to throw an unhandled exception and crash the host if this happens. A better approach may be to skip those lines and log them. 

@mathewc wanted your thoughts since you probably have the most history here. 