### PR TITLE
Handle NullReferenceException in case of null entries

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Listeners/StorageAnalyticsLogParser.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Listeners/StorageAnalyticsLogParser.cs
@@ -112,8 +112,10 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
 
                             _logger.LogWarning(message);
                         }
-
-                        entries.Add(entry);
+                        if (entry != null)
+                        {
+                            entries.Add(entry);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
We are logging warnings if we are not able to parse the log files due to invalid or incorrect entries. However, we are adding those null values to "entries" list, which in turn causing NullReferenceException from Microsoft.Azure.WebJobs.Host.Blobs.Listeners.GetPathsForValidBlobWrites method at line no 88. 
I have encountered one issue where same storage has been used by multiple resources and there were invalid entries within log file. When Azure Function (Blob triggered) tried to parse those logs it started throwing : "An unhandled exception has occurred. Host is shutting down." and host was getting restarted. This situation should not throw unhandled exception. Please see the below exception.

System.NullReferenceException : Object reference not set to an instance of an object.
   at Microsoft.Azure.WebJobs.Host.Blobs.Listeners.BlobLogListener.<>c.<GetPathsForValidBlobWrites>b__12_0(StorageAnalyticsLogEntry entry) at C:\projects\azure-webjobs-sdk-rqm4t\src\Microsoft.Azure.WebJobs.Extensions.Storage\Blobs\Listeners\BlobLogListener.cs : 88
   