### PR TITLE
Fix delay for last retry

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/ExponentialBackoffRetryAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/ExponentialBackoffRetryAttribute.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.WebJobs
                 context.State.Add(_delayStrategyKeyName, delayStrategy);
             }
 
-            if (MaxRetryCount == -1 || context.RetryCount < MaxRetryCount)
+            if (MaxRetryCount == -1 || context.RetryCount <= MaxRetryCount)
             {
                 return delayStrategy.GetNextDelay(false);
             }

--- a/src/Microsoft.Azure.WebJobs.Host/FixedDelayRetryAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/FixedDelayRetryAttribute.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.WebJobs
 
         public override TimeSpan GetNextDelay(RetryContext context)
         {
-            if (MaxRetryCount == -1 || context.RetryCount < MaxRetryCount)
+            if (MaxRetryCount == -1 || context.RetryCount <= MaxRetryCount)
             {
                 return _delayStrategy.GetNextDelay(false);
             }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Retry/RetryAttributeTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Retry/RetryAttributeTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
 
             RetryContext lastRetryContext = new RetryContext
             {
-                RetryCount = 5
+                RetryCount = 6
             };
             Assert.Equal(TimeSpan.Zero, retry.GetNextDelay(lastRetryContext));
         }
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
 
             RetryContext lastRetryContext = new RetryContext
             {
-                RetryCount = 5
+                RetryCount = 6
             };
             Assert.Equal(TimeSpan.Zero, retry.GetNextDelay(lastRetryContext));
         }


### PR DESCRIPTION
The last retry of a function invocation runs immediately instead of waiting according to the selected strategy as brought up in this [doc issue](https://github.com/MicrosoftDocs/azure-docs/issues/74360).

With debug logs enabled, this is the observed log

![image](https://user-images.githubusercontent.com/43602528/119373530-2255be80-bcd6-11eb-8c83-18ef658522bc.png)

Looking at the other unit tests, the number of invocations seemed to be as expected (First Attempt + `MaxRetryCount` Retries), so this PR updates the condition that decides the delay for each retry to consider the last retry as well.

resolves MicrosoftDocs/azure-docs#74360