### PR TITLE
[Storage] updating to 11.1.4; handling storage network timeouts

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/TimeoutHandler.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/TimeoutHandler.cs
@@ -2,21 +2,27 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.Storage;
 using Microsoft.Azure.WebJobs.Host.Timers;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Storage
 {
     internal static class TimeoutHandler
     {
-        private static readonly TimeSpan DefaultTimeout = TimeSpan.FromMinutes(2);
+        private static readonly TimeSpan DefaultTimeout = TimeSpan.FromMinutes(3);
 
-        public static async Task<T> ExecuteWithTimeout<T>(string operationName, string clientRequestId, IWebJobsExceptionHandler exceptionHandler, Func<Task<T>> operation)
+        public static async Task<T> ExecuteWithTimeout<T>(string operationName, string clientRequestId,
+            IWebJobsExceptionHandler exceptionHandler, ILogger logger, CancellationToken cancellationToken, Func<Task<T>> operation)
         {
             using (var cts = new CancellationTokenSource())
             {
+                Stopwatch sw = Stopwatch.StartNew();
+
                 Task timeoutTask = Task.Delay(DefaultTimeout, cts.Token);
                 Task<T> operationTask = operation();
 
@@ -42,7 +48,30 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage
                 // Cancel the Delay.
                 cts.Cancel();
 
-                return await operationTask;
+                try
+                {
+                    // Determine if this was a deadlock. If so, log it and rethrow. Use the passed-in cancellationToken
+                    // to detemrine of this operation was canceled explicitly or was due to an internal network timeout.
+
+                    return await operationTask;
+                }
+                catch (StorageException ex) when (ex.InnerException is OperationCanceledException && !cancellationToken.IsCancellationRequested) // network timeout
+                {
+                    Logger.StorageTimeout(logger, operationName, clientRequestId, sw.ElapsedMilliseconds);
+                    throw;
+                }
+            }
+        }
+
+        private static class Logger
+        {
+            private static readonly Action<ILogger, string, string, long, Exception> _storageDeadlock =
+                LoggerMessage.Define<string, string, long>(Microsoft.Extensions.Logging.LogLevel.Debug, new EventId(600, nameof(StorageTimeout)),
+                    "The operation '{operationName}' with id '{clientRequestId}' was canceled due to a network timeout after '{elapsed}' ms.");
+
+            internal static void StorageTimeout(ILogger logger, string operationName, string clientRequestId, long elapsedMilliseconds)
+            {
+                _storageDeadlock(logger, operationName, clientRequestId, elapsedMilliseconds, null);
             }
         }
     }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/WebJobs.Extensions.Storage.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/WebJobs.Extensions.Storage.csproj
@@ -93,9 +93,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.5" />
-    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.1.0" />
-    <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="11.1.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.7" />
+    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.1.4" />
+    <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="11.1.4" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.14" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Microsoft.Azure.WebJobs.Host.Storage/WebJobs.Host.Storage.csproj
+++ b/src/Microsoft.Azure.WebJobs.Host.Storage/WebJobs.Host.Storage.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.1.0" />
+    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.1.4" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Microsoft.Azure.WebJobs.Host/Timers/TaskSeriesTimer.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Timers/TaskSeriesTimer.cs
@@ -147,9 +147,9 @@ namespace Microsoft.Azure.WebJobs.Host.Timers
                         TaskSeriesCommandResult result = await _command.ExecuteAsync(cancellationToken);
                         wait = result.Wait;
                     }
-                    catch (Exception ex) when (ex.InnerException is TaskCanceledException)
+                    catch (Exception ex) when (ex.InnerException is OperationCanceledException)
                     {
-                        // TaskCanceledExceptions coming from storage are wrapped in a StorageException.
+                        // OperationCanceledExceptions coming from storage are wrapped in a StorageException.
                         // We'll handle them all here so they don't have to be managed for every call.
                     }
                     catch (OperationCanceledException)

--- a/src/Microsoft.Azure.WebJobs.Logging/WebJobs.Logging.csproj
+++ b/src/Microsoft.Azure.WebJobs.Logging/WebJobs.Logging.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.5" />
+    <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.7" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/FakeStorage/FakeAzureStorage.csproj
+++ b/test/FakeStorage/FakeAzureStorage.csproj
@@ -8,9 +8,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.5" />
-    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.1.0" />
-    <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="11.1.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.7" />
+    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.1.4" />
+    <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="11.1.4" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004" />
   </ItemGroup>
 

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/WebJobs.Host.TestCommon.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/WebJobs.Host.TestCommon.csproj
@@ -22,8 +22,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.1.0" />
-    <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="11.1.0" />
+    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.1.4" />
+    <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="11.1.4" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>

--- a/test/Microsoft.Azure.Webjobs.Extensions.Storage.UnitTests/Blobs/Listeners/StorageBlobClientExtensionsTests.cs
+++ b/test/Microsoft.Azure.Webjobs.Extensions.Storage.UnitTests/Blobs/Listeners/StorageBlobClientExtensionsTests.cs
@@ -61,9 +61,9 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Blobs.Listeners
             // Mock the List function to return the correct blob page
             HashSet<BlobContinuationToken> seenTokens = new HashSet<BlobContinuationToken>();
             BlobResultSegment resultSegment = null;
-            mockClient.Setup(p => p.ListBlobsSegmentedAsync("test", true, BlobListingDetails.None, null, It.IsAny<BlobContinuationToken>(), null, It.IsAny<OperationContext>()))
-                .Callback<string, bool, BlobListingDetails, int?, BlobContinuationToken, BlobRequestOptions, OperationContext>(
-                    (prefix, useFlatBlobListing, blobListingDetails, maxResultsValue, currentToken, options, operationContext) =>
+            mockClient.Setup(p => p.ListBlobsSegmentedAsync("test", true, BlobListingDetails.None, null, It.IsAny<BlobContinuationToken>(), null, It.IsAny<OperationContext>(), It.IsAny<CancellationToken>()))
+                .Callback<string, bool, BlobListingDetails, int?, BlobContinuationToken, BlobRequestOptions, OperationContext, CancellationToken>(
+                    (prefix, useFlatBlobListing, blobListingDetails, maxResultsValue, currentToken, options, operationContext, cancellationToken) =>
                     {
                         // Previously this is where a bug existed - ListBlobsAsync wasn't handling
                         // continuation tokens properly and kept sending the same initial token

--- a/test/Microsoft.Azure.Webjobs.Extensions.Storage.UnitTests/Blobs/Listeners/StorageBlobClientExtensionsTests.cs
+++ b/test/Microsoft.Azure.Webjobs.Extensions.Storage.UnitTests/Blobs/Listeners/StorageBlobClientExtensionsTests.cs
@@ -6,13 +6,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.WebJobs.Host.Blobs.Listeners;
-using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.Azure.Storage;
 using Microsoft.Azure.Storage.Blob;
+using Microsoft.Azure.WebJobs.Host.Blobs.Listeners;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
-
 
 namespace Microsoft.Azure.WebJobs.Host.UnitTests.Blobs.Listeners
 {
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Blobs.Listeners
                     })
                 .Returns(() => { return Task.FromResult(resultSegment); });
 
-            IEnumerable<IListBlobItem> results = await mockClient.Object.ListBlobsAsync("test", true, BlobListingDetails.None, "test", new TestExceptionHandler(), CancellationToken.None);
+            IEnumerable<IListBlobItem> results = await mockClient.Object.ListBlobsAsync("test", true, BlobListingDetails.None, "test", new TestExceptionHandler(), NullLogger<BlobListener>.Instance, CancellationToken.None);
 
             Assert.Equal(blobCount, results.Count());
         }

--- a/test/Microsoft.Azure.Webjobs.Extensions.Storage.UnitTests/WebJobs.Extensions.Storage.UnitTests.csproj
+++ b/test/Microsoft.Azure.Webjobs.Extensions.Storage.UnitTests/WebJobs.Extensions.Storage.UnitTests.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.5" />
-    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.1.0" />
-    <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="11.1.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.7" />
+    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.1.4" />
+    <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="11.1.4" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Storage 11.1.4 now cancels network timeouts after 100 seconds by default: https://github.com/Azure/azure-storage-net/pull/985 

Our TimeoutHandler workaround is likely not needed at all anymore, however, I wanted to leave it in just to make sure. So I changed this to:

1. Increase the timeout of our TimeoutHandler from 2 minutes to 3 minutes.
2. Check and log if we get a network timeout to make sure it's behaving as we expect (and also for the added data).

If things go well and we never see the TimeoutHandler fire anymore, we can remove it completely and simplify these calls in a future release.
