### PR TITLE
[pack] Support shared listener pattern in FunctionExecutor concurrency tracking

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionExecutor.cs
@@ -84,12 +84,13 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             string functionStartedMessageId = null;
             FunctionInstanceLogEntry instanceLogEntry = null;
             Stopwatch sw = Stopwatch.StartNew();
+            string concurrencyFunctionId = functionInstanceEx.FunctionDescriptor.SharedListenerId ?? functionInstanceEx.FunctionDescriptor.Id;
 
             try
             {
                 if (_concurrencyManager.Enabled)
                 {
-                    _concurrencyManager.FunctionStarted(functionInstanceEx.FunctionDescriptor.Id);
+                    _concurrencyManager.FunctionStarted(concurrencyFunctionId);
                 }
 
                 using (_resultsLogger?.BeginFunctionScope(functionInstanceEx, HostOutputMessage.HostInstanceId))
@@ -143,7 +144,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
                 sw.Stop();
                 if (_concurrencyManager.Enabled)
                 {
-                    _concurrencyManager.FunctionCompleted(functionInstanceEx.FunctionDescriptor.Id, sw.Elapsed);
+                    _concurrencyManager.FunctionCompleted(concurrencyFunctionId, sw.Elapsed);
                 }
 
                 ((IDisposable)functionInstanceEx)?.Dispose();

--- a/src/Microsoft.Azure.WebJobs.Host/Scale/ConcurrencyManager.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Scale/ConcurrencyManager.cs
@@ -72,7 +72,9 @@ namespace Microsoft.Azure.WebJobs.Host.Scale
         /// <param name="functionId">This should be the full ID, as returned by <see cref="FunctionDescriptor.ID"/>.</param>
         /// <returns>The updated concurrency status.</returns>
         /// <remarks>
-        /// This method shouldn't be called concurrently for the same function ID.
+        /// This method shouldn't be called concurrently for the same function ID. For trigger bindings using a shared listener pattern,
+        /// the ID passed to this function should be the shared ID, and that ID should also be annotated on the
+        /// <see cref="Microsoft.Azure.WebJobs.Host.Triggers.ITriggerBinding"/> implementation using <see cref="SharedListenerAttribute"/>.
         /// </remarks>
         public ConcurrencyStatus GetStatus(string functionId)
         {

--- a/src/Microsoft.Azure.WebJobs.Host/Scale/ConcurrencyManagerService.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Scale/ConcurrencyManagerService.cs
@@ -127,10 +127,11 @@ namespace Microsoft.Azure.WebJobs.Host.Scale
         {
             var snapshot = _concurrencyManager.GetSnapshot();
 
-            // only persist snapshots for functions that are in our current index
-            // this ensures we prune any stale entries from a previously applied snapshot
+            // Only persist snapshots for functions that are in our current index. This ensures
+            // we prune any stale entries from a previously applied snapshot.
+            // Note that functions using a shared listener are treated specially here.
             var functionIndex = await _functionIndexProvider.GetAsync(CancellationToken.None);
-            var functions = functionIndex.ReadAll().ToLookup(p => p.Descriptor.Id, StringComparer.OrdinalIgnoreCase);
+            var functions = functionIndex.ReadAll().ToLookup(p => p.Descriptor.SharedListenerId ?? p.Descriptor.Id, StringComparer.OrdinalIgnoreCase);
             snapshot.FunctionSnapshots = snapshot.FunctionSnapshots.Where(p => functions.Contains(p.Key)).ToDictionary(p => p.Key, p => p.Value);
 
             if (!snapshot.Equals(_lastSnapshot))

--- a/src/Microsoft.Azure.WebJobs.Host/SharedListenerAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/SharedListenerAttribute.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Azure.WebJobs.Host
+{
+    /// <summary>
+    /// Attribute applied to a <see cref="ITriggerBinding"/> implementation when the binding uses
+    /// a shared listener for all functions.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public class SharedListenerAttribute : Attribute
+    {
+        public SharedListenerAttribute(string sharedListenerId)
+        {
+            SharedListenerId = sharedListenerId;
+        }
+
+        /// <summary>
+        /// Gets the shared ID used for all functions.
+        /// </summary>
+        public string SharedListenerId { get; }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Protocols/FunctionDescriptor.cs
+++ b/src/Microsoft.Azure.WebJobs.Protocols/FunctionDescriptor.cs
@@ -79,6 +79,12 @@ namespace Microsoft.Azure.WebJobs.Host.Protocols
         /// </summary>
         [JsonIgnore]
         internal IRetryStrategy RetryStrategy { get; set; }
+
+        /// <summary>
+        /// Gets or sets the shared listener ID for this function.
+        /// </summary>
+        [JsonIgnore]
+        internal string SharedListenerId { get; set; }
 #endif
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/Indexers/FunctionIndexerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/Indexers/FunctionIndexerTests.cs
@@ -8,15 +8,16 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.Storage;
 using Microsoft.Azure.WebJobs.Description;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Indexers;
+using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Azure.WebJobs.Host.Properties;
 using Microsoft.Azure.WebJobs.Host.Protocols;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.Azure.WebJobs.Host.Triggers;
 using Microsoft.Extensions.Logging;
-using Microsoft.Azure.Storage;
 using Moq;
 using Xunit;
 
@@ -279,6 +280,16 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Indexers
             Assert.Equal("ClassB.Test", index.LookupByName("ClassB.Test").Descriptor.ShortName);
         }
 
+        [Fact]
+        public void GetSharedListenerIdOrNull_ReturnsExpectedValue()
+        {
+            string result = FunctionIndexer.GetSharedListenerIdOrNull(new TestTriggerBinding());
+            Assert.Null(result);
+
+            result = FunctionIndexer.GetSharedListenerIdOrNull(new TestSharedListenerTriggerBinding());
+            Assert.Equal("TestSharedListenerId", result);
+        }
+
         public class ClassA
         {
             [NoAutomaticTrigger]
@@ -484,6 +495,50 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Indexers
             }
         }
 
+        [SharedListener("TestSharedListenerId")]
+        public class TestSharedListenerTriggerBinding : ITriggerBinding
+        {
+            public Type TriggerValueType => throw new NotImplementedException();
+
+            public IReadOnlyDictionary<string, Type> BindingDataContract => throw new NotImplementedException();
+
+            public Task<ITriggerData> BindAsync(object value, ValueBindingContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task<IListener> CreateListenerAsync(ListenerFactoryContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            public ParameterDescriptor ToParameterDescriptor()
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public class TestTriggerBinding : ITriggerBinding
+        {
+            public Type TriggerValueType => throw new NotImplementedException();
+
+            public IReadOnlyDictionary<string, Type> BindingDataContract => throw new NotImplementedException();
+
+            public Task<ITriggerData> BindAsync(object value, ValueBindingContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task<IListener> CreateListenerAsync(ListenerFactoryContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            public ParameterDescriptor ToParameterDescriptor()
+            {
+                throw new NotImplementedException();
+            }
+        }
 
         [Fact]
         public async Task FSharpTasks_AreCorrectlyIndexed()

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
@@ -285,7 +285,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 "IHostProcessMonitor",
                 "IPrimaryHostStateProvider",
                 "PrimaryHostCoordinatorOptions",
-                "ThrottleState"
+                "ThrottleState",
+                "SharedListenerAttribute"
             };
 
             TestHelpers.AssertPublicTypes(expected, assembly);


### PR DESCRIPTION
We've discovered that for extensions that use a single shared listener for all functions of that type (e.g. BlobTrigger/Durable), the Function ID tracking used for concurrency management wasn't working properly, preventing concurrency from increasing. Normally functions map 1:1 to their listeners.

The ID used by the listener when calling ConcurrencyManager.GetStatus must be the same ID used in FunctionExecutor when calling ConcurrencyManager.FunctionStarted/Completed. If they're not, the function invocations aren't tracked and CM will never vote to increase concurrency for that function. This is because CM only ever increases concurrency if the current concurrency level is being fully utilized (logic [here](https://github.com/Azure/azure-webjobs-sdk/blob/206e194e03d82a101a6b5dffb7b4c3904730801d/src/Microsoft.Azure.WebJobs.Host/Scale/ConcurrencyStatus.cs#L186)).