### PR TITLE
SharedQueueWatcher simplified

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Queues/Listeners/SharedQueueWatcher.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Queues/Listeners/SharedQueueWatcher.cs
@@ -2,21 +2,23 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.Azure.WebJobs.Host.Queues.Listeners
 {
     internal class SharedQueueWatcher : IMessageEnqueuedWatcher
     {
-        private readonly ConcurrentDictionary<string, ConcurrentBag<INotificationCommand>> _registrations =
-            new ConcurrentDictionary<string, ConcurrentBag<INotificationCommand>>();
+        private readonly ConcurrentDictionary<string, INotificationCommand[]> _registrations =
+            new ConcurrentDictionary<string, INotificationCommand[]>();
 
         public void Notify(string enqueuedInQueueName)
         {
-            ConcurrentBag<INotificationCommand> queueRegistrations;
+            INotificationCommand[] queueRegistrations;
 
             if (_registrations.TryGetValue(enqueuedInQueueName, out queueRegistrations))
             {
-                foreach (INotificationCommand registration in queueRegistrations.ToArray())
+                foreach (INotificationCommand registration in queueRegistrations)
                 {
                     registration.Notify();
                 }
@@ -25,9 +27,14 @@ namespace Microsoft.Azure.WebJobs.Host.Queues.Listeners
 
         public void Register(string queueName, INotificationCommand notification)
         {
-            _registrations.AddOrUpdate(queueName,
-                new ConcurrentBag<INotificationCommand>(new INotificationCommand[] { notification }),
-                (i, existing) => { existing.Add(notification); return existing; });
+            _registrations.AddOrUpdate(queueName, new[] { notification },
+                (i, existing) =>
+                {
+                    var updated = new INotificationCommand[existing.Length + 1];
+                    existing.CopyTo(updated, 0);
+                    updated[existing.Length] = notification;
+                    return updated;
+                });
         }
     }
 }

--- a/test/Benchmarks/WebjobsExtensionsStorage.cs
+++ b/test/Benchmarks/WebjobsExtensionsStorage.cs
@@ -2,7 +2,6 @@
 using BenchmarkDotNet.Attributes;
 using Microsoft.Azure.Storage.Queue;
 using Microsoft.Azure.WebJobs.Host.Queues;
-using Microsoft.Azure.WebJobs.Host.Queues.Listeners;
 using Newtonsoft.Json.Linq;
 
 namespace Benchmarks
@@ -10,10 +9,8 @@ namespace Benchmarks
     [MemoryDiagnoser]
     public class WebjobsExtensionsStorage
     {
-        const string WatcherQueueName = "test";
         readonly CloudQueueMessage _minimal;
         readonly CloudQueueMessage _moderate;
-        readonly SharedQueueWatcher _watcher;
 
         public WebjobsExtensionsStorage()
         {
@@ -34,10 +31,6 @@ namespace Benchmarks
             };
 
             _moderate = new CloudQueueMessage(moderate.ToString());
-
-            // assume one listener
-            _watcher = new SharedQueueWatcher();
-            _watcher.Register(WatcherQueueName, new NoopNotifyCommand());
         }
 
         [Benchmark]
@@ -50,17 +43,6 @@ namespace Benchmarks
         public Guid? QueueCausalityManager_GetOwner_Moderate()
         {
             return QueueCausalityManager.GetOwner(_moderate);
-        }
-
-        [Benchmark]
-        public void SharedQueueWatcher_Notify()
-        {
-            _watcher.Notify(WatcherQueueName);
-        }
-
-        class NoopNotifyCommand : INotificationCommand
-        {
-            public void Notify() { }
         }
     }
 }

--- a/test/Microsoft.Azure.Webjobs.Extensions.Storage.UnitTests/Queues/SharedQueueWatcherTests.cs
+++ b/test/Microsoft.Azure.Webjobs.Extensions.Storage.UnitTests/Queues/SharedQueueWatcherTests.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Threading;
+using Microsoft.Azure.WebJobs.Host.Queues.Listeners;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Storage.UnitTests.Queues
+{
+    public class SharedQueueWatcherTests
+    {
+        [Fact]
+        public void SharedQueueWatcher_IfConcurrentRegistrations_RegistersThemAll()
+        {
+            const string queue = "queue";
+            const int countPerThread = 1000;
+            const int threadCount = 4;
+            const int commandCount = countPerThread * threadCount;
+
+            Mock<INotificationCommand>[] commands = new Mock<INotificationCommand>[commandCount];
+            for (int i = 0; i < commandCount; i++)
+            {
+                commands[i] = new Mock<INotificationCommand>(MockBehavior.Strict);
+                commands[i].Setup(cmd => cmd.Notify());
+            }
+
+            var wait = new ManualResetEvent(false);
+
+            SharedQueueWatcher watcher = new SharedQueueWatcher();
+
+            Thread[] threads = new Thread[threadCount];
+
+            for (int i = 0; i < threadCount; i++)
+            {
+                var startAt = i * countPerThread;
+                threads[i] = new Thread(() =>
+                {
+                   wait.WaitOne();
+                    for (int j = 0; j < countPerThread; j++)
+                    {
+                        watcher.Register(queue, commands[startAt + j].Object);
+                    }
+                });
+            }
+
+            foreach (var thread in threads)
+            {
+                thread.Start();
+            }
+
+            wait.Set();
+
+            foreach (var thread in threads)
+            {
+                thread.Join();
+            }
+
+            watcher.Notify(queue);
+
+            foreach (var mock in commands)
+            {
+                mock.Verify();
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR changes the way `SharedQueueWatcher` is written, by replacing the costly `ConcurrentBag` and the call to `.ToArray` when notifing. The replacement is provided with a simple array `INotificationCommand[]`. The update function for `AddOrUpdate` is changed to operate on the input and return a new array. It ensures that the value, if swapped, in the concurrent dictionary will be properly updated.

This removes the `.ToArray` and heaviness of `ConcurrentBag` from the hot `Notify` path. 

### Benchmarks

After introducing this change I understood that it's highly likely that there will be a single notification command and run a bechmark that is in history of these changed, but is removed as it's something that won't be useful in the future.

#### Before:

|                    Method |     Mean |   Error |  StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------------- |---------:|--------:|--------:|-------:|------:|------:|----------:|
| SharedQueueWatcher_Notify | 150.8 ns | 2.78 ns | 5.15 ns | 0.0100 |     - |     - |      32 B |

#### After:

|                    Method |     Mean |    Error |   StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------------- |---------:|---------:|---------:|------:|------:|------:|----------:|
| SharedQueueWatcher_Notify | 44.40 ns | 1.757 ns | 4.897 ns |     - |     - |     - |         - |

It's a small gain but makes the code a bit clearer imho, so I'll still propose it as a change.