### PR TITLE
Removed unnecessary dependency of Logging.ApplicationInsights on AspNetCore.Mvc

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
@@ -29,8 +29,6 @@
   <PackageReference Include="Microsoft.ApplicationInsights.SnapshotCollector" Version="1.3.7" />
   <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.14.0" />
   <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.14.0" />
-  <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.1.0" />
-  <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.0" />
   <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
We're using the "Microsoft.Azure.WebJobs.Logging.ApplicationInsights" package on an ASP.NET MVC 5 project and these MVC Core references are causing some trouble (due to mixing MVC and MVC Core together).

It seems that they are not actually necessary, all it needs is the HTTP abstractions, so I removed those dependencies.