### PR TITLE
moving App Insights to 2.14.0

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
@@ -24,18 +24,18 @@
   </ItemGroup>
   
   <ItemGroup>
-  <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.12.2" />
-  <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.12.2" />
+  <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.14.0" />
+  <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.14.0" />
   <PackageReference Include="Microsoft.ApplicationInsights.SnapshotCollector" Version="1.3.7" />
-  <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.12.2" />
-  <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.12.2" />
+  <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.14.0" />
+  <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.14.0" />
   <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.1.0" />
   <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.0" />
   <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.12.2" />
-    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.12.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.14.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.14.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.0" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/ApplicationInsightsEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/ApplicationInsightsEndToEndTests.cs
@@ -661,7 +661,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     true,
                     "0",
                     traceId,
-                    $"|{traceId}.{parentSpanId}.");
+                    parentSpanId);
 
                 Assert.Equal(sampledIn ? SamplingDecision.SampledIn : SamplingDecision.None, functionRequest.ProactiveSamplingDecision);                    
 
@@ -945,7 +945,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     success,
                     "204",
                     "4bf92f3577b34da6a3ce929d0e0e4736",
-                    "|4bf92f3577b34da6a3ce929d0e0e4736.00f067aa0ba902b7.");
+                    "00f067aa0ba902b7");
 
                 Assert.DoesNotContain("MS_HttpRequest", functionRequest.Properties.Keys);
                 // Make sure operation ids match
@@ -1105,7 +1105,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                         true,
                         "204",
                         "4bf92f3577b34da6a3ce929d0e0e4736",
-                        "|4bf92f3577b34da6a3ce929d0e0e4736.00f067aa0ba902b7.");
+                        "00f067aa0ba902b7");
 
                     Assert.Equal(_expectedResponseCode.ToString(), functionRequest.ResponseCode);
                 }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsLoggerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsLoggerTests.cs
@@ -11,7 +11,6 @@ using System.Threading.Tasks;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
-using Microsoft.ApplicationInsights.Extensibility.W3C;
 using Microsoft.ApplicationInsights.SnapshotCollector;
 using Microsoft.ApplicationInsights.WindowsServer.Channel.Implementation;
 using Microsoft.AspNetCore.Http;
@@ -88,7 +87,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             string expectedOperationId, expectedRequestId;
             using (logger.BeginFunctionScope(CreateFunctionInstance(_invocationId), _hostInstanceId))
             {
-                expectedRequestId = $"|{Activity.Current.TraceId.ToHexString()}.{Activity.Current.SpanId.ToHexString()}.";
+                expectedRequestId = Activity.Current.SpanId.ToHexString();
                 expectedOperationId = Activity.Current.TraceId.ToHexString();
 
                 // sleep briefly to provide a non-zero Duration
@@ -124,7 +123,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             string expectedOperationId, expectedRequestId;
             using (logger.BeginFunctionScope(CreateFunctionInstance(_invocationId), _hostInstanceId))
             {
-                expectedRequestId = $"|{Activity.Current.TraceId.ToHexString()}.{Activity.Current.SpanId.ToHexString()}.";
+                expectedRequestId = Activity.Current.SpanId.ToHexString();
                 expectedOperationId = Activity.Current.TraceId.ToHexString();
 
                 logger.LogFunctionResult(result);
@@ -217,7 +216,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                 logger.LogTrace("Trace");
                 logger.LogWarning("Warning");
 
-                expectedRequestId = $"|{Activity.Current.TraceId.ToHexString()}.{Activity.Current.SpanId.ToHexString()}.";
+                expectedRequestId = Activity.Current.SpanId.ToHexString();
                 expectedOperationId = Activity.Current.TraceId.ToHexString();
             }
 
@@ -285,7 +284,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             {
                 logger.LogError(0, ex, "Error with customer: {customer}.", "John Doe");
 
-                expectedRequestId = $"|{Activity.Current.TraceId.ToHexString()}.{Activity.Current.SpanId.ToHexString()}.";
+                expectedRequestId = Activity.Current.SpanId.ToHexString();
                 expectedOperationId = Activity.Current.TraceId.ToHexString();
             }
 
@@ -336,7 +335,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             {
                 logger.LogMetric("CustomMetric", 44.9);
 
-                expectedRequestId = $"|{Activity.Current.TraceId.ToHexString()}.{Activity.Current.SpanId.ToHexString()}.";
+                expectedRequestId = Activity.Current.SpanId.ToHexString();
                 expectedOperationId = Activity.Current.TraceId.ToHexString();
             }
 
@@ -402,7 +401,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             string expectedOperationId, expectedRequestId;
             using (logger.BeginFunctionScope(CreateFunctionInstance(scopeGuid), _hostInstanceId))
             {
-                expectedRequestId = $"|{Activity.Current.TraceId.ToHexString()}.{Activity.Current.SpanId.ToHexString()}.";
+                expectedRequestId = Activity.Current.SpanId.ToHexString();
                 expectedOperationId = Activity.Current.TraceId.ToHexString();
 
                 var props = new Dictionary<string, object>
@@ -462,7 +461,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                 };
                 logger.LogMetric("CustomMetric", 1.1, props);
 
-                expectedRequestId = $"|{Activity.Current.TraceId.ToHexString()}.{Activity.Current.SpanId.ToHexString()}.";
+                expectedRequestId = Activity.Current.SpanId.ToHexString();
                 expectedOperationId = Activity.Current.TraceId.ToHexString();
             }
 
@@ -734,7 +733,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             var logger = CreateLogger(LogCategories.Results);
 
             Activity parent = new Activity("foo").Start();
-            using (logger.BeginScope(new Dictionary<string, object> { ["MS_IgnoreActivity"] = null} ))
+            using (logger.BeginScope(new Dictionary<string, object> { ["MS_IgnoreActivity"] = null }))
             using (logger.BeginFunctionScope(CreateFunctionInstance(_invocationId), _hostInstanceId))
             {
                 logger.LogFunctionResult(result);
@@ -778,12 +777,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
 
             Assert.Single(_channel.Telemetries.OfType<RequestTelemetry>());
             RequestTelemetry telemetry = _channel.Telemetries.OfType<RequestTelemetry>().Single();
-            Assert.Equal(FormatTelemetryId(current), telemetry.Id);
-        }
-
-        private static string FormatTelemetryId(Activity activity)
-        {
-            return "|" + activity.TraceId.ToHexString() + "." + activity.SpanId.ToHexString() + ".";
+            Assert.Equal(current.SpanId.ToHexString(), telemetry.Id);
         }
 
         [Fact]


### PR DESCRIPTION
This required some non-breaking test updates due to:
- https://github.com/microsoft/ApplicationInsights-dotnet/pull/1498
- https://github.com/microsoft/ApplicationInsights-Announcements/issues/27