### PR TITLE
Fixing packaging paths

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -38,7 +38,7 @@ foreach ($project in $projects)
 
 ### Sign package if build is not a PR
 $isPr = Test-Path env:APPVEYOR_PULL_REQUEST_NUMBER
-if (-not $isPr -and -not $isLocal) {
+if ((-not $isPr -and -not $isLocal) -or $env:ForceArtifacts -eq "1") {
   & ".\tools\RunSigningJob.ps1" 
   if (-not $?) { exit 1 }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/DynamicConcurrencyEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/DynamicConcurrencyEndToEndTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             // force an initial concurrency to ensure throttles are hit relatively quickly
             IHost host = CreateTestJobHost<TestJobs>();
             var concurrencyManager = host.GetServiceOrNull<ConcurrencyManager>();
-            int initialConcurrency = 5;
+            int initialConcurrency = 10;
             ApplyTestSnapshot(concurrencyManager, highCpuConcurrency: initialConcurrency);
 
             host.Start();
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 bool complete = TestJobs.InvokeCount > 5 && throttleLogs.Length > 0 && concurrencyDecreaseLogs.Length > 0;
 
                 return Task.FromResult(complete);
-            });
+            }, timeout: 90 * 1000);
 
             await host.StopAsync();
 

--- a/tools/PollSigningResults.ps1
+++ b/tools/PollSigningResults.ps1
@@ -1,7 +1,7 @@
 $isPr = Test-Path env:APPVEYOR_PULL_REQUEST_NUMBER
 $directoryPath = Split-Path $MyInvocation.MyCommand.Path -Parent
 
-if (-not $isPr -and $env:SkipAssemblySigning -ne "true") {
+if ((-not $isPr -and $env:SkipAssemblySigning -ne "true") -or $env:ForceArtifacts -eq "1") {
   $timeout = new-timespan -Minutes 15
   $sw = [diagnostics.stopwatch]::StartNew();
   $polling = $true;
@@ -24,15 +24,15 @@ if (-not $isPr -and $env:SkipAssemblySigning -ne "true") {
     exit(1);
   }
 
-  Remove-Item "$directoryPath/../buildoutput" -Recurse -Force
+  Remove-Item "$directoryPath/../../../buildoutput" -Recurse -Force
 
-  Mkdir "$directoryPath/../buildoutput"
+  Mkdir "$directoryPath/../../../buildoutput"
 
-  Get-AzureStorageBlobContent "$env:APPVEYOR_BUILD_VERSION.zip" "webjobs-signed" -Destination "$directoryPath/../buildoutput/signed.zip" -Context $ctx
+  Get-AzureStorageBlobContent "$env:APPVEYOR_BUILD_VERSION.zip" "webjobs-signed" -Destination "$directoryPath/../../../buildoutput/signed.zip" -Context $ctx
 
-  Expand-Archive "$directoryPath/../buildoutput/signed.zip" "$directoryPath/../buildoutput/signed"
+  Expand-Archive "$directoryPath/../../../buildoutput/signed.zip" "$directoryPath/../../../buildoutput/signed"
 
-  Get-ChildItem "$directoryPath/../buildoutput/signed" | % {
+  Get-ChildItem "$directoryPath/../../../buildoutput/signed" | % {
     Push-AppveyorArtifact $_.FullName
   }
   if (-not $?) { exit 1 }

--- a/tools/RunSigningJob.ps1
+++ b/tools/RunSigningJob.ps1
@@ -1,16 +1,26 @@
 $isPr = Test-Path env:APPVEYOR_PULL_REQUEST_NUMBER
 $directoryPath = Split-Path $MyInvocation.MyCommand.Path -Parent
 
-if (-not $isPr) {
-  Compress-Archive $directoryPath\..\buildoutput\* $directoryPath\..\buildoutput\tosign.zip
+if (-not $isPr -or $env:ForceArtifacts -eq "1") {
+  Write-Host "Zipping output for signing"
+
+  Compress-Archive -Force $directoryPath\..\..\..\buildoutput\* $directoryPath\..\..\..\buildoutput\tosign.zip
+  Write-Host "Signing payload created at " $directoryPath\..\..\..\buildoutput\tosign.zip
 
   if ($env:SkipAssemblySigning -eq "true") {
     "Assembly signing disabled. Skipping signing process."
     exit 0;
   }
 
+  if ($env:FILES_ACCOUNT_NAME -eq $null -or $env:FILES_ACCOUNT_KEY -eq $null) {
+    "Assembly signing credentials not present. Skipping signing process."
+    exit 0;
+  }
+
+  Write-Host "Uploading signing job to storage"
+
   $ctx = New-AzureStorageContext $env:FILES_ACCOUNT_NAME $env:FILES_ACCOUNT_KEY
-  Set-AzureStorageBlobContent "$directoryPath/../buildoutput/tosign.zip" "webjobs" -Blob "$env:APPVEYOR_BUILD_VERSION.zip" -Context $ctx
+  Set-AzureStorageBlobContent "$directoryPath/../../../buildoutput/tosign.zip" "webjobs" -Blob "$env:APPVEYOR_BUILD_VERSION.zip" -Context $ctx
 
   $queue = Get-AzureStorageQueue "signing-jobs" -Context $ctx
 


### PR DESCRIPTION
For some reason the even after a successful build where packages are produced, the output location in the scripts was incorrect (two levels of nesting off). You can see that this recent failed job: https://ci.appveyor.com/project/appsvc/azure-webjobs-sdk-rqm4t/builds/39651765.
