### PR TITLE
Rename log param to blobName

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Bindings/WatchableCloudBlobStream.Logger.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Bindings/WatchableCloudBlobStream.Logger.cs
@@ -12,13 +12,13 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
           LoggerMessage.Define<string, string, string, TimeSpan, long>(
               LogLevel.Debug,
               new EventId(2, nameof(BlobWriteAccess)),
-              "BlobWriteAccess - Name: {name}, Type: {type}, ETag: {etag}, WriteTime: {writeTime}, BytesWritten: {bytesWritten}");
+              "BlobWriteAccess - Name: {blobName}, Type: {type}, ETag: {etag}, WriteTime: {writeTime}, BytesWritten: {bytesWritten}");
 
         // Name is of the format <ContainerName>/<BlobName>
         // Type is of the format <BlobType>/<ContentType>
-        public static void BlobWriteAccess(this ILogger logger, string name, string type, string etag, TimeSpan writeTime, long bytesWritten)
+        public static void BlobWriteAccess(this ILogger logger, string blobName, string type, string etag, TimeSpan writeTime, long bytesWritten)
         {
-            _blobWriteAccess(logger, name, type, etag, writeTime, bytesWritten, null);
+            _blobWriteAccess(logger, blobName, type, etag, writeTime, bytesWritten, null);
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Bindings/WatchableCloudBlobStream.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Bindings/WatchableCloudBlobStream.cs
@@ -192,9 +192,9 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
                 return;
             }
 
-            string name = $"{_blob.Container.Name}/{_blob.Name}";
+            string blobName = $"{_blob.Container.Name}/{_blob.Name}";
             string type = $"{_blob.Properties.BlobType}/{_blob.Properties.ContentType}";
-            _logger.BlobWriteAccess(name, type, _blob.Properties.ETag, _timeWrite.Elapsed, _countWritten);
+            _logger.BlobWriteAccess(blobName, type, _blob.Properties.ETag, _timeWrite.Elapsed, _countWritten);
             _logged = true;
         }
     }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/WatchableReadStream.Logger.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/WatchableReadStream.Logger.cs
@@ -12,13 +12,13 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs
           LoggerMessage.Define<string, string, long, string, TimeSpan, long>(
               LogLevel.Debug,
               new EventId(1, nameof(BlobReadAccess)),
-              "BlobReadAccess - Name: {name}, Type: {type}, Length: {length}, ETag: {etag}, ReadTime: {readTime}, BytesRead: {bytesRead}");
+              "BlobReadAccess - BlobName: {blobName}, Type: {type}, Length: {length}, ETag: {etag}, ReadTime: {readTime}, BytesRead: {bytesRead}");
 
         // Name is of the format <ContainerName>/<BlobName>
         // Type is of the format <BlobType>/<ContentType>
-        public static void BlobReadAccess(this ILogger logger, string name, string type, long length, string etag, TimeSpan readTime, long bytesRead)
+        public static void BlobReadAccess(this ILogger logger, string blobName, string type, long length, string etag, TimeSpan readTime, long bytesRead)
         {
-            _blobReadAccess(logger, name, type, length, etag, readTime, bytesRead, null);
+            _blobReadAccess(logger, blobName, type, length, etag, readTime, bytesRead, null);
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/WatchableReadStream.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/WatchableReadStream.cs
@@ -132,9 +132,9 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs
                 return;
             }
 
-            string name = $"{_blob.Container.Name}/{_blob.Name}";
+            string blobName = $"{_blob.Container.Name}/{_blob.Name}";
             string type = $"{_blob.Properties.BlobType}/{_blob.Properties.ContentType}";
-            _logger.BlobReadAccess(name, type, _blob.Properties.Length, _blob.Properties.ETag, _timeRead.Elapsed, _countRead);
+            _logger.BlobReadAccess(blobName, type, _blob.Properties.Length, _blob.Properties.ETag, _timeRead.Elapsed, _countRead);
             _logged = true;
         }
 

--- a/test/Microsoft.Azure.Webjobs.Extensions.Storage.UnitTests/Blobs/Bindings/WatchableCloudBlobStreamTests.cs
+++ b/test/Microsoft.Azure.Webjobs.Extensions.Storage.UnitTests/Blobs/Bindings/WatchableCloudBlobStreamTests.cs
@@ -2160,7 +2160,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Blobs.Bindings
             Assert.Equal("BlobWriteAccess", logMessage.EventId.Name);
             Assert.Equal(LogLevel.Debug, logMessage.Level);
             Assert.Equal(6, logMessage.State.Count());
-            Assert.Equal($"{containerName}/{blobName}", logMessage.GetStateValue<string>("name"));
+            Assert.Equal($"{containerName}/{blobName}", logMessage.GetStateValue<string>("blobName"));
             Assert.Equal($"{blob.Properties.BlobType}/{blob.Properties.ContentType}", logMessage.GetStateValue<string>("type"));
             Assert.Equal(blob.Properties.ETag, logMessage.GetStateValue<string>("etag"));
             Assert.True(logMessage.GetStateValue<TimeSpan>("writeTime") >= TimeSpan.Zero);

--- a/test/Microsoft.Azure.Webjobs.Extensions.Storage.UnitTests/Blobs/WatchableReadStreamTests.cs
+++ b/test/Microsoft.Azure.Webjobs.Extensions.Storage.UnitTests/Blobs/WatchableReadStreamTests.cs
@@ -1617,7 +1617,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Blobs
             Assert.Equal("BlobReadAccess", logMessage.EventId.Name);
             Assert.Equal(LogLevel.Debug, logMessage.Level);
             Assert.Equal(7, logMessage.State.Count());
-            Assert.Equal($"{containerName}/{blobName}", logMessage.GetStateValue<string>("name"));
+            Assert.Equal($"{containerName}/{blobName}", logMessage.GetStateValue<string>("blobName"));
             Assert.Equal($"{blob.Properties.BlobType}/{blob.Properties.ContentType}", logMessage.GetStateValue<string>("type"));
             Assert.Equal(blob.Properties.Length, logMessage.GetStateValue<long>("length"));
             Assert.Equal(blob.Properties.ETag, logMessage.GetStateValue<string>("etag"));


### PR DESCRIPTION
Fixes #2623

cc @goiri 

`{Name}`  is used as FunctionName 

https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script/Utility.cs#L500-L505

PR renames log params