### PR TITLE
Add "EventName" App Insights telemetry

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/Constants/LogConstants.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/Constants/LogConstants.cs
@@ -125,6 +125,11 @@ namespace Microsoft.Azure.WebJobs.Logging
         public const string EventIdKey = "EventId";
 
         /// <summary>
+        /// Gets the name of the key used to store the event name in the EventId of the log message.
+        /// </summary>
+        public const string EventNameKey = "EventName";
+
+        /// <summary>
         /// Gets the function start event name.
         /// </summary>
         public const string FunctionStartEvent = "FunctionStart";

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                 LogConstants.CategoryNameKey,
                 LogConstants.LogLevelKey,
                 LogConstants.EventIdKey,
+                LogConstants.EventNameKey,
                 LogConstants.OriginalFormatKey,
                 ApplicationInsightsScopeKeys.HttpRequest,
                 ScopeKeys.Event,
@@ -77,7 +78,8 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
             {
                 [LogConstants.CategoryNameKey] = _categoryName,
                 [LogConstants.LogLevelKey] = (LogLevel?)logLevel,
-                [LogConstants.EventIdKey] = eventId.Id
+                [LogConstants.EventIdKey] = eventId.Id,
+                [LogConstants.EventNameKey] = eventId.Name,
             }))
             {
                 // Log a metric from user logs only

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/WebJobsTelemetryInitializer.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/WebJobsTelemetryInitializer.cs
@@ -96,6 +96,12 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                 {
                     telemetryProps[LogConstants.EventIdKey] = eventId.Value.ToString();
                 }
+
+                string eventName = scopeProps.GetValueOrDefault<string>(LogConstants.EventNameKey);
+                if (eventName != null)
+                {
+                    telemetryProps[LogConstants.EventNameKey] = eventName;
+                }
             }
             
             // we may track traces/dependencies after function scope ends - we don't want to update those

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsLoggerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsLoggerTests.cs
@@ -367,15 +367,16 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
         public void Log_IncludesEventId()
         {
             ILogger logger = CreateLogger(_functionCategoryName);
-            logger.Log(LogLevel.Information, 100, "Test", null, (s, e) => s);
+            logger.Log(LogLevel.Information, new EventId(100, "TestEvent"), "Test", null, (s, e) => s);
 
             var telemetry = _channel.Telemetries.Single() as ISupportProperties;
 
-            Assert.Equal(4, telemetry.Properties.Count);
+            Assert.Equal(5, telemetry.Properties.Count);
             Assert.Equal(Process.GetCurrentProcess().Id.ToString(), telemetry.Properties[LogConstants.ProcessIdKey]);
             Assert.Equal(_functionCategoryName, telemetry.Properties[LogConstants.CategoryNameKey]);
             Assert.Equal(LogLevel.Information.ToString(), telemetry.Properties[LogConstants.LogLevelKey]);
             Assert.Equal("100", telemetry.Properties[LogConstants.EventIdKey]);
+            Assert.Equal("TestEvent", telemetry.Properties[LogConstants.EventNameKey]);
         }
 
         [Fact]


### PR DESCRIPTION
### Problem Statement
I'm working on a [structured logging enhancement for the Durable Task Framework](https://github.com/Azure/durabletask/pull/425) that will allow Durable Functions customers to push low level DTFx logs to their Application Insights if they so choose. The intent is to greatly improve the self-diagnostic abilities for customers.

I tested my DTFx changes with [Microsoft.Extensions.Logging.ApplicationInsights](https://www.nuget.org/packages/Microsoft.Extensions.Logging.ApplicationInsights/) directly and indirectly by passing it the functions `ILoggerFactory`. One important thing I noticed immediately was that the Functions host does _not_ preserve the `EventName` field of an event. For example, consider the following log statement:

```csharp
var eventId = new EventId(100, "TestEvent");
logger.Log(LogLevel.Information, eventId, "Test", null, (s, e) => s);
```

Microsoft.Extensions.Logging.ApplicationInsights will include both `100` and `TestEvent` in the `customProperties`. However, the functions host will leave out `TestEvent`. This generally makes query authoring more difficult because customers have to remember event ID numbers instead of human-friendly event names. Durable Functions use of structured logging makes it very important for users to be able to filter by the event name.

### Fix Description
The fix is to simply update `Microsoft.Azure.WebJobs.Logging.ApplicationInsights` to write both `EventId` and `EventName` if `EventName` is present. This is accomplished by updating the AI telemetry initializer and the AI logger to include this field. I've also updated one of the existing unit tests to verify the behavior.

I verified this works end-to-end by patching the copy of the Functions core tools on my local box. Below is a screenshot of my App Insights output after this change.

![image](https://user-images.githubusercontent.com/2704139/89255521-c8fd9100-d5d6-11ea-8e8a-c0a81c0c0cac.png)

