### PR TITLE
Added stringified stack trace as an optional parameter.

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionExecutor.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
                     if (instanceLogEntry != null)
                     {
                         await NotifyCompleteAsync(instanceLogEntry, functionStartedMessage.Arguments, exceptionInfo);
-                        _resultsLogger?.LogFunctionResult(instanceLogEntry);
+                        _resultsLogger?.LogFunctionResult(instanceLogEntry, exceptionInfo?.SourceException.ToString());
                     }
 
                     if (loggedStartedEvent)

--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/LoggerExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/LoggerExtensions.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Extensions.Logging
             logger?.Log(LogLevel.Information, LogConstants.MetricEventId, payload, null, (s, e) => null);
         }
 
-        internal static void LogFunctionResult(this ILogger logger, FunctionInstanceLogEntry logEntry)
+        internal static void LogFunctionResult(this ILogger logger, FunctionInstanceLogEntry logEntry, string exceptionStackAsString = null)
         {
             bool succeeded = logEntry.Exception == null;
 
@@ -50,7 +50,7 @@ namespace Microsoft.Extensions.Logging
             LogLevel level = succeeded ? LogLevel.Information : LogLevel.Error;
 
             // Only pass the state dictionary; no string message.
-            logger.Log(level, 0, payload, logEntry.Exception, (s, e) => null);
+            logger.Log(level, 0, payload, logEntry.Exception, (s, e) => exceptionStackAsString);
         }
 
         internal static void LogFunctionResultAggregate(this ILogger logger, FunctionResultAggregate resultAggregate)

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncChainEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncChainEndToEndTests.cs
@@ -537,7 +537,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
             // Results logs the exception with no message
             Assert.NotNull(resultLogger.GetLogMessages().Single().Exception);
-            Assert.Null(resultLogger.GetLogMessages().Single().FormattedMessage);
 
             // It logs Executed/Executing messages and the timeout message.
             Assert.Equal(3, executorLogger.GetLogMessages().Count());


### PR DESCRIPTION
In case of errors, there are some logs which do not have the full stack trace. Adding an optional parameter as a workaround that would aid in investigations. One example is this https://github.com/Azure/azure-webjobs-sdk/issues/2576  

![image](https://user-images.githubusercontent.com/26885664/93150245-715e4500-f6ad-11ea-84c3-389fb6c4cfa4.png)

The above screenshot just has the exception without the stack trace.