### PR TITLE
Remove RegexOptions.Compiled for code paths executed during cold start

### DIFF
--- a/src/Microsoft.Azure.WebJobs/FunctionNameAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs/FunctionNameAttribute.cs
@@ -30,7 +30,8 @@ namespace Microsoft.Azure.WebJobs
 
         /// <summary>
         /// Validation for name. 
+        /// RegexOptions.Compiled is specifically removed as it impacts the cold start.
         /// </summary>
-        public static readonly Regex FunctionNameValidationRegex = new Regex(@"^[a-z][a-z0-9_\-]{0,127}$(?<!^host$)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        public static readonly Regex FunctionNameValidationRegex = new Regex(@"^[a-z][a-z0-9_\-]{0,127}$(?<!^host$)", RegexOptions.IgnoreCase);
     }
 }


### PR DESCRIPTION
The default uses interpreter rather than compile into MSIL. We do not need compiled regexes for codes that run only during cold start. based on profiles, compiling regexes are taking between 20-50 msec of cold start.

### Pull request checklist
* [X] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [X] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [X] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

 