### PR TITLE
Exit from retry loop if trigger canceled the execution

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/LoggerExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/LoggerExtensions.cs
@@ -102,8 +102,14 @@ namespace Microsoft.Extensions.Logging
         private static readonly Action<ILogger, string, Exception> _functionConcurrencyIncrease =
            LoggerMessage.Define<string>(
            LogLevel.Debug,
-           new EventId(338, nameof(FunctionConcurrencyIncrease)),
+           new EventId(339, nameof(FunctionConcurrencyIncrease)),
            "{functionId} Increasing concurrency");
+
+        private static readonly Action<ILogger, Exception> _logExitFromRetryLoop =
+           LoggerMessage.Define(
+           LogLevel.Warning,
+           new EventId(340, nameof(LogExitFromRetryLoop)),
+           "Invocation cancelled - exiting retry loop.");
 
         public static void PrimaryHostCoordinatorLockLeaseAcquired(this ILogger logger, string websiteInstanceId)
         {
@@ -235,6 +241,11 @@ namespace Microsoft.Extensions.Logging
         public static void LogFunctionRetryAttempt(this ILogger logger, TimeSpan nextDelay, int attemptCount, int maxRetryCount)
         {
             _logFunctionRetryAttempt(logger, nextDelay, attemptCount, maxRetryCount, null);
+        }
+
+        internal static void LogExitFromRetryLoop(this ILogger logger)
+        {
+            _logExitFromRetryLoop(logger, null);
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/FunctionExecutorExtensionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/FunctionExecutorExtensionsTests.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Azure.WebJobs.Host.Protocols;
+using Microsoft.Azure.WebJobs.Host.TestCommon;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
+{
+    public class FunctionExecutorExtensionsTests
+    {
+        [Fact]
+        public async Task TryExecuteWithRetries_ExitRetryLoop()
+        {
+            TestLoggerProvider loggerProvider = new TestLoggerProvider();
+            var loggerFactory = new LoggerFactory();
+            loggerFactory.AddProvider(loggerProvider);
+
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+
+            _ = Task.Run(async () =>
+            {
+                await Task.Delay(1000);
+                cancellationTokenSource.Cancel();
+            });
+
+            Mock<IFunctionInstance> mockFunctionInstance = new Mock<IFunctionInstance>(MockBehavior.Strict);
+            FunctionDescriptor functionDescriptor = GetFunctionDescriptor();
+            mockFunctionInstance.Setup(x => x.FunctionDescriptor).Returns(functionDescriptor);
+
+            Func<IFunctionInstance> instanceFactory = () => mockFunctionInstance.Object;
+            Mock<IFunctionExecutor> functionExecutor = new Mock<IFunctionExecutor>(MockBehavior.Strict);
+
+            functionExecutor.Setup(x => x.TryExecuteAsync(It.IsAny<IFunctionInstance>(), It.IsAny<CancellationToken>())).Returns(() =>
+            {
+                return Task.FromResult((IDelayedException)new DelayedException(new Exception("test")));
+            });
+
+            var result = await functionExecutor.Object.TryExecuteAsync(instanceFactory, loggerFactory, cancellationTokenSource.Token);
+            Assert.NotNull(loggerProvider.GetAllLogMessages().SingleOrDefault(x => x.FormattedMessage == "Invocation cancelled - exiting retry loop."));
+        }
+
+        private FunctionDescriptor GetFunctionDescriptor()
+        {
+            int maxRetryCount = 5;
+            TimeSpan delay = TimeSpan.FromMilliseconds(1000);
+            var mockRetryStrategy = new Mock<IRetryStrategy>();
+            mockRetryStrategy.Setup(p => p.MaxRetryCount).Returns(maxRetryCount);
+            mockRetryStrategy.Setup(p => p.GetNextDelay(It.IsAny<RetryContext>())).Returns(delay);
+
+            return new FunctionDescriptor()
+            {
+                RetryStrategy = mockRetryStrategy.Object
+            };
+        }
+    }
+}


### PR DESCRIPTION
Adding ability to exit from retry loop if caller requested cancellation.

eventhubs 4.x issue:
https://github.com/Azure/azure-functions-eventhubs-extension/issues/92
eventhubs 5.x issue:
https://github.com/Azure/azure-sdk-for-net/issues/20174
servicebus 4.x issue:
https://github.com/Azure/azure-functions-servicebus-extension/issues/145
servicebus 5.x issue:
https://github.com/Azure/azure-sdk-for-net/issues/20177