### PR TITLE
Ensure graceful host shutdown when shutdown file is created (#2088)

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Constants.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Constants.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.WebJobs.Host
         public const string DevelopmentEnvironmentValue = "Development";
         public const string DynamicSku = "Dynamic";
         public const string AzureWebsiteSku = "WEBSITE_SKU";
+        public const string AzureWebJobsShutdownFile = "WEBJOBS_SHUTDOWN_FILE";
         public const string DateTimeFormatString = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffK";
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/WebjobsShutdownWatcher.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/WebjobsShutdownWatcher.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading;
+using Microsoft.Azure.WebJobs.Host;
 
 namespace Microsoft.Azure.WebJobs
 {
@@ -32,7 +33,7 @@ namespace Microsoft.Azure.WebJobs
         {
             // http://blog.amitapple.com/post/2014/05/webjobs-graceful-shutdown/#.U3aIXRFOVaQ
             // Antares will set this file to signify shutdown
-            _shutdownFile = Environment.GetEnvironmentVariable("WEBJOBS_SHUTDOWN_FILE");
+            _shutdownFile = Environment.GetEnvironmentVariable(Constants.AzureWebJobsShutdownFile);
             if (_shutdownFile == null)
             {
                 // If env var is not set, then no shutdown support


### PR DESCRIPTION
Addresses https://github.com/Azure/azure-webjobs-sdk/issues/2088

As the referenced issue indicates, currently when a shutdown is triggered, listeners are stopped, but the host itself isn't stopped, nor are hosted services, and IHost.RunAsync doesn't complete. With my changes everything shuts down gracefully, RunAsync completes allowing the WebJobs console app to run any cleanup code before exiting.