### PR TITLE
Fixing SDK version to 3.0.27

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- Packages can have independent versions and only increment when released -->
-    <Version>3.0.28$(VersionSuffix)</Version>
+    <Version>3.0.27$(VersionSuffix)</Version>
     <ExtensionsStorageVersion>4.0.4$(VersionSuffix)</ExtensionsStorageVersion>
     <HostStorageVersion>4.0.2$(VersionSuffix)</HostStorageVersion>
     <LoggingVersion>4.0.2$(VersionSuffix)</LoggingVersion>


### PR DESCRIPTION
Commit https://github.com/Azure/azure-webjobs-sdk/commit/ae74eb57eb01fac8391d6619548a15b0c3eb3331#diff-63de1c90cb11c45c67e7a2814b8a7f352542b00f63d7a09278c52bc915203532 incremented the version unecessarily - we've never released 3.0.27.