### PR TITLE
Less allocatey logging for trigger details

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/FunctionInstanceLogger.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/FunctionInstanceLogger.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Protocols;
@@ -37,12 +38,23 @@ namespace Microsoft.Azure.WebJobs.Host.Loggers
             return Task.FromResult<string>(null);
         }
 
-        private void LogTemplatizedTriggerDetails(ILogger logger, FunctionStartedMessage message)
+        private static void LogTemplatizedTriggerDetails(ILogger logger, FunctionStartedMessage message)
         {
-            var templateKeys = message.TriggerDetails.Select(entry => $"{entry.Key}: {{{entry.Key}}}");
-            string messageTemplate = "Trigger Details: " + string.Join(", ", templateKeys);
-            string[] templateValues = message.TriggerDetails.Values.ToArray();
+            var sb = new StringBuilder("Trigger Details: ");
 
+            foreach (var entry in message.TriggerDetails)
+            {
+                sb.Append(entry.Key);
+                sb.Append(": {");
+                sb.Append(entry.Key);
+                sb.Append("}, ");
+            }
+
+            // remove last 2 chars, which are ", "
+            sb.Remove(sb.Length - 2, 2);
+            var messageTemplate = sb.ToString();
+
+            var templateValues = message.TriggerDetails.Values.ToArray();
             logger.LogInformation(messageTemplate, templateValues);
         }
 


### PR DESCRIPTION
This PR reduces by half amount of memory allocated for logging the templatized trigger details.

### Bechmarking

For rough benchmarking purposes I simulated an Azure Queue trigger and its trigger details and used sharplab to verify the PR, see [this gist](https://gist.github.com/Scooletz/e7e9e91584e3123fee57b8a38770d6a7)

The amount of reduced memory footprint is quite high.