### PR TITLE
Added logging for blob accesses during (input/output) binding

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Bindings/WatchableCloudBlobStream.Logger.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Bindings/WatchableCloudBlobStream.Logger.cs
@@ -10,8 +10,6 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
     {
         private static class Logger
         {
-            // Keep these events in 1-100 range.
-
             private static readonly Action<ILogger, string, string, string, TimeSpan, long, Exception> _blobWriteAccess =
               LoggerMessage.Define<string, string, string, TimeSpan, long>(
                   LogLevel.Debug,

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Bindings/WatchableCloudBlobStream.Logger.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Bindings/WatchableCloudBlobStream.Logger.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
+{
+    internal partial class WatchableCloudBlobStream
+    {
+        private static class Logger
+        {
+            // Keep these events in 1-100 range.
+
+            private static readonly Action<ILogger, string, string, string, TimeSpan, long, Exception> _blobWriteAccess =
+              LoggerMessage.Define<string, string, string, TimeSpan, long>(
+                  LogLevel.Debug,
+                  new EventId(2, nameof(BlobWriteAccess)),
+                  "BlobWriteAccess - Name: {name}, Type: {type}, ETag: {etag}, WriteTime: {writeTime}, BytesWritten: {bytesWritten}");
+
+            // Name is of the format <ContainerName>/<BlobName>
+            // Type is of the format <BlobType>/<ContentType>
+            public static void BlobWriteAccess(ILogger logger, string name, string type, string etag, TimeSpan writeTime, long bytesWritten) => _blobWriteAccess(logger, name, type, etag, writeTime, bytesWritten, null);
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Bindings/WatchableCloudBlobStream.Logger.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Bindings/WatchableCloudBlobStream.Logger.cs
@@ -6,19 +6,19 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
 {
-    internal partial class WatchableCloudBlobStream
+    public static class WatchableCloudBlobStreamLoggerExtension
     {
-        private static class Logger
-        {
-            private static readonly Action<ILogger, string, string, string, TimeSpan, long, Exception> _blobWriteAccess =
-              LoggerMessage.Define<string, string, string, TimeSpan, long>(
-                  LogLevel.Debug,
-                  new EventId(2, nameof(BlobWriteAccess)),
-                  "BlobWriteAccess - Name: {name}, Type: {type}, ETag: {etag}, WriteTime: {writeTime}, BytesWritten: {bytesWritten}");
+        private static readonly Action<ILogger, string, string, string, TimeSpan, long, Exception> _blobWriteAccess =
+          LoggerMessage.Define<string, string, string, TimeSpan, long>(
+              LogLevel.Debug,
+              new EventId(2, nameof(BlobWriteAccess)),
+              "BlobWriteAccess - Name: {name}, Type: {type}, ETag: {etag}, WriteTime: {writeTime}, BytesWritten: {bytesWritten}");
 
-            // Name is of the format <ContainerName>/<BlobName>
-            // Type is of the format <BlobType>/<ContentType>
-            public static void BlobWriteAccess(ILogger logger, string name, string type, string etag, TimeSpan writeTime, long bytesWritten) => _blobWriteAccess(logger, name, type, etag, writeTime, bytesWritten, null);
+        // Name is of the format <ContainerName>/<BlobName>
+        // Type is of the format <BlobType>/<ContentType>
+        public static void BlobWriteAccess(this ILogger logger, string name, string type, string etag, TimeSpan writeTime, long bytesWritten)
+        {
+            _blobWriteAccess(logger, name, type, etag, writeTime, bytesWritten, null);
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Bindings/WatchableCloudBlobStream.Logger.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Bindings/WatchableCloudBlobStream.Logger.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
 {
-    public static class WatchableCloudBlobStreamLoggerExtension
+    internal static class WatchableCloudBlobStreamLoggerExtension
     {
         private static readonly Action<ILogger, string, string, string, TimeSpan, long, Exception> _blobWriteAccess =
           LoggerMessage.Define<string, string, string, TimeSpan, long>(

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Bindings/WatchableCloudBlobStream.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Bindings/WatchableCloudBlobStream.cs
@@ -8,23 +8,40 @@ using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Protocols;
 using Microsoft.Azure.Storage.Blob;
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
 
 namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
 {
     internal class WatchableCloudBlobStream : DelegatingCloudBlobStream, IWatcher
     {
+        private readonly ILogger _logger;
+        private readonly ICloudBlob _blob;
+        private readonly Stopwatch _timeWrite = new Stopwatch();
         private readonly IBlobCommitedAction _committedAction;
 
         private bool _committed;
         private bool _completed;
         private long _countWritten;
         private bool _flushed;
+        private bool _logged;
 
         public WatchableCloudBlobStream(CloudBlobStream inner, IBlobCommitedAction committedAction)
             : base(inner)
         {
             _committedAction = committedAction;
         }
+
+        public WatchableCloudBlobStream(CloudBlobStream inner, IBlobCommitedAction committedAction, ICloudBlob blob, ILogger logger)
+            : base(inner)
+        {
+            _committedAction = committedAction;
+            _logged = false;
+            _blob = blob;
+            _logger = logger;
+        }
+
 
         public override bool CanWrite
         {
@@ -62,6 +79,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
             }
 
             base.Close();
+            Log();
         }
 
         public override void Flush()
@@ -84,8 +102,16 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
 
         public override void Write(byte[] buffer, int offset, int count)
         {
-            base.Write(buffer, offset, count);
-            _countWritten += count;
+            try
+            {
+                _timeWrite.Start();
+                base.Write(buffer, offset, count);
+                _countWritten += count;
+            }
+            finally
+            {
+                _timeWrite.Stop();
+            }
         }
 
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
@@ -96,8 +122,16 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
 
         private async Task WriteAsyncCore(Task task, int count)
         {
-            await task;
-            _countWritten += count;
+            try
+            {
+                _timeWrite.Start();
+                await task;
+                _countWritten += count;
+            }
+            finally
+            {
+                _timeWrite.Stop();
+            }
         }
 
         public override void WriteByte(byte value)
@@ -151,6 +185,41 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
             else
             {
                 return null;
+            }
+        }
+
+        private void Log()
+        {
+            if (_logged)
+            {
+                return;
+            }
+
+            if (_blob == null || _logger == null)
+            {
+                return;
+            }
+
+            try
+            {
+                List<string> statisticsList = new List<string>
+                {
+                    $"BlobName: {_blob.Name}",
+                    $"ContainerName: {_blob.Container.Name}",
+                    $"ETag: {_blob.Properties.ETag}",
+                    $"BlobType: {_blob.BlobType}",
+                    $"BytesWritten: {_countWritten}",
+                    $"ElapsedTime: {_timeWrite.Elapsed}",
+                };
+
+                string statistics = string.Join(", ", statisticsList);
+                string logMessage = $"WriteStream ({statistics})";
+                _logger.LogInformation(logMessage);
+                _logged = true;
+            }
+            catch
+            {
+                return;
             }
         }
     }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Bindings/WatchableCloudBlobStream.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Bindings/WatchableCloudBlobStream.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
 {
-    internal partial class WatchableCloudBlobStream : DelegatingCloudBlobStream, IWatcher
+    internal class WatchableCloudBlobStream : DelegatingCloudBlobStream, IWatcher
     {
         private readonly ILogger _logger;
         private readonly ICloudBlob _blob;
@@ -36,7 +36,6 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
             : base(inner)
         {
             _committedAction = committedAction;
-            _logged = false;
             _logger = logger ?? throw new ArgumentNullException("logger");
             _blob = blob ?? throw new ArgumentNullException("blob");
         }
@@ -195,7 +194,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
 
             string name = $"{_blob.Container.Name}/{_blob.Name}";
             string type = $"{_blob.Properties.BlobType}/{_blob.Properties.ContentType}";
-            Logger.BlobWriteAccess(_logger, name, type, _blob.Properties.ETag, _timeWrite.Elapsed, _countWritten);
+            _logger.BlobWriteAccess(name, type, _blob.Properties.ETag, _timeWrite.Elapsed, _countWritten);
             _logged = true;
         }
     }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Bindings/WatchableCloudBlobStream.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Bindings/WatchableCloudBlobStream.cs
@@ -203,7 +203,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
             _blobAccessLog["ETag"] = _blob.Properties.ETag;
             _blobAccessLog["ElapsedTimeOnWrite"] = _timeWrite.Elapsed;
             _blobAccessLog["BytesWritten"] = _countWritten;
-            _logger.LogInformation($"WriteStream: {_blobAccessLog}");
+            _logger.LogDebug($"WriteStream: {_blobAccessLog}");
             _logged = true;
         }
     }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Bindings/WriteBlobArgumentBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Bindings/WriteBlobArgumentBinding.cs
@@ -5,13 +5,14 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.Storage.Blob;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
 {
     internal static class WriteBlobArgumentBinding
     {
         public static async Task<WatchableCloudBlobStream> BindStreamAsync(ICloudBlob blob,
-            ValueBindingContext context, IBlobWrittenWatcher blobWrittenWatcher)
+            ValueBindingContext context, IBlobWrittenWatcher blobWrittenWatcher, ILogger logger)
         {
             var blockBlob = blob as CloudBlockBlob;
 
@@ -24,7 +25,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
 
             CloudBlobStream rawStream = await blockBlob.OpenWriteAsync(context.CancellationToken);
             IBlobCommitedAction committedAction = new BlobCommittedAction(blob, blobWrittenWatcher);
-            return new WatchableCloudBlobStream(rawStream, committedAction);
+            return new WatchableCloudBlobStream(rawStream, committedAction, blob, logger);
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Config/BlobsExtensionConfigProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Config/BlobsExtensionConfigProvider.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
         private IContextGetter<IBlobWrittenWatcher> _blobWrittenWatcherGetter;
         private readonly INameResolver _nameResolver;
         private IConverterManager _converterManager;
-        private readonly ILogger _logger;
+        private readonly ILogger _bindingStatsLogger;
 
         public BlobsExtensionConfigProvider(StorageAccountProvider accountProvider,
             BlobTriggerAttributeBindingProvider triggerBinder,
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
             _blobWrittenWatcherGetter = contextAccessor;
             _nameResolver = nameResolver;
             _converterManager = converterManager;
-            _logger = loggerFactory?.CreateLogger(LogCategories.BindingsAccessStats);
+            _bindingStatsLogger = loggerFactory.CreateLogger(LogCategories.BindingsAccessStats);
         }
 
         public void Initialize(ExtensionConfigContext context)
@@ -249,7 +249,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
 
         private async Task<Stream> ConvertToStreamAsync(ICloudBlob input, CancellationToken cancellationToken)
         {
-            WatchableReadStream watchableStream = await ReadBlobArgumentBinding.TryBindStreamAsync(input, cancellationToken, _logger);
+            WatchableReadStream watchableStream = await ReadBlobArgumentBinding.TryBindStreamAsync(input, cancellationToken, _bindingStatsLogger);
             return watchableStream;
         }
 
@@ -277,12 +277,12 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
             switch (blobAttribute.Access)
             {
                 case FileAccess.Read:
-                    var readStream = await ReadBlobArgumentBinding.TryBindStreamAsync(blob, context, _logger);
+                    var readStream = await ReadBlobArgumentBinding.TryBindStreamAsync(blob, context, _bindingStatsLogger);
                     return readStream;
 
                 case FileAccess.Write:
                     var writeStream = await WriteBlobArgumentBinding.BindStreamAsync(blob,
-                    context, _blobWrittenWatcherGetter.Value, _logger);
+                    context, _blobWrittenWatcherGetter.Value, _bindingStatsLogger);
                     return writeStream;
 
                 default:

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Config/BlobsExtensionConfigProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Config/BlobsExtensionConfigProvider.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
             _blobWrittenWatcherGetter = contextAccessor;
             _nameResolver = nameResolver;
             _converterManager = converterManager;
-            _logger = loggerFactory?.CreateLogger(LogCategories.Bindings);
+            _logger = loggerFactory?.CreateLogger(LogCategories.BindingsAccessStats);
         }
 
         public void Initialize(ExtensionConfigContext context)

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/ReadBlobArgumentBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/ReadBlobArgumentBinding.cs
@@ -7,17 +7,18 @@ using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.Storage;
 using System.Threading;
 using Microsoft.Azure.Storage.Blob;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Host.Blobs
 {
     internal static class ReadBlobArgumentBinding
     {
-        public static Task<WatchableReadStream> TryBindStreamAsync(ICloudBlob blob, ValueBindingContext context)
+        public static Task<WatchableReadStream> TryBindStreamAsync(ICloudBlob blob, ValueBindingContext context, ILogger logger)
         {
-            return TryBindStreamAsync(blob, context.CancellationToken);
+            return TryBindStreamAsync(blob, context.CancellationToken, logger);
         }
 
-        public static async Task<WatchableReadStream> TryBindStreamAsync(ICloudBlob blob, CancellationToken cancellationToken)
+        public static async Task<WatchableReadStream> TryBindStreamAsync(ICloudBlob blob, CancellationToken cancellationToken, ILogger logger)
         {
             Stream rawStream;
             try
@@ -36,7 +37,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs
                 return null;
             }
             
-            return new WatchableReadStream(rawStream);
+            return new WatchableReadStream(rawStream, blob, logger);
         }
 
         public static TextReader CreateTextReader(WatchableReadStream watchableStream)

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/WatchableReadStream.Logger.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/WatchableReadStream.Logger.cs
@@ -6,19 +6,19 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Host.Blobs
 {
-    internal partial class WatchableReadStream
+    public static class WatchableReadStreamLoggerExtension
     {
-        private static class Logger
-        {
-            private static readonly Action<ILogger, string, string, long, string, TimeSpan, long, Exception> _blobReadAccess =
-              LoggerMessage.Define<string, string, long, string, TimeSpan, long>(
-                  LogLevel.Debug,
-                  new EventId(1, nameof(BlobReadAccess)),
-                  "BlobReadAccess - Name: {name}, Type: {type}, Length: {length}, ETag: {etag}, ReadTime: {readTime}, BytesRead: {bytesRead}");
+        private static readonly Action<ILogger, string, string, long, string, TimeSpan, long, Exception> _blobReadAccess =
+          LoggerMessage.Define<string, string, long, string, TimeSpan, long>(
+              LogLevel.Debug,
+              new EventId(1, nameof(BlobReadAccess)),
+              "BlobReadAccess - Name: {name}, Type: {type}, Length: {length}, ETag: {etag}, ReadTime: {readTime}, BytesRead: {bytesRead}");
 
-            // Name is of the format <ContainerName>/<BlobName>
-            // Type is of the format <BlobType>/<ContentType>
-            public static void BlobReadAccess(ILogger logger, string name, string type, long length, string etag, TimeSpan readTime, long bytesRead) => _blobReadAccess(logger, name, type, length, etag, readTime, bytesRead, null);
+        // Name is of the format <ContainerName>/<BlobName>
+        // Type is of the format <BlobType>/<ContentType>
+        public static void BlobReadAccess(this ILogger logger, string name, string type, long length, string etag, TimeSpan readTime, long bytesRead)
+        {
+            _blobReadAccess(logger, name, type, length, etag, readTime, bytesRead, null);
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/WatchableReadStream.Logger.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/WatchableReadStream.Logger.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Host.Blobs
+{
+    internal partial class WatchableReadStream
+    {
+        private static class Logger
+        {
+            // Keep these events in 1-100 range.
+
+            private static readonly Action<ILogger, string, string, long, string, TimeSpan, long, Exception> _blobReadAccess =
+              LoggerMessage.Define<string, string, long, string, TimeSpan, long>(
+                  LogLevel.Debug,
+                  new EventId(1, nameof(BlobReadAccess)),
+                  "BlobReadAccess - Name: {name}, Type: {type}, Length: {length}, ETag: {etag}, ReadTime: {readTime}, BytesRead: {bytesRead}");
+
+            // Name is of the format <ContainerName>/<BlobName>
+            // Type is of the format <BlobType>/<ContentType>
+            public static void BlobReadAccess(ILogger logger, string name, string type, long length, string etag, TimeSpan readTime, long bytesRead) => _blobReadAccess(logger, name, type, length, etag, readTime, bytesRead, null);
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/WatchableReadStream.Logger.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/WatchableReadStream.Logger.cs
@@ -10,8 +10,6 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs
     {
         private static class Logger
         {
-            // Keep these events in 1-100 range.
-
             private static readonly Action<ILogger, string, string, long, string, TimeSpan, long, Exception> _blobReadAccess =
               LoggerMessage.Define<string, string, long, string, TimeSpan, long>(
                   LogLevel.Debug,

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/WatchableReadStream.Logger.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/WatchableReadStream.Logger.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Host.Blobs
 {
-    public static class WatchableReadStreamLoggerExtension
+    internal static class WatchableReadStreamLoggerExtension
     {
         private static readonly Action<ILogger, string, string, long, string, TimeSpan, long, Exception> _blobReadAccess =
           LoggerMessage.Define<string, string, long, string, TimeSpan, long>(

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/WatchableReadStream.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/WatchableReadStream.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs
                 return;
             }
 
-            _logger.LogInformation($"ReadStream: {_blobAccessLog}");
+            _logger.LogDebug($"ReadStream: {_blobAccessLog}");
             _blobAccessLog["ElapsedTimeOnRead"] = _timeRead.Elapsed;
             _blobAccessLog["BytesRead"] = _countRead;
             _logged = true;

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/WatchableReadStream.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/WatchableReadStream.cs
@@ -28,7 +28,6 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs
             : base(inner)
         {
             _totalLength = inner.Length;
-            _logged = false;
         }
 
         public WatchableReadStream(Stream inner, ICloudBlob blob, ILogger logger)
@@ -136,7 +135,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs
 
             string name = $"{_blob.Container.Name}/{_blob.Name}";
             string type = $"{_blob.Properties.BlobType}/{_blob.Properties.ContentType}";
-            Logger.BlobReadAccess(_logger, name, type, _blob.Properties.Length, _blob.Properties.ETag, _timeRead.Elapsed, _countRead);
+            _logger.BlobReadAccess(name, type, _blob.Properties.Length, _blob.Properties.ETag, _timeRead.Elapsed, _countRead);
             _logged = true;
         }
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/WatchableReadStream.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/WatchableReadStream.cs
@@ -142,9 +142,9 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs
                 return;
             }
 
-            _logger.LogDebug($"ReadStream: {_blobAccessLog}");
             _blobAccessLog["ElapsedTimeOnRead"] = _timeRead.Elapsed;
             _blobAccessLog["BytesRead"] = _countRead;
+            _logger.LogDebug($"ReadStream: {_blobAccessLog}");
             _logged = true;
         }
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/WatchableReadStream.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/WatchableReadStream.cs
@@ -34,7 +34,6 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs
             : base(inner)
         {
             _totalLength = inner.Length;
-            _logged = false;
             _logger = logger ?? throw new ArgumentNullException("logger");
             _blob = blob ?? throw new ArgumentNullException("blob");
         }

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncChainEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncChainEndToEndTests.cs
@@ -183,7 +183,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     "  \"LockAcquisitionPollingInterval\": \"00:00:05\"",
                     "  \"LockAcquisitionTimeout\": \"",
                     "  \"LockPeriod\": \"00:00:15\"",
-                    "}"
+                    "}",
                 }.OrderBy(p => p).ToArray();
 
                 bool hasError = loggerOutputLines.Any(p => p.Contains("Function had errors"));

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncChainEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncChainEndToEndTests.cs
@@ -184,6 +184,10 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     "  \"LockAcquisitionTimeout\": \"",
                     "  \"LockPeriod\": \"00:00:15\"",
                     "}",
+                    $"ReadStream (BlobName: {Blob2Name}, ContainerName: {blobContainerName}, ",
+                    $"WriteStream (BlobName: {Blob1Name}, ContainerName: {blobContainerName}, ",
+                    $"WriteStream (BlobName: {Blob2Name}, ContainerName: {blobContainerName}, ",
+                    $"WriteStream (BlobName: {NonWebJobsBlobName}, ContainerName: {blobContainerName}, ",
                 }.OrderBy(p => p).ToArray();
 
                 bool hasError = loggerOutputLines.Any(p => p.Contains("Function had errors"));

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncChainEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncChainEndToEndTests.cs
@@ -183,11 +183,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     "  \"LockAcquisitionPollingInterval\": \"00:00:05\"",
                     "  \"LockAcquisitionTimeout\": \"",
                     "  \"LockPeriod\": \"00:00:15\"",
-                    "}",
-                    $"ReadStream (BlobName: {Blob2Name}, ContainerName: {blobContainerName}, ",
-                    $"WriteStream (BlobName: {Blob1Name}, ContainerName: {blobContainerName}, ",
-                    $"WriteStream (BlobName: {Blob2Name}, ContainerName: {blobContainerName}, ",
-                    $"WriteStream (BlobName: {NonWebJobsBlobName}, ContainerName: {blobContainerName}, ",
+                    "}"
                 }.OrderBy(p => p).ToArray();
 
                 bool hasError = loggerOutputLines.Any(p => p.Contains("Function had errors"));


### PR DESCRIPTION
Log blob properties for blobs accessed as part of input/output parameter binding.

Sample output:
```
Application started. Press Ctrl+C to shut down.
info: Microsoft.Azure.WebJobs.Script.Workers.Rpc.RpcFunctionInvocationDispatcher[0]
      Worker process started and initialized.
info: Host.General[316]
      Host lock lease acquired by instance ID '00000000000000000000000040112D37'.
info: Function.burn_cpu_input_blob[1]
      Executing 'Functions.burn_cpu_input_blob' (Reason='This function was programmatically called via the host APIs.', Id=9040ccf6-2d98-452d-919e-fdb6df239cf8)
info: Host.Bindings[0]
      BlobAccessed (BlobName: in-hello.txt, ContainerName: testreadwrite, Length: 8, ETag: "0x8D839910DB7832E", BlobType: BlockBlob, Access: Read)
info: Host.Bindings[0]
      BlobAccessed (BlobName: out-hello.txt, ContainerName: testreadwrite, Length: 5, ETag: "0x8D8461150CCA496", BlobType: BlockBlob, Access: Write)
info: Function.burn_cpu_input_blob[2]
      Executed 'Functions.burn_cpu_input_blob' (Succeeded, Id=9040ccf6-2d98-452d-919e-fdb6df239cf8, Duration=2480ms)
```