### PR TITLE
Fixing null ref in AI logger

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
@@ -203,7 +203,15 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
             ApplyScopeAndStateProperties(properties, values);
 
             var severityLevel = GetSeverityLevel(logLevel);
-            _telemetryClient.TrackTrace(formattedMessage, severityLevel.Value, properties);
+            if (severityLevel.HasValue)
+            {
+                _telemetryClient.TrackTrace(formattedMessage, severityLevel.Value, properties);
+            }
+            else
+            {
+                // LogLevel.None maps to null, so we have to handle that specially
+                _telemetryClient.TrackTrace(formattedMessage, properties);
+            }
         }
 
         private static SeverityLevel? GetSeverityLevel(LogLevel logLevel)


### PR DESCRIPTION
There was a regression in [this commit](https://github.com/Azure/azure-webjobs-sdk/commit/f0c9d0998ced69c8baf02fedb4e7f9184e0e05c9#diff-53748978dccb3c067e2aec0255d681b45146638d23f2c806c1033ca524db0b81R205). Previously we were constructing a TraceTelemetry object and setting it's SecurityLevel to the result of GetSecurityLevel (which may be null). This was changed to avoid instantiation of the TraceTelemetryObject and call the TelemetryClient.TrackTrace method directly passing in the message, level, etc.

The issue is that when the LogLevel is "None", GetSecurityLevel returns null, and we get a null-ref trying to access the value [here](https://github.com/Azure/azure-webjobs-sdk/blob/67aa71a43f1973ab30600b84de5df9c6ba0341c7/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs#L206).