### PR TITLE
Fix #2349 Add package description for Extensions lib

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/WebJobs.Extensions.Storage.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/WebJobs.Extensions.Storage.csproj
@@ -5,6 +5,7 @@
   
   <PropertyGroup>
     <Version>$(ExtensionsStorageVersion)</Version>
+    <Description>This package extends the Microsoft.Azure.WebJobs library with Blob, Queue, and Table triggers using Microsoft Azure Storage.</Description>
     <InformationalVersion>$(Version) Commit hash: $(CommitHash)</InformationalVersion>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Microsoft.Azure.WebJobs.Extensions.Storage</AssemblyName>


### PR DESCRIPTION
This change fixes #2349 by adding a description for the Microsoft.Azure.WebJobs.Extensions.Storage library.

By default, SDK-style nuget projects will use the default value of "Package description", which is not very helpful. The description was written to be similar to the format used by other WebJobs packages.