### PR TITLE
Allocating a lot less in ExceptionFormatter.GetFormattedException

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Diagnostics/ExceptionFormatter.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Diagnostics/ExceptionFormatter.cs
@@ -209,7 +209,8 @@ namespace Microsoft.Azure.WebJobs.Host.Diagnostics
                 var end = fullName.LastIndexOf('>');
                 if (start >= 0 && end >= 0)
                 {
-                    stringBuilder.Append(fullName.Remove(start, 1).Substring(0, end - 1));
+                    stringBuilder.Append(fullName, 0, start);
+                    stringBuilder.Append(fullName, start + 1, end - start - 1);
                 }
                 else
                 {

--- a/src/Microsoft.Azure.WebJobs.Host/Diagnostics/ExceptionFormatter.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Diagnostics/ExceptionFormatter.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Azure.WebJobs.Host.Diagnostics
             var method = frame.GetMethod();
             var declaringType = method?.DeclaringType;
             
-            if (ShouldShowFrame(declaringType) == false)
+            if (!ShouldShowFrame(declaringType))
             {
                 return;
             }

--- a/src/Microsoft.Azure.WebJobs.Host/Diagnostics/ExceptionFormatter.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Diagnostics/ExceptionFormatter.cs
@@ -107,23 +107,25 @@ namespace Microsoft.Azure.WebJobs.Host.Diagnostics
                 return;
             }
 
-            var toProcess = from frame in stackFrames
-                                  let method = frame.GetMethod()
-                                  let declaringType = method?.DeclaringType
-                                  where ShouldShowFrame(declaringType)
-                                  select (method: method, declaringType: declaringType, frame: frame);
-
-            foreach (var frame in toProcess)
+            foreach (var frame in stackFrames)
             {
-                FormatFrame(sb, frame.method, frame.declaringType, frame.frame);
+                FormatFrame(sb, frame);
             }
         }
 
         private static bool ShouldShowFrame(Type declaringType) =>
             !(declaringType != null && typeof(INotifyCompletion).IsAssignableFrom(declaringType));
 
-        private static void FormatFrame(StringBuilder stringBuilder, MethodBase method, Type declaringType, StackFrame frame)
+        private static void FormatFrame(StringBuilder stringBuilder, StackFrame frame)
         {
+            var method = frame.GetMethod();
+            var declaringType = method?.DeclaringType;
+            
+            if (ShouldShowFrame(declaringType) == false)
+            {
+                return;
+            }
+
             stringBuilder.AppendLine();
 
             stringBuilder.Append("   at ");

--- a/src/Microsoft.Azure.WebJobs.Host/Diagnostics/ExceptionFormatter.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Diagnostics/ExceptionFormatter.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Azure.WebJobs.Host.Diagnostics
                                   let method = frame.GetMethod()
                                   let declaringType = method?.DeclaringType
                                   where ShouldShowFrame(declaringType)
-                                  select (method, declaringType, frame);
+                                  select (method: method, declaringType: declaringType, frame: frame);
 
             foreach (var frame in toProcess)
             {

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/ExceptionFormatterTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/ExceptionFormatterTests.cs
@@ -34,6 +34,9 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             catch (Exception exc)
             {
                 string formattedException = GetFormattedException(exc);
+
+                Assert.Equal(OutputRemovesAsyncFrames, formattedException);
+
                 Assert.DoesNotMatch("d__.\\.MoveNext()", formattedException);
                 Assert.DoesNotContain("TaskAwaiter", formattedException);
             }
@@ -50,6 +53,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             catch (Exception exc)
             {
                 string formattedException = GetFormattedException(exc);
+
+                Assert.Equal(OutputResolvesAsyncMethodNames, formattedException);
 
                 string typeName = $"{typeof(TestClass).DeclaringType.FullName}.{ nameof(TestClass)}";
                 Assert.Contains($"async {typeName}.{nameof(TestClass.Run1Async)}()", formattedException);
@@ -69,7 +74,10 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             catch (Exception exc)
             {
                 string formattedException = GetFormattedException(exc);
-                
+
+                Assert.Equal(OutputOutputsMethodParameters, formattedException);
+
+
                 Assert.Contains($"{nameof(TestClass.Run)}(String arg)", formattedException);
             }
         }
@@ -85,6 +93,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             catch (Exception exc)
             {
                 string formattedException = GetFormattedException(exc);
+
+                Assert.Equal(OutputOutputsExpectedAsyncMethodParameters, formattedException);
 
                 Assert.Contains($"{nameof(TestClass.Run4Async)}(String arg)", formattedException);
 
@@ -187,5 +197,66 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 await CrashAsync();
             }
         }
+
+        const string OutputRemovesAsyncFrames =
+@"System.AggregateException : One or more errors occurred. (Crash!) ---> Crash!
+   at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
+   at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout,CancellationToken cancellationToken)
+   at System.Threading.Tasks.Task.Wait()
+   at Microsoft.Azure.WebJobs.Host.UnitTests.ExceptionFormatterTests.TestClass.Run(String arg) at C:\GIT\azure-webjobs-sdk\test\Microsoft.Azure.WebJobs.Host.UnitTests\ExceptionFormatterTests.cs : 137
+   at Microsoft.Azure.WebJobs.Host.UnitTests.ExceptionFormatterTests.TestClass.Run() at C:\GIT\azure-webjobs-sdk\test\Microsoft.Azure.WebJobs.Host.UnitTests\ExceptionFormatterTests.cs : 129
+   at Microsoft.Azure.WebJobs.Host.UnitTests.ExceptionFormatterTests.FormatException_RemovesAsyncFrames() at C:\GIT\azure-webjobs-sdk\test\Microsoft.Azure.WebJobs.Host.UnitTests\ExceptionFormatterTests.cs : 32
+---> (Inner Exception #0) System.Exception : Crash!
+   at async Microsoft.Azure.WebJobs.Host.UnitTests.ExceptionFormatterTests.TestClass.CrashAsync() at C:\GIT\azure-webjobs-sdk\test\Microsoft.Azure.WebJobs.Host.UnitTests\ExceptionFormatterTests.cs : 179
+   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
+   at async Microsoft.Azure.WebJobs.Host.UnitTests.ExceptionFormatterTests.TestClass.Run2Async() at C:\GIT\azure-webjobs-sdk\test\Microsoft.Azure.WebJobs.Host.UnitTests\ExceptionFormatterTests.cs : 172
+   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
+   at async Microsoft.Azure.WebJobs.Host.UnitTests.ExceptionFormatterTests.TestClass.Run1Async() at C:\GIT\azure-webjobs-sdk\test\Microsoft.Azure.WebJobs.Host.UnitTests\ExceptionFormatterTests.cs : 166<---
+";
+
+        const string OutputResolvesAsyncMethodNames =
+@"System.AggregateException : One or more errors occurred. (Crash!) ---> Crash!
+   at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
+   at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout,CancellationToken cancellationToken)
+   at System.Threading.Tasks.Task.Wait()
+   at Microsoft.Azure.WebJobs.Host.UnitTests.ExceptionFormatterTests.TestClass.Run(String arg) at C:\GIT\azure-webjobs-sdk\test\Microsoft.Azure.WebJobs.Host.UnitTests\ExceptionFormatterTests.cs : 137
+   at Microsoft.Azure.WebJobs.Host.UnitTests.ExceptionFormatterTests.TestClass.Run() at C:\GIT\azure-webjobs-sdk\test\Microsoft.Azure.WebJobs.Host.UnitTests\ExceptionFormatterTests.cs : 129
+   at Microsoft.Azure.WebJobs.Host.UnitTests.ExceptionFormatterTests.FormatException_ResolvesAsyncMethodNames() at C:\GIT\azure-webjobs-sdk\test\Microsoft.Azure.WebJobs.Host.UnitTests\ExceptionFormatterTests.cs : 51
+---> (Inner Exception #0) System.Exception : Crash!
+   at async Microsoft.Azure.WebJobs.Host.UnitTests.ExceptionFormatterTests.TestClass.CrashAsync() at C:\GIT\azure-webjobs-sdk\test\Microsoft.Azure.WebJobs.Host.UnitTests\ExceptionFormatterTests.cs : 179
+   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
+   at async Microsoft.Azure.WebJobs.Host.UnitTests.ExceptionFormatterTests.TestClass.Run2Async() at C:\GIT\azure-webjobs-sdk\test\Microsoft.Azure.WebJobs.Host.UnitTests\ExceptionFormatterTests.cs : 172
+   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
+   at async Microsoft.Azure.WebJobs.Host.UnitTests.ExceptionFormatterTests.TestClass.Run1Async() at C:\GIT\azure-webjobs-sdk\test\Microsoft.Azure.WebJobs.Host.UnitTests\ExceptionFormatterTests.cs : 166<---
+"; 
+        const string OutputOutputsMethodParameters =
+@"System.AggregateException : One or more errors occurred. (Crash!) ---> Crash!
+   at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
+   at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout,CancellationToken cancellationToken)
+   at System.Threading.Tasks.Task.Wait()
+   at Microsoft.Azure.WebJobs.Host.UnitTests.ExceptionFormatterTests.TestClass.Run(String arg) at C:\GIT\azure-webjobs-sdk\test\Microsoft.Azure.WebJobs.Host.UnitTests\ExceptionFormatterTests.cs : 137
+   at Microsoft.Azure.WebJobs.Host.UnitTests.ExceptionFormatterTests.TestClass.Run() at C:\GIT\azure-webjobs-sdk\test\Microsoft.Azure.WebJobs.Host.UnitTests\ExceptionFormatterTests.cs : 129
+   at Microsoft.Azure.WebJobs.Host.UnitTests.ExceptionFormatterTests.FormatException_OutputsMethodParameters() at C:\GIT\azure-webjobs-sdk\test\Microsoft.Azure.WebJobs.Host.UnitTests\ExceptionFormatterTests.cs : 72
+---> (Inner Exception #0) System.Exception : Crash!
+   at async Microsoft.Azure.WebJobs.Host.UnitTests.ExceptionFormatterTests.TestClass.CrashAsync() at C:\GIT\azure-webjobs-sdk\test\Microsoft.Azure.WebJobs.Host.UnitTests\ExceptionFormatterTests.cs : 179
+   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
+   at async Microsoft.Azure.WebJobs.Host.UnitTests.ExceptionFormatterTests.TestClass.Run2Async() at C:\GIT\azure-webjobs-sdk\test\Microsoft.Azure.WebJobs.Host.UnitTests\ExceptionFormatterTests.cs : 172
+   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
+   at async Microsoft.Azure.WebJobs.Host.UnitTests.ExceptionFormatterTests.TestClass.Run1Async() at C:\GIT\azure-webjobs-sdk\test\Microsoft.Azure.WebJobs.Host.UnitTests\ExceptionFormatterTests.cs : 166<---
+";
+        const string OutputOutputsExpectedAsyncMethodParameters =
+@"System.AggregateException : One or more errors occurred. (Crash!) ---> Crash!
+   at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
+   at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout,CancellationToken cancellationToken)
+   at System.Threading.Tasks.Task.Wait()
+   at Microsoft.Azure.WebJobs.Host.UnitTests.ExceptionFormatterTests.TestClass.Run(String arg) at C:\GIT\azure-webjobs-sdk\test\Microsoft.Azure.WebJobs.Host.UnitTests\ExceptionFormatterTests.cs : 141
+   at Microsoft.Azure.WebJobs.Host.UnitTests.ExceptionFormatterTests.FormatException_OutputsExpectedAsyncMethodParameters() at C:\GIT\azure-webjobs-sdk\test\Microsoft.Azure.WebJobs.Host.UnitTests\ExceptionFormatterTests.cs : 91
+---> (Inner Exception #0) System.Exception : Crash!
+   at async Microsoft.Azure.WebJobs.Host.UnitTests.ExceptionFormatterTests.TestClass.CrashAsync() at C:\GIT\azure-webjobs-sdk\test\Microsoft.Azure.WebJobs.Host.UnitTests\ExceptionFormatterTests.cs : 179
+   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
+   at async Microsoft.Azure.WebJobs.Host.UnitTests.ExceptionFormatterTests.TestClass.Run5Async(??) at C:\GIT\azure-webjobs-sdk\test\Microsoft.Azure.WebJobs.Host.UnitTests\ExceptionFormatterTests.cs : 191
+   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
+   at async Microsoft.Azure.WebJobs.Host.UnitTests.ExceptionFormatterTests.TestClass.Run4Async(String arg) at C:\GIT\azure-webjobs-sdk\test\Microsoft.Azure.WebJobs.Host.UnitTests\ExceptionFormatterTests.cs : 185<---
+";
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
@@ -29,7 +29,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.DotMemoryUnit" Version="3.1.20200127.214830" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <!-- This project needs a static version number for the HostId checks, which are based on the version -->
     <Version>3.0.0$(VersionSuffix)</Version>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>Microsoft.Azure.WebJobs.Host.UnitTests</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Host.UnitTests</RootNamespace>

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <!-- This project needs a static version number for the HostId checks, which are based on the version -->
     <Version>3.0.0$(VersionSuffix)</Version>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>Microsoft.Azure.WebJobs.Host.UnitTests</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Host.UnitTests</RootNamespace>
@@ -29,6 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="JetBrains.DotMemoryUnit" Version="3.1.20200127.214830" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This PR reduces the amount of memory used by `ExceptionFormatter.GetFormattedException` by passing using all the way up/down a single `StringBuilder`. The amount of allocated memory shown by dotMemory have been reduced and for the following tests is following

|  Test name | Before (bytes)  | After (bytes)  |  
|---|---|---|
| FormatException_OutputsExpectedAsyncMethodParameters  | 294383 	  | 271439|
| FormatException_OutputsMethodParameters | 78014			  | 53774|
| FormatException_RemovesAsyncFrames  | 74614			  | 50450|
| FormatException_ResolvesAsyncMethodNames |94052			|69418|

This PR includes several commits that were put at the beginning and reverted at the end. 

The first one is related to `dotMemory` as I failed to find a benchmarking for this. I didn't want to blow it up out proportion so used locally dotMemory for finding the gaps.

The other commit is related to assertions for the formatted exceptions. I found the number of assertions no big enough to make me sure about the outcome, so I captured the initial output and used it through the whole process.

Even if this PR seems flaky, the implementation of `ExceptionFormatter.GetFormattedException` is good to be copied if/when the benchmarking and stronger assertions are added to the suite. Again, I'm not prescriptive, just trying to bring the reasoning and the work behind the PR