### PR TITLE
Fix Max number of function execution attempts

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- Packages can have independent versions and only increment when released -->
-    <Version>3.0.22$(VersionSuffix)</Version>
+    <Version>3.0.23$(VersionSuffix)</Version>
     <ExtensionsStorageVersion>4.0.2$(VersionSuffix)</ExtensionsStorageVersion>
     <HostStorageVersion>4.0.1$(VersionSuffix)</HostStorageVersion>
     <LoggingVersion>4.0.1$(VersionSuffix)</LoggingVersion>

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionExecutor.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
                     break;
                 }
 
-                if (++attempt >= retryStrategy.MaxRetryCount)
+                if (++attempt > retryStrategy.MaxRetryCount)
                 {
                     // no.of retries exceeded
                     break;
@@ -117,7 +117,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
                 nextDelay = retryStrategy.GetNextDelay(retryContext);
                 logger.LogFunctionRetryAttempt(nextDelay, attempt, retryStrategy.MaxRetryCount);
                 await Task.Delay(nextDelay);
-            } while (attempt < retryStrategy.MaxRetryCount || retryStrategy.MaxRetryCount == -1);
+            } while (attempt <= retryStrategy.MaxRetryCount || retryStrategy.MaxRetryCount == -1);
             return functionResult;
         }
 

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/FunctionExecutorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/FunctionExecutorTests.cs
@@ -453,11 +453,10 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             await functionExecutor.ExecuteWithRetriesAsync(functionInstanceEx, CancellationToken.None, logger, mockRetryStrategy.Object);
             if (invocationThrows)
             {
-                mockRetryStrategy.Verify(p => p.GetNextDelay(It.IsAny<RetryContext>()), Times.Exactly(maxRetryCount - 1));
+                mockRetryStrategy.Verify(p => p.GetNextDelay(It.IsAny<RetryContext>()), Times.Exactly(maxRetryCount));
                 var messages = logger.GetLogMessages().Select(p => p.FormattedMessage);
-                Assert.Equal(4, messages.Count());
-                var delayMessages = messages.Where(p => p.Contains($"Waiting for `{delay}`"));
-                Assert.Equal(4, delayMessages.Count());
+                Assert.Equal(5, messages.Count());
+                Assert.True(messages.All(p => p.Contains($"Waiting for `{delay}`")));
             }
             else
             {


### PR DESCRIPTION
If `MaxRetryCount` set to `n` , execute function `n+1` number of times.