### PR TITLE
create inner OptionsFactory via DI

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- Packages can have independent versions and only increment when released -->
-    <Version>3.0.28$(VersionSuffix)</Version>
+    <Version>3.0.29$(VersionSuffix)</Version>
     <ExtensionsStorageVersion>4.0.5$(VersionSuffix)</ExtensionsStorageVersion>
     <HostStorageVersion>4.0.2$(VersionSuffix)</HostStorageVersion>
     <LoggingVersion>4.0.2$(VersionSuffix)</LoggingVersion>

--- a/src/Microsoft.Azure.WebJobs.Host/Hosting/OptionsFormatter/WebJobsOptionsFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Hosting/OptionsFormatter/WebJobsOptionsFactory.cs
@@ -17,15 +17,14 @@ namespace Microsoft.Azure.WebJobs.Hosting
         private readonly IOptionsLoggingSource _logSource;
         private readonly IOptionsFormatter<TOptions> _optionsFormatter;
 
-        public WebJobsOptionsFactory(IEnumerable<IConfigureOptions<TOptions>> setups, IEnumerable<IPostConfigureOptions<TOptions>> postConfigures, IOptionsLoggingSource logSource) :
-            this(setups, postConfigures, logSource, null)
+        public WebJobsOptionsFactory(OptionsFactory<TOptions> innerFactory, IOptionsLoggingSource logSource) :
+            this(innerFactory, logSource, null)
         {
         }
 
-        public WebJobsOptionsFactory(IEnumerable<IConfigureOptions<TOptions>> setups, IEnumerable<IPostConfigureOptions<TOptions>> postConfigures,
-            IOptionsLoggingSource logSource, IOptionsFormatter<TOptions> optionsFormatter)
+        public WebJobsOptionsFactory(OptionsFactory<TOptions> innerFactory, IOptionsLoggingSource logSource, IOptionsFormatter<TOptions> optionsFormatter)
         {
-            _innerFactory = new OptionsFactory<TOptions>(setups, postConfigures);
+            _innerFactory = innerFactory;
             _logSource = logSource;
 
             // This allows us to wrap behavior around an existing type. It will be null for types we don't log.

--- a/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsServiceCollectionExtensions.cs
@@ -8,7 +8,6 @@ using Microsoft.Azure.WebJobs.Host.Config;
 using Microsoft.Azure.WebJobs.Host.Configuration;
 using Microsoft.Azure.WebJobs.Host.Dispatch;
 using Microsoft.Azure.WebJobs.Host.Executors;
-using Microsoft.Azure.WebJobs.Host.Hosting;
 using Microsoft.Azure.WebJobs.Host.Indexers;
 using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Azure.WebJobs.Host.Loggers;
@@ -110,6 +109,7 @@ namespace Microsoft.Azure.WebJobs
             services.AddSingleton(typeof(IWebJobsExtensionConfiguration<>), typeof(WebJobsExtensionConfiguration<>));
 
             // Options logging
+            services.AddTransient(typeof(OptionsFactory<>));
             services.AddTransient(typeof(IOptionsFactory<>), typeof(WebJobsOptionsFactory<>));
             services.AddSingleton<IOptionsLoggingSource, OptionsLoggingSource>();
             services.AddSingleton<IHostedService, OptionsLoggingService>();

--- a/src/Microsoft.Azure.WebJobs/WebJobs.csproj
+++ b/src/Microsoft.Azure.WebJobs/WebJobs.csproj
@@ -6,7 +6,7 @@
     <Description>This library simplifies the task of adding background processing to your Microsoft Azure Web Sites. The SDK uses Microsoft Azure Storage, triggering a function in your program when items are added to Queues and Blobs. A dashboard provides rich monitoring and diagnostics for the programs that you write by using the SDK. For more information, please visit http://go.microsoft.com/fwlink/?LinkID=320971</Description>
     <AssemblyName>Microsoft.Azure.WebJobs</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs</RootNamespace>
-    <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Hosting/WebJobsOptionsFactoryTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Hosting/WebJobsOptionsFactoryTests.cs
@@ -23,10 +23,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Hosting
         {
             IOptionsLoggingSource source = new OptionsLoggingSource();
 
-            IOptionsFactory<TestOptions> factory = new WebJobsOptionsFactory<TestOptions>(
-                Enumerable.Empty<IConfigureOptions<TestOptions>>(),
-                Enumerable.Empty<IPostConfigureOptions<TestOptions>>(),
-                source);
+            IOptionsFactory<TestOptions> factory = new WebJobsOptionsFactory<TestOptions>(GetOptionsFactory<TestOptions>(), source);
 
             TestOptions options = factory.Create(null);
 
@@ -56,8 +53,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Hosting
             IOptionsLoggingSource source = new OptionsLoggingSource();
 
             IOptionsFactory<LoggerFilterOptions> factory = new WebJobsOptionsFactory<LoggerFilterOptions>(
-                Enumerable.Empty<IConfigureOptions<LoggerFilterOptions>>(),
-                Enumerable.Empty<IPostConfigureOptions<LoggerFilterOptions>>(),
+                GetOptionsFactory<LoggerFilterOptions>(),
                 source,
                 new LoggerFilterOptionsFormatter());
 
@@ -83,6 +79,9 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Hosting
 
             Assert.Equal(expected, log);
         }
+
+        private static OptionsFactory<T> GetOptionsFactory<T>() where T : class, new() =>
+            new OptionsFactory<T>(Enumerable.Empty<IConfigureOptions<T>>(), Enumerable.Empty<IPostConfigureOptions<T>>());
 
         private class TestOptions : IOptionsFormatter
         {


### PR DESCRIPTION
fixes #2522 

In later versions of .NET Core, there is an additional parameter for `validations` accepted by the `OptionsFactory<>` constructor. These weren't being picked up because we were creating the factory directly rather than letting DI handle it.

Confirmed by updating the Functions host locally with this change and validations are now called.