### PR TITLE
Fix name collision in indexer cache (#2645)

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndex.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndex.cs
@@ -34,9 +34,17 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
             _functionsByMethod.Add(method, function);
 
             // For compat, accept either the short name ("Class.Name") or log name (just "Name")
-            _functionsByName.Add(descriptor.LogName, function);
-            if (descriptor.ShortName != descriptor.LogName)
+            if (!_functionsByName.ContainsKey(descriptor.LogName))
             {
+                // since there can be duplicate method names across job classes, it's first one
+                // wins for this cache
+                _functionsByName.Add(descriptor.LogName, function);
+            }
+            if (descriptor.ShortName != descriptor.LogName &&
+                !_functionsByName.ContainsKey(descriptor.ShortName))
+            {
+                // we do a duplicate check here as well for completeness, though a conflict here
+                // is much less likely (could only happen if functions are coming from multiple assemblies).
                 _functionsByName.Add(descriptor.ShortName, function);
             }
 

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/Indexers/FunctionIndexerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/Indexers/FunctionIndexerTests.cs
@@ -262,6 +262,41 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Indexers
             Assert.Equal(false, actual);
         }
 
+        [Fact]
+        public async Task IndexMethod_SameName_Succeeds()
+        {
+            FunctionIndex index = new FunctionIndex();
+            FunctionIndexer product = CreateProductUnderTest();
+
+            await product.IndexMethodAsync(typeof(ClassA).GetMethod("Test"), index, CancellationToken.None);
+            await product.IndexMethodAsync(typeof(ClassB).GetMethod("Test"), index, CancellationToken.None);
+
+            var functions = index.ReadAll().ToArray();
+            Assert.Equal(2, functions.Length);
+
+            Assert.Equal("ClassA.Test", index.LookupByName("Test").Descriptor.ShortName);
+            Assert.Equal("ClassA.Test", index.LookupByName("ClassA.Test").Descriptor.ShortName);
+            Assert.Equal("ClassB.Test", index.LookupByName("ClassB.Test").Descriptor.ShortName);
+        }
+
+        public class ClassA
+        {
+            [NoAutomaticTrigger]
+            public void Test(string test, ILogger logger)
+            {
+                logger.LogInformation("Test invoked!");
+            }
+        }
+
+        public class ClassB
+        {
+            [NoAutomaticTrigger]
+            public void Test(string test, ILogger logger)
+            {
+                logger.LogInformation("Test invoked!");
+            }
+        }
+
         private class TestExtensionBindingProvider : IBindingProvider
         {
             public Task<IBinding> TryCreateAsync(BindingProviderContext context)


### PR DESCRIPTION
Fix for https://github.com/Azure/azure-webjobs-sdk/issues/2645. As noted in the issue, the bug was introduced in https://github.com/Azure/azure-webjobs-sdk/commit/76d44ca915b817ed3f3cc46e355aa6cb0f741b4b when a method name cache was introduced.