### PR TITLE
Fix client information population of ApplicationInsights telemetry

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
@@ -355,7 +355,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
         /// </summary>
         /// <param name="state"></param>
         /// <param name="scope"></param>
-        private static void ApplyFunctionResultActivityTags(IEnumerable<KeyValuePair<string, object>> state, IDictionary<string, object> scope)
+        private void ApplyFunctionResultActivityTags(IEnumerable<KeyValuePair<string, object>> state, IDictionary<string, object> scope)
         {
             // Activity carries tracing context. It is managed by instrumented library (e.g. ServiceBus or Asp.Net Core)
             // and consumed by ApplicationInsights.
@@ -416,7 +416,9 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                     currentActivity.AddTag(LogConstants.LogLevelKey, logLevel.ToString());
                 }
 
-                if (scope.TryGetValue(ApplicationInsightsScopeKeys.HttpRequest, out var request) && request is HttpRequest httpRequest)
+                if (!_loggerOptions.HttpAutoCollectionOptions.EnableHttpTriggerExtendedInfoCollection && 
+                    scope.TryGetValue(ApplicationInsightsScopeKeys.HttpRequest, out var request) &&
+                    request is HttpRequest httpRequest)
                 {
                     currentActivity.AddTag(LoggingConstants.ClientIpKey, GetIpAddress(httpRequest));
                 }

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/NullTelemetryInitializer.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/NullTelemetryInitializer.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
+{
+    internal class NullTelemetryInitializer : ITelemetryInitializer
+    {
+        public static NullTelemetryInitializer Instance { get; } = new NullTelemetryInitializer();
+        public void Initialize(ITelemetry telemetry)
+        {
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/WebJobsTelemetryInitializer.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/WebJobsTelemetryInitializer.cs
@@ -43,21 +43,12 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
             }
 
             telemetry.Context.Cloud.RoleInstance = _roleInstanceName;
-
-            RequestTelemetry request = telemetry as RequestTelemetry;
-
-            // Zero out all IP addresses other than Requests
-            if (request == null)
+            if (telemetry.Context.Location.Ip == null)
             {
                 telemetry.Context.Location.Ip = LoggingConstants.ZeroIpAddress;
             }
-            else
-            {
-                if (request.Context.Location.Ip == null)
-                {
-                    request.Context.Location.Ip = LoggingConstants.ZeroIpAddress;
-                }
-            }
+
+            RequestTelemetry request = telemetry as RequestTelemetry;
 
             IDictionary<string, string> telemetryProps = telemetry.Context.Properties;
             telemetryProps[LogConstants.ProcessIdKey] = _currentProcessId;

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/WebJobs.Host.EndToEndTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/WebJobs.Host.EndToEndTests.csproj
@@ -23,13 +23,13 @@
 
   <ItemGroup>
     <PackageReference Include="appinsights.testlogger" Version="1.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="3.1.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="xunit" Version="2.3.1" />


### PR DESCRIPTION
Fix #2552

This PR adds default ApplicaitonInsights way to populate client IP. Because of GDPR, client IPs are removed at ingestion endpoint and instead location info is populated.

The default behavior (available for ASP.NET  and ASP.NET Core apps) populates client Ip from  `X-forwarded-For` (first value) on request telemetry and all nested telemetry items.

Functions/WebJobs behaves differently: webjobs parse `X-Forwarded-For` and falling back to `HttpContext.Connection.RemoteIpAddress` and set it on request only. WebJobs also set ip to 0.0.0.0 on all other items.

This PR enables default AppInsights way to populate clientIp by adding TelemetryInitializer. 
1. It relies on presence of `IHttpContextAccessor` enabled by [functions host](https://github.com/Azure/azure-functions-host/blob/826c0b520c1e81d2f3106d08711c08f1bce4aa95/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs#L67)
   - it uses this mechanism only if extended HTTP trigger info is configured (`HttpAutoCollectionOptions.EnableHttpTriggerExtendedInfoCollection`, true by default)
2. for the case when `EnableHttpTriggerExtendedInfoCollection` is false, we keep the old behavior (use  `X-Forwarded-For` and fall back to `HttpContext.Connection.RemoteIpAddress` and set it on request only. WebJobs also set ip to 0.0.0.0 on all other items)

I'm also happy to change old behavior. I'm not sure what were the reasons to set IPs to `0.0.0.0` and how useful it is to fallback  `HttpContext.Connection.RemoteIpAddress`.  
@brettsam what do you think?