### PR TITLE
Allow binding data to be lazily evaluated

### DIFF
--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Bindings/BindingContextTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Bindings/BindingContextTests.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Host.UnitTests.Bindings
+{
+    public class BindingContextTests
+    {
+        [Fact]
+        public void Constructor_BindingData_InitializesMembers()
+        {
+            var cancellationToken = new CancellationToken();
+            var functionCancellationToken = new CancellationToken();
+            var functionBindingContext = new FunctionBindingContext(Guid.NewGuid(), functionCancellationToken);
+            var valueContext = new ValueBindingContext(functionBindingContext, cancellationToken);
+            Dictionary<string, object> bindingData = new Dictionary<string, object>();
+            var context = new BindingContext(valueContext, bindingData);
+
+            Assert.Same(valueContext, context.ValueContext);
+            Assert.Same(bindingData, context.BindingData);
+            Assert.Equal(cancellationToken, context.CancellationToken);
+            Assert.Equal(functionCancellationToken, context.FunctionCancellationToken);
+            Assert.Equal(functionBindingContext.FunctionInstanceId, context.FunctionInstanceId);
+        }
+
+        [Fact]
+        public void Constructor_BindingDataFactory_InitializesMembers()
+        {
+            var cancellationToken = new CancellationToken();
+            var functionCancellationToken = new CancellationToken();
+            var functionBindingContext = new FunctionBindingContext(Guid.NewGuid(), functionCancellationToken);
+            var valueContext = new ValueBindingContext(functionBindingContext, cancellationToken);
+            int invokeCount = 0;
+            Dictionary<string, object> bindingData = new Dictionary<string, object>();
+            Func<IReadOnlyDictionary<string, object>> factory = () =>
+            {
+                invokeCount++;
+                return bindingData;
+            };
+            var context = new BindingContext(valueContext, factory);
+
+            Assert.Equal(0, invokeCount);
+            Assert.Same(valueContext, context.ValueContext);
+            Assert.Equal(cancellationToken, context.CancellationToken);
+            Assert.Equal(functionCancellationToken, context.FunctionCancellationToken);
+            Assert.Equal(functionBindingContext.FunctionInstanceId, context.FunctionInstanceId);
+
+            Assert.Same(bindingData, context.BindingData);
+            Assert.Equal(1, invokeCount);
+
+            // factory only called once
+            Assert.Same(bindingData, context.BindingData);
+            Assert.Same(bindingData, context.BindingData);
+            Assert.Equal(1, invokeCount);
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Bindings/FunctionBindingTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Bindings/FunctionBindingTests.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Azure.WebJobs.Host.Protocols;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Host.UnitTests.Bindings
+{
+    public class FunctionBindingTests
+    {
+        [Fact]
+        public void NewBindingContext_LazyBindingData()
+        {
+            var cancellationToken = new CancellationToken();
+            var functionCancellationToken = new CancellationToken();
+            var functionDescriptor = new FunctionDescriptor
+            {
+                LogName = "Test"
+            };
+            var functionBindingContext = new FunctionBindingContext(Guid.NewGuid(), functionCancellationToken, functionDescriptor);
+            var valueContext = new ValueBindingContext(functionBindingContext, cancellationToken);
+            Dictionary<string, object> bindingData = new Dictionary<string, object>
+            {
+                { "d1", 1 },
+                { "d2", 2 },
+                { "d3", 3 }
+            };
+            Dictionary<string, object> parameters = new Dictionary<string, object>()
+            {
+                { "p1", 1 },
+                { "p2", 2 },
+                { "p3", 3 },
+                { "d3", "Overridden" }
+            };
+
+            var context = FunctionBinding.NewBindingContext(valueContext, bindingData, parameters);
+
+            Assert.Same(valueContext, context.ValueContext);
+            Assert.Equal(cancellationToken, context.CancellationToken);
+            Assert.Equal(functionCancellationToken, context.FunctionCancellationToken);
+            Assert.Equal(functionBindingContext.FunctionInstanceId, context.FunctionInstanceId);
+
+            var bindingContextField = typeof(BindingContext).GetField("_bindingData", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.Null(bindingContextField.GetValue(context));
+            var result = context.BindingData;
+            Assert.NotSame(bindingData, context.BindingData);
+            Assert.NotNull(bindingContextField.GetValue(context));
+
+            // make sure factory only called once
+            Assert.Same(result, context.BindingData);
+            Assert.Same(result, context.BindingData);
+            Assert.Same(result, context.BindingData);
+
+            Assert.Equal(7, context.BindingData.Count);
+            Assert.Equal("Overridden", context.BindingData["d3"]);
+            var sys = (SystemBindingData)context.BindingData["sys"];
+            Assert.Equal("Test", sys.MethodName);
+        }
+    }
+}


### PR DESCRIPTION
Not all triggered functions actually use binding data when they're invoked. The binding pipeline will only access BindingContext.BindingData when it needs to bind input/output bindings. So for many functions that are simple trigger only, we don't need to build the binding data. However, currently we always build the dictionary eagerly. This can be expensive, depending on the specific trigger.

The PR for updating HttpTrigger to work with this is here: https://github.com/Azure/azure-webjobs-sdk-extensions/pull/675.