### PR TITLE
moving storage to 4.0.3

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- Packages can have independent versions and only increment when released -->
     <Version>3.0.23$(VersionSuffix)</Version>
-    <ExtensionsStorageVersion>4.0.2$(VersionSuffix)</ExtensionsStorageVersion>
+    <ExtensionsStorageVersion>4.0.3$(VersionSuffix)</ExtensionsStorageVersion>
     <HostStorageVersion>4.0.1$(VersionSuffix)</HostStorageVersion>
     <LoggingVersion>4.0.1$(VersionSuffix)</LoggingVersion>
     

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/WebJobs.Extensions.Storage.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/WebJobs.Extensions.Storage.csproj
@@ -96,12 +96,10 @@
     <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.7" />
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.1.7" />
     <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="11.1.7" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.22" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Microsoft.Azure.WebJobs.Host\WebJobs.Host.csproj" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
- Moving storage to 4.0.3
- Locking storage extension to reference WebJobs 3.0.22

This helps with #2589 