### PR TITLE
Reducing the number of async transitions in the core execution pipeline

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionExecutorExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionExecutorExtensions.cs
@@ -12,7 +12,9 @@ using Microsoft.Azure.WebJobs.Logging;
 
 namespace Microsoft.Azure.WebJobs.Host.Executors
 {
-    /// <summary>Provides extension methods for the <see cref="IFunctionExecutor"/> interface.</summary>
+    /// <summary>
+    /// Provides extension methods for the <see cref="IFunctionExecutor"/> interface.
+    /// </summary>
     internal static class FunctionExecutorExtensions
     {
         public static async Task<IDelayedException> TryExecuteAsync(this IFunctionExecutor executor, Func<IFunctionInstance> instanceFactory, ILoggerFactory loggerFactory, CancellationToken cancellationToken)
@@ -20,6 +22,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             var attempt = 0;
             IDelayedException functionResult = null;
             ILogger logger = null;
+
             while (true)
             {
                 IFunctionInstance functionInstance = instanceFactory.Invoke();
@@ -27,7 +30,9 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
                 {
                     logger = loggerFactory.CreateLogger(LogCategories.CreateFunctionCategory(functionInstance.FunctionDescriptor.LogName));
                 }
+
                 functionResult = await executor.TryExecuteAsync(functionInstance, cancellationToken);
+
                 if (functionResult == null)
                 {
                     // function invocation succeeded
@@ -35,14 +40,14 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
                 }
                 if (functionInstance.FunctionDescriptor.RetryStrategy == null)
                 {
-                    //retry is not configured
+                    // retry is not configured
                     break;
                 }
 
                 IRetryStrategy retryStrategy = functionInstance.FunctionDescriptor.RetryStrategy;
                 if (retryStrategy.MaxRetryCount != -1 && ++attempt > retryStrategy.MaxRetryCount)
                 {
-                    // no.of retries exceeded
+                    // retry count exceeded
                     break;
                 }
 
@@ -56,8 +61,10 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
 
                 TimeSpan nextDelay = retryStrategy.GetNextDelay(retryContext);
                 logger.LogFunctionRetryAttempt(nextDelay, attempt, retryStrategy.MaxRetryCount);
+
                 await Task.Delay(nextDelay);
             }
+
             return functionResult;
         }
     }

--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/FunctionOutputLogger/FunctionOutputLogger.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/FunctionOutputLogger/FunctionOutputLogger.cs
@@ -44,10 +44,9 @@ namespace Microsoft.Azure.WebJobs.Logging
 
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
         {
-            string formattedMessage = formatter(state, exception);
-
             if (IsEnabled(logLevel))
             {
+                string formattedMessage = formatter?.Invoke(state, exception);
                 InvokeTextWriter(_asyncLocalOutput.Value?.Output, formattedMessage, exception);
             }
         }

--- a/src/Microsoft.Azure.WebJobs.Protocols/FunctionFailure.cs
+++ b/src/Microsoft.Azure.WebJobs.Protocols/FunctionFailure.cs
@@ -26,5 +26,15 @@ namespace Microsoft.Azure.WebJobs.Host.Protocols
 
         /// <summary>Gets or sets the details of the exception that occurred.</summary>
         public string ExceptionDetails { get; set; }
+
+        internal static FunctionFailure FromException(Exception ex)
+        {
+            return new FunctionFailure
+            {
+                Exception = ex,
+                ExceptionType = ex.GetType().FullName,
+                ExceptionDetails = ex.ToDetails()
+            };
+        }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/FunctionExecutorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/FunctionExecutorTests.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             var shutdownSource = new CancellationTokenSource();
             bool throwOnTimeout = true;
 
-            await FunctionExecutor.InvokeAsync(mockInvoker.Object, NewArgs(new object[0]), timeoutSource, shutdownSource,
+            await FunctionExecutor.InvokeWithTimeoutAsync(mockInvoker.Object, NewArgs(new object[0]), timeoutSource, shutdownSource,
                 throwOnTimeout, TimeSpan.MinValue, null);
 
             Assert.True(called);
@@ -170,7 +170,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             bool throwOnTimeout = false;
 
             timeoutSource.CancelAfter(500);
-            await FunctionExecutor.InvokeAsync(mockInvoker.Object, NewArgs(parameters), timeoutSource, shutdownSource,
+            await FunctionExecutor.InvokeWithTimeoutAsync(mockInvoker.Object, NewArgs(parameters), timeoutSource, shutdownSource,
                 throwOnTimeout, TimeSpan.FromMilliseconds(1), null);
 
             Assert.True(called);
@@ -204,7 +204,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
 
             TimeSpan timeoutInterval = TimeSpan.FromMilliseconds(500);
             timeoutSource.CancelAfter(timeoutInterval);
-            var ex = await Assert.ThrowsAsync<FunctionTimeoutException>(() => FunctionExecutor.InvokeAsync(mockInvoker.Object, NewArgs(parameters), timeoutSource, shutdownSource,
+            var ex = await Assert.ThrowsAsync<FunctionTimeoutException>(() => FunctionExecutor.InvokeWithTimeoutAsync(mockInvoker.Object, NewArgs(parameters), timeoutSource, shutdownSource,
                 throwOnTimeout, timeoutInterval, _mockFunctionInstance.Object));
 
             var expectedMessage = string.Format("Timeout value of {0} was exceeded by function: {1}", timeoutInterval, _mockFunctionInstance.Object.FunctionDescriptor.ShortName);
@@ -234,7 +234,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             bool throwOnTimeout = false;
 
             shutdownSource.CancelAfter(500);
-            await FunctionExecutor.InvokeAsync(mockInvoker.Object, NewArgs(parameters), timeoutSource, shutdownSource,
+            await FunctionExecutor.InvokeWithTimeoutAsync(mockInvoker.Object, NewArgs(parameters), timeoutSource, shutdownSource,
                 throwOnTimeout, TimeSpan.MinValue, null);
 
             Assert.True(called);
@@ -264,7 +264,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
 
             shutdownSource.CancelAfter(500);
             timeoutSource.CancelAfter(1000);
-            await FunctionExecutor.InvokeAsync(mockInvoker.Object, NewArgs(parameters), timeoutSource, shutdownSource,
+            await FunctionExecutor.InvokeWithTimeoutAsync(mockInvoker.Object, NewArgs(parameters), timeoutSource, shutdownSource,
                 throwOnTimeout, TimeSpan.MinValue, null);
 
             Assert.True(called);
@@ -299,7 +299,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             TimeSpan timeoutInterval = TimeSpan.FromMilliseconds(1000);
             shutdownSource.CancelAfter(500);
             timeoutSource.CancelAfter(timeoutInterval);
-            var ex = await Assert.ThrowsAsync<FunctionTimeoutException>(() => FunctionExecutor.InvokeAsync(mockInvoker.Object, NewArgs(parameters), timeoutSource, shutdownSource,
+            var ex = await Assert.ThrowsAsync<FunctionTimeoutException>(() => FunctionExecutor.InvokeWithTimeoutAsync(mockInvoker.Object, NewArgs(parameters), timeoutSource, shutdownSource,
                  throwOnTimeout, timeoutInterval, _mockFunctionInstance.Object));
 
             var expectedMessage = string.Format("Timeout value of {0} was exceeded by function: {1}", timeoutInterval, _mockFunctionInstance.Object.FunctionDescriptor.ShortName);


### PR DESCRIPTION
Crank runs below (5 iterations for each, each iteration 15 seconds) show small improvements from this in RPS/Latency (about 5%).

Before:

| load                   |         |
| ---------------------- | ------- |
| CPU Usage (%)          | 14      |
| Raw CPU Usage (%)      | 28.10   |
| Working Set (MB)       | 32      |
| Build Time (ms)        | 5,779   |
| Start Time (ms)        | 1,296   |
| Published Size (KB)    | 68,222  |
| First Request (ms)     | 256     |
| Requests               | 31,129  |
| Bad responses          | 0       |
| Mean latency (us)      | 123,910 |
| Max latency (us)       | 636,788 |
| Requests/sec           | 2,071   |
| Requests/sec (max)     | 15,055  |
| Read throughput (MB/s) | 0.18    |

After:

| load                   |         |
| ---------------------- | ------- |
| CPU Usage (%)          | 14      |
| Raw CPU Usage (%)      | 27.86   |
| Working Set (MB)       | 32      |
| Build Time (ms)        | 5,933   |
| Start Time (ms)        | 1,221   |
| Published Size (KB)    | 68,222  |
| First Request (ms)     | 278     |
| Requests               | 32,585  |
| Bad responses          | 0       |
| Mean latency (us)      | 118,439 |
| Max latency (us)       | 772,088 |
| Requests/sec           | 2,165   |
| Requests/sec (max)     | 14,842  |
| Read throughput (MB/s) | 0.19    |