### PR TITLE
Reduce logging frequency in ConcurrencyManager.GetStatus

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Scale/ConcurrencyManager.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Scale/ConcurrencyManager.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Azure.WebJobs.Host.Scale
                 functionConcurrencyStatus.DecreaseConcurrency();
             }
 
-            _logger.HostConcurrencyStatus(functionId, functionConcurrencyStatus.CurrentConcurrency, functionConcurrencyStatus.OutstandingInvocations);
+            functionConcurrencyStatus.LogUpdates(_logger);
 
             return functionConcurrencyStatus;
         }

--- a/src/Microsoft.Azure.WebJobs.Host/Scale/ConcurrencyStatus.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Scale/ConcurrencyStatus.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Threading;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Host.Scale
 {
@@ -22,6 +23,7 @@ namespace Microsoft.Azure.WebJobs.Host.Scale
 
         private int _adjustmentRunDirection;
         private int _adjustmentRunCount;
+        private int _lastLoggedConcurrency;
 
         /// <summary>
         /// Constructs a new instance.
@@ -237,6 +239,19 @@ namespace Microsoft.Azure.WebJobs.Host.Scale
         {
             int delta = GetNextAdjustment(-1);
             AdjustConcurrency(delta);
+        }
+
+        /// <summary>
+        /// Log if concurrency status has changed since the last call.
+        /// </summary>
+        /// <param name="logger">The logger to use.</param>
+        internal void LogUpdates(ILogger logger)
+        {
+            if (CurrentConcurrency != _lastLoggedConcurrency)
+            {
+                logger.HostConcurrencyStatus(FunctionId, CurrentConcurrency, OutstandingInvocations);
+                _lastLoggedConcurrency = CurrentConcurrency;
+            }
         }
 
         internal void FunctionStarted()


### PR DESCRIPTION
This change is being made to reduce logs. Consumers may call GetStatus very often in their listener poll loops, so we don't want to log unnecessarily.