### PR TITLE
Track original activity at the Application Insights Logger

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
@@ -526,7 +526,10 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                     // We'll need to store this operation context so we can stop it when the function completes
                     stateValues[OperationContext] = operation;
                 }
-            } // Track Activity if the key is the TrackActivity Scope is specified. 
+            } 
+            // If there is a current activity, it is assumed that Application Insights will track it so we do not start an operation. 
+            // However, in some cases (such as Durable functions), this is not the case. This allows the scope to decide whether
+            // an operation should be started, even when the current activity is not null. 
             else if (allScopes.ContainsKey("MS_TrackActivity"))
             {
                 var operation = _telemetryClient.StartOperation<RequestTelemetry>(currentActivity);

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
@@ -526,6 +526,11 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                     // We'll need to store this operation context so we can stop it when the function completes
                     stateValues[OperationContext] = operation;
                 }
+            } // Track Activity if the key is the TrackActivity Scope is specified. 
+            else if (allScopes.ContainsKey("MS_TrackActivity"))
+            {
+                var operation = _telemetryClient.StartOperation<RequestTelemetry>(currentActivity);
+                stateValues[OperationContext] = operation;
             }
         }
 


### PR DESCRIPTION
Hi @brettsam 

I use to submit the PR that is enabling suppression of the telemetry, however, we realized that we don't need suppression, but we need to track the activity that is generated from an extension with adding custom property of the functions host (e.g. invocation id) 

We can do it if we specify "MS_IgnoreActivity" however, it generate a new telemetry that is a child of the original telemetry. 

To enable it, I create this PR. Could you have a look? 

I'll going to close the 
https://github.com/Azure/azure-webjobs-sdk/pull/2467
Since It is not needed anymore. 

## Usage 

```csharp
using (logger.BeginScope(new Dictionary<string, object> { ["MS_TrackActivity"] = null }))
{
     // functions invocation
 }
```