### PR TITLE
Some Dynamic Concurrency updates

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Scale/ConcurrencyThrottleAggregateStatus.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Scale/ConcurrencyThrottleAggregateStatus.cs
@@ -12,6 +12,11 @@ namespace Microsoft.Azure.WebJobs.Host.Scale
     /// </summary>
     public class ConcurrencyThrottleAggregateStatus
     {
+        public ConcurrencyThrottleAggregateStatus()
+        {
+            State = ThrottleState.Unknown;
+        }
+
         /// <summary>
         /// Gets or sets current aggregate throttle state.
         /// </summary>

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/TriggeredFunctionExecutorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/TriggeredFunctionExecutorTests.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
                 // need to simulate the listener beginning the invocation
                 concurrencyStatus = _concurrencyManager.GetStatus(functionId);
                 Assert.Single(_concurrencyManager.ConcurrencyStatuses);
-                Assert.Equal(1, concurrencyStatus.AvailableInvocationCount);
+                Assert.Equal(1, concurrencyStatus.GetAvailableInvocationCount(0));
                 Assert.Equal(0, concurrencyStatus.OutstandingInvocations);
                 Assert.Equal(0, concurrencyStatus.InvocationsSinceLastAdjustment);
                 Assert.Equal(0, concurrencyStatus.MaxConcurrentExecutionsSinceLastAdjustment);
@@ -125,7 +125,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             {
                 // verify concurrency manager tracked the invocation
                 concurrencyStatus = _concurrencyManager.ConcurrencyStatuses[functionId];
-                Assert.Equal(1, concurrencyStatus.AvailableInvocationCount);
+                Assert.Equal(1, concurrencyStatus.GetAvailableInvocationCount(0));
                 Assert.Equal(0, concurrencyStatus.OutstandingInvocations);
                 Assert.Equal(1, concurrencyStatus.InvocationsSinceLastAdjustment);
                 Assert.Equal(1, concurrencyStatus.MaxConcurrentExecutionsSinceLastAdjustment);


### PR DESCRIPTION
Changes in this PR:

* Changing the API for callers to determine the available invocation count. The previous AvailableInvocationCount property was too simplistic to handle all listener scenarios. While it worked well for single listener loop that always ensured they dispatched the invocations before calling GetStatus again, it doesn't work well in scenarios where there might be multiple concurrent listener loops for the same function. In that case it would be possible for 2 or more threads to call GetStatus and receive the same AvailableInvocationCount. If both those threads then started that number of invocations, 2x the actual allowed number would be started. The API is changed to a method that expects the caller to pass in the # of outstanding work items it has fetched/started. In a multi-threaded scenario, it's up to the caller to keep a count of the total number of items it has started, and ensure that count is synchronized across the listener loops to ensure OutstandingInvocations is never greater than CurrentConcurrency. E.g. that might be done by having each listener loop treat the GetStatus/FetchItems step as a critical section that only one loop at a time is executing, and increment their own outstandingInvocations count within that critical section.
* Exposing ThrottleStatus to provide more visibility into concurrency status. E.g. if zero is returned for # available invocations and the reason is because throttles are enabled, you can inspect the throttle details.
* Removing the NextStatusDelay property from ConcurrencyStatus for now. It was based on AvailableInvocationCount which was removed. I think it's fine for now to allow listeners to decide their delay when no invocations are available.
* Fixing a bug where it would be possible for a persisted snapshot to be applied that has a concurrency level greater than the configured MaximumFunctionConcurrency. That could happen for example if the customer changed their config after snapshots were persisted.