### PR TITLE
Improving indexing exceptions for potential failed contract bindings.

### DIFF
--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/Indexers/FunctionIndexerFactory.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/Indexers/FunctionIndexerFactory.cs
@@ -36,7 +36,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 .ConfigureDefaultTestHost(b =>
                 {
                     b.UseHostId("testhost")
-                    .AddAzureStorage();
+                    .AddAzureStorage()
+                    .AddServiceBus();
                 })
                 .ConfigureServices(services =>
                 {


### PR DESCRIPTION
Improvement to address https://github.com/Azure/azure-webjobs-sdk/issues/2729. Basically, if a parameter binding fails and we have binding contract information, we expand the binding error to include the following:

_Cannot bind parameter 'receiver' to type MessageReceiver. Make sure the parameter Type is supported by the binding. **The binding supports the following parameter names for type MessageReceiver: (MessageReceiver). If you're trying to bind to one of those values, rename your parameter to match the contract name (case insensitive).** If you're using binding extensions (e.g. Azure Storage, ServiceBus, Timers, etc.) make sure you've called the registration method for the extension(s) in your startup code (e.g. builder.AddAzureStorage(), builder.AddServiceBus(), builder.AddTimers(), etc.)._