### PR TITLE
Creating maintenance branch for WebJobs.Host.Storage v4

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -15,14 +15,8 @@ dotnet build Webjobs.sln -v q
 if (-not $?) { exit 1 }
 
 $projects = 
-  "src\Microsoft.Azure.WebJobs\WebJobs.csproj",
-  "src\Microsoft.Azure.WebJobs.Host\WebJobs.Host.csproj",
-  "src\Microsoft.Azure.WebJobs.Host\WebJobs.Host.Sources.csproj",
-  "src\Microsoft.Azure.WebJobs.Logging\WebJobs.Logging.csproj",
-  "src\Microsoft.Azure.WebJobs.Logging.ApplicationInsights\WebJobs.Logging.ApplicationInsights.csproj",
   "src\Microsoft.Azure.WebJobs.Extensions.Storage\WebJobs.Extensions.Storage.csproj",
-  "src\Microsoft.Azure.WebJobs.Host.Storage\WebJobs.Host.Storage.csproj",
-  "test\Microsoft.Azure.WebJobs.Host.TestCommon\WebJobs.Host.TestCommon.csproj"
+  "src\Microsoft.Azure.WebJobs.Host.Storage\WebJobs.Host.Storage.csproj"
 
 foreach ($project in $projects)
 {

--- a/WebJobs.sln
+++ b/WebJobs.sln
@@ -7,14 +7,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{639967B0
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Sample", "Sample", "{72A798F0-699B-4C8E-8D43-C1749661471E}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebJobs", "src\Microsoft.Azure.WebJobs\WebJobs.csproj", "{9D176316-CA11-40F3-A960-1ADC9AD0C460}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebJobs.Host", "src\Microsoft.Azure.WebJobs.Host\WebJobs.Host.csproj", "{39554ABE-D7B7-45FF-8D7C-56432ABCDE3D}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebJobs.Logging", "src\Microsoft.Azure.WebJobs.Logging\WebJobs.Logging.csproj", "{4F668623-B7D3-4834-99E2-2C0C8E0FFB9D}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebJobs.Logging.ApplicationInsights", "src\Microsoft.Azure.WebJobs.Logging.ApplicationInsights\WebJobs.Logging.ApplicationInsights.csproj", "{32F7D43D-1DD6-46F3-90FE-99B914DE8DAA}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleHost", "sample\SampleHost\SampleHost.csproj", "{93429246-CCE9-4EB0-B94D-68522862BA79}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebJobs.Host.UnitTests", "test\Microsoft.Azure.WebJobs.Host.UnitTests\WebJobs.Host.UnitTests.csproj", "{CA75D667-A785-4394-AA5C-3A6C658C23A7}"
@@ -55,8 +47,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Benchmarks", "test\Benchmar
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		src\Microsoft.Azure.WebJobs.Shared\WebJobs.Shared.projitems*{32f7d43d-1dd6-46f3-90fe-99b914de8daa}*SharedItemsImports = 5
-		src\Microsoft.Azure.WebJobs.Shared\WebJobs.Shared.projitems*{39554abe-d7b7-45ff-8d7c-56432abcde3d}*SharedItemsImports = 5
 		src\Microsoft.Azure.WebJobs.Shared.Storage\Microsoft.Azure.WebJobs.Shared.Storage.projitems*{6bed7f8a-a199-4d9d-85d1-6856ee3292c6}*SharedItemsImports = 13
 		src\Microsoft.Azure.WebJobs.Protocols\Microsoft.Azure.WebJobs.Protocols.projitems*{6fcd0852-6019-4cd5-9b7e-0de021a72bd7}*SharedItemsImports = 13
 		src\Microsoft.Azure.WebJobs.Shared.Storage\Microsoft.Azure.WebJobs.Shared.Storage.projitems*{a9733406-267c-4a53-ab07-d3a834e22153}*SharedItemsImports = 5
@@ -70,22 +60,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{9D176316-CA11-40F3-A960-1ADC9AD0C460}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{9D176316-CA11-40F3-A960-1ADC9AD0C460}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{9D176316-CA11-40F3-A960-1ADC9AD0C460}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{9D176316-CA11-40F3-A960-1ADC9AD0C460}.Release|Any CPU.Build.0 = Release|Any CPU
-		{39554ABE-D7B7-45FF-8D7C-56432ABCDE3D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{39554ABE-D7B7-45FF-8D7C-56432ABCDE3D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{39554ABE-D7B7-45FF-8D7C-56432ABCDE3D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{39554ABE-D7B7-45FF-8D7C-56432ABCDE3D}.Release|Any CPU.Build.0 = Release|Any CPU
-		{4F668623-B7D3-4834-99E2-2C0C8E0FFB9D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{4F668623-B7D3-4834-99E2-2C0C8E0FFB9D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{4F668623-B7D3-4834-99E2-2C0C8E0FFB9D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{4F668623-B7D3-4834-99E2-2C0C8E0FFB9D}.Release|Any CPU.Build.0 = Release|Any CPU
-		{32F7D43D-1DD6-46F3-90FE-99B914DE8DAA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{32F7D43D-1DD6-46F3-90FE-99B914DE8DAA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{32F7D43D-1DD6-46F3-90FE-99B914DE8DAA}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{32F7D43D-1DD6-46F3-90FE-99B914DE8DAA}.Release|Any CPU.Build.0 = Release|Any CPU
 		{93429246-CCE9-4EB0-B94D-68522862BA79}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{93429246-CCE9-4EB0-B94D-68522862BA79}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{93429246-CCE9-4EB0-B94D-68522862BA79}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/build/common.props
+++ b/build/common.props
@@ -1,10 +1,8 @@
 <Project>
   <PropertyGroup>
     <!-- Packages can have independent versions and only increment when released -->
-    <Version>3.0.31$(VersionSuffix)</Version>
     <ExtensionsStorageVersion>4.0.5$(VersionSuffix)</ExtensionsStorageVersion>
     <HostStorageVersion>4.0.4$(VersionSuffix)</HostStorageVersion>
-    <LoggingVersion>4.0.2$(VersionSuffix)</LoggingVersion>
     
     <TargetFramework>netstandard2.0</TargetFramework>
     <DebugType>embedded</DebugType>      

--- a/sample/SampleHost/SampleHost.csproj
+++ b/sample/SampleHost/SampleHost.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004" />
-	<PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.30" />
+	<PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.31" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sample/SampleHost/SampleHost.csproj
+++ b/sample/SampleHost/SampleHost.csproj
@@ -19,13 +19,13 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004" />
+	<PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.31-11877" />
+	<PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.31-11877" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Azure.WebJobs.Extensions.Storage\WebJobs.Extensions.Storage.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Azure.WebJobs.Host.Storage\WebJobs.Host.Storage.csproj" />
-    <ProjectReference Include="..\..\src\Microsoft.Azure.WebJobs.Host\WebJobs.Host.csproj" />
-    <ProjectReference Include="..\..\src\Microsoft.Azure.WebJobs.Logging.ApplicationInsights\WebJobs.Logging.ApplicationInsights.csproj" />
   </ItemGroup>
   
 

--- a/sample/SampleHost/SampleHost.csproj
+++ b/sample/SampleHost/SampleHost.csproj
@@ -19,8 +19,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004" />
-	<PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.31-11877" />
-	<PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.31-11877" />
+	<PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.30" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Azure.WebJobs.Host.Storage/WebJobs.Host.Storage.csproj
+++ b/src/Microsoft.Azure.WebJobs.Host.Storage/WebJobs.Host.Storage.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-	<PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.30" />
+	<PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.31" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.Azure.WebJobs.Host.Storage/WebJobs.Host.Storage.csproj
+++ b/src/Microsoft.Azure.WebJobs.Host.Storage/WebJobs.Host.Storage.csproj
@@ -36,10 +36,7 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\Microsoft.Azure.WebJobs.Host\WebJobs.Host.csproj" />
+	<PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.31-11877" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.Azure.WebJobs.Host.Storage/WebJobs.Host.Storage.csproj
+++ b/src/Microsoft.Azure.WebJobs.Host.Storage/WebJobs.Host.Storage.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-	<PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.31-11877" />
+	<PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.30" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/ApplicationInsightsEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/ApplicationInsightsEndToEndTests.cs
@@ -1256,12 +1256,12 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
             public void StopListening()
             {
-                _applicationInsightsListener.Stop();
                 _tcs?.Cancel(false);
                 if (_listenTask != null && !_listenTask.IsCompleted)
                 {
                     _listenTask.Wait();
                 }
+                _applicationInsightsListener.Stop();
 
                 _tcs?.Dispose();
                 _listenTask = null;

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/WebJobs.Host.EndToEndTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/WebJobs.Host.EndToEndTests.csproj
@@ -34,13 +34,13 @@
     <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+	<PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.31-11877" />
+	<PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.31-11877" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Azure.WebJobs.Extensions.Storage\WebJobs.Extensions.Storage.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Azure.WebJobs.Host.Storage\WebJobs.Host.Storage.csproj" />
-    <ProjectReference Include="..\..\src\Microsoft.Azure.WebJobs.Host\WebJobs.Host.csproj" />
-    <ProjectReference Include="..\..\src\Microsoft.Azure.WebJobs.Logging.ApplicationInsights\WebJobs.Logging.ApplicationInsights.csproj" />
     <ProjectReference Include="..\Microsoft.Azure.WebJobs.Host.TestCommon\WebJobs.Host.TestCommon.csproj" />
   </ItemGroup>
 

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/WebJobs.Host.EndToEndTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/WebJobs.Host.EndToEndTests.csproj
@@ -34,8 +34,8 @@
     <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-	<PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.31-11877" />
-	<PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.31-11877" />
+	<PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.30" />
+	<PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.30" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/WebJobs.Host.EndToEndTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/WebJobs.Host.EndToEndTests.csproj
@@ -34,8 +34,8 @@
     <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-	<PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.30" />
-	<PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.30" />
+	<PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.31" />
+	<PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.31" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/WebJobs.Host.FunctionalTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/WebJobs.Host.FunctionalTests.csproj
@@ -31,8 +31,8 @@
     <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-	<PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.31-11877" />
-	<PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.31-11877" />
+	<PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.31" />
+	<PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.31" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/WebJobs.Host.FunctionalTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/WebJobs.Host.FunctionalTests.csproj
@@ -31,13 +31,13 @@
     <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+	<PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.31-11877" />
+	<PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.31-11877" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Azure.WebJobs.Extensions.Storage\WebJobs.Extensions.Storage.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Azure.WebJobs.Host.Storage\WebJobs.Host.Storage.csproj" />
-    <ProjectReference Include="..\..\src\Microsoft.Azure.WebJobs.Host\WebJobs.Host.csproj" />
-    <ProjectReference Include="..\..\src\Microsoft.Azure.WebJobs.Logging.ApplicationInsights\WebJobs.Logging.ApplicationInsights.csproj" />
     <ProjectReference Include="..\FakeStorage\FakeAzureStorage.csproj" />
     <ProjectReference Include="..\Microsoft.Azure.WebJobs.Host.TestCommon\WebJobs.Host.TestCommon.csproj" />
     <ProjectReference Include="..\TestProjects\FSharpFunctions\FSharpFunctions.fsproj" />

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/WebJobs.Host.TestCommon.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/WebJobs.Host.TestCommon.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-	<PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.30" />
+	<PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.31" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/WebJobs.Host.TestCommon.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/WebJobs.Host.TestCommon.csproj
@@ -31,10 +31,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Microsoft.Azure.WebJobs.Host\WebJobs.Host.csproj" />
+	<PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.31-11877" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/WebJobs.Host.TestCommon.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/WebJobs.Host.TestCommon.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-	<PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.31-11877" />
+	<PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.30" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Hosting/FunctionDataCacheKeyTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Hosting/FunctionDataCacheKeyTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using Microsoft.Azure.WebJobs;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Host.UnitTests.Hosting

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
@@ -40,8 +40,8 @@
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta3-build3705" />
-	<PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.31-11877" />
-	<PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.31-11877" />
+	<PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.31" />
+	<PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.31" />
 	<PackageReference Include="Microsoft.Azure.WebJobs.Logging" Version="4.0.2" />
   </ItemGroup>
 

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
@@ -40,12 +40,12 @@
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta3-build3705" />
+	<PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.31-11877" />
+	<PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.31-11877" />
+	<PackageReference Include="Microsoft.Azure.WebJobs.Logging" Version="4.0.2" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Microsoft.Azure.WebJobs.Host\WebJobs.Host.csproj" />
-    <ProjectReference Include="..\..\src\Microsoft.Azure.WebJobs.Logging.ApplicationInsights\WebJobs.Logging.ApplicationInsights.csproj" />
-    <ProjectReference Include="..\..\src\Microsoft.Azure.WebJobs.Logging\WebJobs.Logging.csproj" />
     <ProjectReference Include="..\Microsoft.Azure.WebJobs.Host.TestCommon\WebJobs.Host.TestCommon.csproj" />
   </ItemGroup>
 

--- a/test/Microsoft.Azure.WebJobs.Logging.FunctionalTests/WebJobs.Logging.FunctionalTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Logging.FunctionalTests/WebJobs.Logging.FunctionalTests.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-	<PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.30" />
+	<PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.31" />
 	<PackageReference Include="Microsoft.Azure.WebJobs.Logging" Version="4.0.2" />
   </ItemGroup>
 

--- a/test/Microsoft.Azure.WebJobs.Logging.FunctionalTests/WebJobs.Logging.FunctionalTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Logging.FunctionalTests/WebJobs.Logging.FunctionalTests.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-	<PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.31-11877" />
+	<PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.30" />
 	<PackageReference Include="Microsoft.Azure.WebJobs.Logging" Version="4.0.2" />
   </ItemGroup>
 

--- a/test/Microsoft.Azure.WebJobs.Logging.FunctionalTests/WebJobs.Logging.FunctionalTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Logging.FunctionalTests/WebJobs.Logging.FunctionalTests.csproj
@@ -30,11 +30,11 @@
     <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+	<PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.31-11877" />
+	<PackageReference Include="Microsoft.Azure.WebJobs.Logging" Version="4.0.2" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Microsoft.Azure.WebJobs.Host\WebJobs.Host.csproj" />
-    <ProjectReference Include="..\..\src\Microsoft.Azure.WebJobs.Logging\WebJobs.Logging.csproj" />
     <ProjectReference Include="..\Microsoft.Azure.WebJobs.Host.TestCommon\WebJobs.Host.TestCommon.csproj" />
   </ItemGroup>
 

--- a/test/Microsoft.Azure.Webjobs.Extensions.Storage.UnitTests/WebJobs.Extensions.Storage.UnitTests.csproj
+++ b/test/Microsoft.Azure.Webjobs.Extensions.Storage.UnitTests/WebJobs.Extensions.Storage.UnitTests.csproj
@@ -35,12 +35,12 @@
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta3-build3705" />
+	<PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.31-11877" />
+	<PackageReference Include="Microsoft.Azure.WebJobs.Logging" Version="4.0.2" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Azure.WebJobs.Extensions.Storage\WebJobs.Extensions.Storage.csproj" />
-    <ProjectReference Include="..\..\src\Microsoft.Azure.WebJobs.Host\WebJobs.Host.csproj" />
-    <ProjectReference Include="..\..\src\Microsoft.Azure.WebJobs.Logging\WebJobs.Logging.csproj" />
     <ProjectReference Include="..\FakeStorage\FakeAzureStorage.csproj" />
     <ProjectReference Include="..\Microsoft.Azure.WebJobs.Host.TestCommon\WebJobs.Host.TestCommon.csproj" />
   </ItemGroup>

--- a/test/Microsoft.Azure.Webjobs.Extensions.Storage.UnitTests/WebJobs.Extensions.Storage.UnitTests.csproj
+++ b/test/Microsoft.Azure.Webjobs.Extensions.Storage.UnitTests/WebJobs.Extensions.Storage.UnitTests.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta3-build3705" />
-	<PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.30" />
+	<PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.31" />
 	<PackageReference Include="Microsoft.Azure.WebJobs.Logging" Version="4.0.2" />
   </ItemGroup>
 

--- a/test/Microsoft.Azure.Webjobs.Extensions.Storage.UnitTests/WebJobs.Extensions.Storage.UnitTests.csproj
+++ b/test/Microsoft.Azure.Webjobs.Extensions.Storage.UnitTests/WebJobs.Extensions.Storage.UnitTests.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta3-build3705" />
-	<PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.31-11877" />
+	<PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.30" />
 	<PackageReference Include="Microsoft.Azure.WebJobs.Logging" Version="4.0.2" />
   </ItemGroup>
 

--- a/test/TestProjects/FSharpFunctions/FSharpFunctions.fsproj
+++ b/test/TestProjects/FSharpFunctions/FSharpFunctions.fsproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="TaskBuilder.fs" Version="2.1.0" />
-	<PackageReference Include="Microsoft.Azure.WebJobs.Core" Version="3.0.30" />
+	<PackageReference Include="Microsoft.Azure.WebJobs.Core" Version="3.0.31" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/FSharpFunctions/FSharpFunctions.fsproj
+++ b/test/TestProjects/FSharpFunctions/FSharpFunctions.fsproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="TaskBuilder.fs" Version="2.1.0" />
-	<PackageReference Include="Microsoft.Azure.WebJobs.Core" Version="3.0.31-11877" />
+	<PackageReference Include="Microsoft.Azure.WebJobs.Core" Version="3.0.30" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjects/FSharpFunctions/FSharpFunctions.fsproj
+++ b/test/TestProjects/FSharpFunctions/FSharpFunctions.fsproj
@@ -10,10 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="TaskBuilder.fs" Version="2.1.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Microsoft.Azure.WebJobs\WebJobs.csproj" />
+	<PackageReference Include="Microsoft.Azure.WebJobs.Core" Version="3.0.31-11877" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Freezing the current dev branch into storagev4 for future maintenance on Microsoft.Azure.WebJobs.Host.Storage v4 and Microsoft.Azure.WebJobs.Extensions.Storage v4.

All project references to WebJobs.Host or WebJobs.Core are replaced with package references.