### PR TITLE
Function execution log message now includes execution duration.

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/FunctionInstanceLogger.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/FunctionInstanceLogger.cs
@@ -76,19 +76,19 @@ namespace Microsoft.Azure.WebJobs.Host.Loggers
                 LoggerMessage.Define<string, string, Guid>(
                     LogLevel.Information,
                     new EventId(1, nameof(FunctionStarted)),
-                    "Executing '{FunctionName}' (Reason='{Reason}', Id={InvocationId})");
+                    "Executing '{functionName}' (Reason='{reason}', Id={invocationId})");
 
             private static readonly Action<ILogger, string, string, Guid, int, Exception> _functionSucceeded =
                 LoggerMessage.Define<string, string, Guid, int>(
                     LogLevel.Information,
                     new EventId(2, nameof(FunctionCompleted)),
-                    "Executed '{FunctionName}' ({Status}, Id={InvocationId}, Duration={ExecutionDuration}ms)");
+                    "Executed '{functionName}' ({status}, Id={invocationId}, Duration={executionDuration}ms)");
 
             private static readonly Action<ILogger, string, string, Guid, int, Exception> _functionFailed =
                 LoggerMessage.Define<string, string, Guid, int>(
                     LogLevel.Error,
                     new EventId(3, nameof(FunctionCompleted)),
-                    "Executed '{FunctionName}' ({Status}, Id={InvocationId}, Duration={ExecutionDuration}ms)");
+                    "Executed '{functionName}' ({status}, Id={invocationId}, Duration={executionDuration}ms)");
 
             public static void FunctionStarted(ILogger logger, string functionName, string reason, Guid invocationId)
             {


### PR DESCRIPTION
#### Summary of changes
This change resolves Azure/azure-functions-host#5340 by adding the function execution duration to the log event written by the webjobs sdk each time a function execution completes (successfully or unsuccessfully).  In Functions v1, this duration was logged in the azure-functions-host code but that log line was removed from Functions v2 onwards, however a similar event is logged in the azure-webjobs-sdk code where I have added the duration.

This change also takes the opportunity to modify the placeholder names in the log message string in this file to Pascal case to meet the recommendation [here](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/loggermessage?view=aspnetcore-3.1).  The placeholder names show up as property names in the structured logs.

Sample log message before this change:
"Executed 'Functions.BlobTrigger' (Succeeded, Id=c3004a96-5aa3-4bbe-a31a-284623cae9e8)"

Sample log message after this change:
"Executed 'Functions.BlobTrigger' (Succeeded, Id=c3004a96-5aa3-4bbe-a31a-284623cae9e8**, Duration=596ms**)"

#### Validation
Code was tested locally and validated for both successful and unsuccessful function execution by checking console logs and App Insights logs.