### PR TITLE
Added new category to log resource access stats

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/Constants/LogCategories.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/Constants/LogCategories.cs
@@ -45,6 +45,11 @@ namespace Microsoft.Azure.WebJobs.Logging
         public const string Bindings = "Host.Bindings";
 
         /// <summary>
+        /// The category for function binding access stats.
+        /// </summary>
+        public const string BindingsAccessStats = "Host.Bindings.AccessStats";
+
+        /// <summary>
         /// The category for logs written for a specific function invocation.
         /// </summary>
         public static string CreateFunctionCategory(string functionName) => $"Function.{functionName}";


### PR DESCRIPTION
This new category will be used in logging blob resource accesses. That body of work is being done in [this](https://github.com/Azure/azure-webjobs-sdk/pull/2557) PR.