### PR TITLE
[pack] Adding FunctionActivityStatusProvider to monitor retries or active invocations.

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- Packages can have independent versions and only increment when released -->
-    <Version>3.0.31$(VersionSuffix)</Version>
+    <Version>3.0.32$(VersionSuffix)</Version>
     <HostStorageVersion>5.0.0-beta.1$(VersionSuffix)</HostStorageVersion>
     <LoggingVersion>4.0.2$(VersionSuffix)</LoggingVersion>
     

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/AbortListenerFunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/AbortListenerFunctionExecutor.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             {
                 await listener.StartAsync(cancellationToken);
 
-                result = await _innerExecutor.TryExecuteAsync(instance, cancellationToken);
+                result = await base.TryExecuteAsync(instance, cancellationToken);
 
                 await listener.StopAsync(cancellationToken);
             }

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/AbortListenerFunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/AbortListenerFunctionExecutor.cs
@@ -7,18 +7,16 @@ using Microsoft.Azure.WebJobs.Host.Listeners;
 
 namespace Microsoft.Azure.WebJobs.Host.Executors
 {
-    internal class AbortListenerFunctionExecutor : IFunctionExecutor
+    internal class AbortListenerFunctionExecutor : DelegatingFunctionExecutor
     {
         private readonly IListenerFactory _abortListenerFactory;
-        private readonly IFunctionExecutor _innerExecutor;
 
-        public AbortListenerFunctionExecutor(IListenerFactory abortListenerFactory, IFunctionExecutor innerExecutor)
+        public AbortListenerFunctionExecutor(IListenerFactory abortListenerFactory, IFunctionExecutor innerExecutor) : base(innerExecutor)
         {
             _abortListenerFactory = abortListenerFactory;
-            _innerExecutor = innerExecutor;
         }
 
-        public async Task<IDelayedException> TryExecuteAsync(IFunctionInstance instance, CancellationToken cancellationToken)
+        public override async Task<IDelayedException> TryExecuteAsync(IFunctionInstance instance, CancellationToken cancellationToken)
         {
             IDelayedException result;
 

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/DelegatingFunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/DelegatingFunctionExecutor.cs
@@ -6,10 +6,10 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Azure.WebJobs.Host.Executors
 {
-    abstract internal class DelegatingFunctionExecutor : IRetryNotifier, IFunctionExecutor
+    internal abstract class DelegatingFunctionExecutor : IRetryNotifier, IFunctionExecutor
     {
-        readonly private IFunctionExecutor _innerExecutor;
-        readonly private IRetryNotifier _retryNotifier;
+        private readonly IFunctionExecutor _innerExecutor;
+        private readonly IRetryNotifier _retryNotifier;
 
         public DelegatingFunctionExecutor(IFunctionExecutor innerExecutor)
         {

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/DelegatingFunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/DelegatingFunctionExecutor.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.WebJobs.Host.Executors
+{
+    abstract internal class DelegatingFunctionExecutor : IRetryNotifier, IFunctionExecutor
+    {
+        readonly protected IFunctionExecutor _innerExecutor;
+
+        public DelegatingFunctionExecutor(IFunctionExecutor innerExecutor)
+        {
+            _innerExecutor = innerExecutor;
+        }
+
+        public virtual Task<IDelayedException> TryExecuteAsync(IFunctionInstance instance, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<IDelayedException>(null);
+        }
+
+        public void RetryPending()
+        {
+            if (_innerExecutor is IRetryNotifier retryNotifier)
+            {
+                retryNotifier.RetryPending();
+            }
+        }
+
+        public void RetryComplete()
+        {
+            if (_innerExecutor is IRetryNotifier retryNotifier)
+            {
+                retryNotifier.RetryComplete();
+            }
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/DelegatingFunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/DelegatingFunctionExecutor.cs
@@ -8,32 +8,28 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
 {
     abstract internal class DelegatingFunctionExecutor : IRetryNotifier, IFunctionExecutor
     {
-        readonly protected IFunctionExecutor _innerExecutor;
+        readonly private IFunctionExecutor _innerExecutor;
+        readonly private IRetryNotifier _retryNotifier;
 
         public DelegatingFunctionExecutor(IFunctionExecutor innerExecutor)
         {
             _innerExecutor = innerExecutor;
+            _retryNotifier = innerExecutor as IRetryNotifier;
         }
 
         public virtual Task<IDelayedException> TryExecuteAsync(IFunctionInstance instance, CancellationToken cancellationToken)
         {
-            return Task.FromResult<IDelayedException>(null);
+            return _innerExecutor.TryExecuteAsync(instance, cancellationToken);
         }
 
-        public void RetryPending()
+        public virtual void RetryPending()
         {
-            if (_innerExecutor is IRetryNotifier retryNotifier)
-            {
-                retryNotifier.RetryPending();
-            }
+            _retryNotifier?.RetryPending();
         }
 
-        public void RetryComplete()
+        public virtual void RetryComplete()
         {
-            if (_innerExecutor is IRetryNotifier retryNotifier)
-            {
-                retryNotifier.RetryComplete();
-            }
+            _retryNotifier?.RetryComplete();
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionActivityStatus.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionActivityStatus.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Host.Executors
+{
+    /// <summary>
+    /// Represents activity status the of job host
+    /// </summary>
+    public class FunctionActivityStatus
+    {
+        /// <summary>
+        /// Gets or sets number of outstanding invocations
+        /// </summary>
+        public int OutstandingInvocations { get; set; }
+
+        /// <summary>
+        /// Gets or sets number of outstanding retries
+        /// </summary>
+        public int OutstandingRetries { get; set; }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/HeartbeatFunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/HeartbeatFunctionExecutor.cs
@@ -7,21 +7,19 @@ using Microsoft.Azure.WebJobs.Host.Timers;
 
 namespace Microsoft.Azure.WebJobs.Host.Executors
 {
-    internal class HeartbeatFunctionExecutor : IFunctionExecutor
+    internal class HeartbeatFunctionExecutor : DelegatingFunctionExecutor, IFunctionExecutor
     {
         private readonly IRecurrentCommand _heartbeatCommand;
         private readonly IWebJobsExceptionHandler _exceptionHandler;
-        private readonly IFunctionExecutor _innerExecutor;
 
         public HeartbeatFunctionExecutor(IRecurrentCommand heartbeatCommand,
-            IWebJobsExceptionHandler exceptionHandler, IFunctionExecutor innerExecutor)
+            IWebJobsExceptionHandler exceptionHandler, IFunctionExecutor innerExecutor) : base(innerExecutor)
         {
             _heartbeatCommand = heartbeatCommand;
             _exceptionHandler = exceptionHandler;
-            _innerExecutor = innerExecutor;
         }
 
-        public async Task<IDelayedException> TryExecuteAsync(IFunctionInstance instance, CancellationToken cancellationToken)
+        public override async Task<IDelayedException> TryExecuteAsync(IFunctionInstance instance, CancellationToken cancellationToken)
         {
             IDelayedException result;
 

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/HeartbeatFunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/HeartbeatFunctionExecutor.cs
@@ -7,7 +7,7 @@ using Microsoft.Azure.WebJobs.Host.Timers;
 
 namespace Microsoft.Azure.WebJobs.Host.Executors
 {
-    internal class HeartbeatFunctionExecutor : DelegatingFunctionExecutor, IFunctionExecutor
+    internal class HeartbeatFunctionExecutor : DelegatingFunctionExecutor
     {
         private readonly IRecurrentCommand _heartbeatCommand;
         private readonly IWebJobsExceptionHandler _exceptionHandler;
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
                 await _heartbeatCommand.TryExecuteAsync(cancellationToken);
                 timer.Start();
 
-                result = await _innerExecutor.TryExecuteAsync(instance, cancellationToken);
+                result = await base.TryExecuteAsync(instance, cancellationToken);
 
                 await timer.StopAsync(cancellationToken);
             }

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/IFunctionActivityStatusProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/IFunctionActivityStatusProvider.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
     public interface IFunctionActivityStatusProvider
     {
         /// <summary>
-        /// Returns activity status of the job host
+        /// Gets the current <see cref="FunctionActivityStatus"/> of the job host.
         /// </summary>
         /// <returns></returns>
         public FunctionActivityStatus GetStatus();

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/IFunctionActivityStatusProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/IFunctionActivityStatusProvider.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Host.Executors
+{
+    /// <summary>
+    /// Interface providing access to job function activity information for the job host.
+    /// </summary>
+    public interface IFunctionActivityStatusProvider
+    {
+        /// <summary>
+        /// Returns activity status of the job host
+        /// </summary>
+        /// <returns></returns>
+        public FunctionActivityStatus GetStatus();
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/IRetryNotifier .cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/IRetryNotifier .cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+namespace Microsoft.Azure.WebJobs.Host.Executors
+{
+    internal interface IRetryNotifier
+    {
+        void RetryPending();
+
+        void RetryComplete();
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/ShutdownFunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/ShutdownFunctionExecutor.cs
@@ -6,18 +6,16 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Azure.WebJobs.Host.Executors
 {
-    internal class ShutdownFunctionExecutor : IFunctionExecutor
+    internal class ShutdownFunctionExecutor : DelegatingFunctionExecutor, IFunctionExecutor
     {
         private readonly CancellationToken _shutdownToken;
-        private readonly IFunctionExecutor _innerExecutor;
 
-        public ShutdownFunctionExecutor(CancellationToken shutdownToken, IFunctionExecutor innerExecutor)
+        public ShutdownFunctionExecutor(CancellationToken shutdownToken, IFunctionExecutor innerExecutor) : base(innerExecutor)
         {
             _shutdownToken = shutdownToken;
-            _innerExecutor = innerExecutor;
         }
 
-        public async Task<IDelayedException> TryExecuteAsync(IFunctionInstance instance, CancellationToken cancellationToken)
+        public override async Task<IDelayedException> TryExecuteAsync(IFunctionInstance instance, CancellationToken cancellationToken)
         {
             using (CancellationTokenSource callCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(
                 _shutdownToken, cancellationToken))

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/ShutdownFunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/ShutdownFunctionExecutor.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Azure.WebJobs.Host.Executors
 {
-    internal class ShutdownFunctionExecutor : DelegatingFunctionExecutor, IFunctionExecutor
+    internal class ShutdownFunctionExecutor : DelegatingFunctionExecutor
     {
         private readonly CancellationToken _shutdownToken;
 
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             using (CancellationTokenSource callCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(
                 _shutdownToken, cancellationToken))
             {
-                return await _innerExecutor.TryExecuteAsync(instance, callCancellationSource.Token);
+                return await base.TryExecuteAsync(instance, callCancellationSource.Token);
             }
         }
     }

--- a/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsServiceCollectionExtensions.cs
@@ -63,7 +63,9 @@ namespace Microsoft.Azure.WebJobs
             services.TryAddSingleton<SingletonManager>();
             services.TryAddSingleton<IHostSingletonManager>(provider => provider.GetRequiredService<SingletonManager>());
             services.TryAddSingleton<SharedQueueHandler>();
-            services.TryAddSingleton<IFunctionExecutor, FunctionExecutor>();
+            services.TryAddSingleton<FunctionExecutor>();
+            services.TryAddSingleton<IFunctionExecutor>(x => x.GetRequiredService<FunctionExecutor>());
+            services.TryAddSingleton<IFunctionActivityStatusProvider>(x => x.GetRequiredService<FunctionExecutor>());
             services.TryAddSingleton<IDrainModeManager, DrainModeManager>();
             services.TryAddSingleton<IJobHostContextFactory, JobHostContextFactory>();
 

--- a/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexer.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexer.cs
@@ -408,7 +408,7 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
             }
 
             IRetryStrategy retryStrategy = TypeUtility.GetHierarchicalAttributeOrNull<RetryAttribute>(method) ?? defaultRetryStrategy;
-
+ 
             return new FunctionDescriptor
             {
                 Id = method.GetFullName(),

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/FunctionExecutorExtensionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/FunctionExecutorExtensionsTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Protocols;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using System;
 using System.Linq;
@@ -45,6 +46,36 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
 
             var result = await functionExecutor.Object.TryExecuteAsync(instanceFactory, loggerFactory, cancellationTokenSource.Token);
             Assert.NotNull(loggerProvider.GetAllLogMessages().SingleOrDefault(x => x.FormattedMessage == "Invocation cancelled - exiting retry loop."));
+        }
+
+        [Fact]
+        public async Task TryExecuteWithRetries_Call_RetryNotifier()
+        {
+            Mock<IFunctionInstance> mockFunctionInstance = new Mock<IFunctionInstance>(MockBehavior.Strict);
+            FunctionDescriptor functionDescriptor = GetFunctionDescriptor();
+            mockFunctionInstance.Setup(x => x.FunctionDescriptor).Returns(functionDescriptor);
+
+            Func<IFunctionInstance> instanceFactory = () => mockFunctionInstance.Object;
+            Mock<IFunctionExecutor> functionExecutor = new Mock<IFunctionExecutor>(MockBehavior.Strict);
+            functionExecutor.Setup(x => x.TryExecuteAsync(It.IsAny<IFunctionInstance>(), It.IsAny<CancellationToken>())).Returns(() =>
+            {
+                return Task.FromResult((IDelayedException)new DelayedException(new Exception("test")));
+            });
+            int retryPendingCallsCount = 0, retryCompletedCallsCount = 0;
+            functionExecutor.As<IRetryNotifier>().Setup(x => x.RetryPending()).Callback(() =>
+            {
+                retryPendingCallsCount++;
+            });
+
+            functionExecutor.As<IRetryNotifier>().Setup(x => x.RetryComplete()).Callback(() =>
+            {
+                retryCompletedCallsCount++;
+            });
+         
+            var result = await functionExecutor.Object.TryExecuteAsync(instanceFactory, NullLoggerFactory.Instance, CancellationToken.None);
+
+            Assert.Equal(retryPendingCallsCount, 1);
+            Assert.Equal(retryCompletedCallsCount, 1);
         }
 
         private FunctionDescriptor GetFunctionDescriptor()

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/FunctionExecutorExtensionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/FunctionExecutorExtensionsTests.cs
@@ -28,12 +28,12 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
 
             _ = Task.Run(async () =>
             {
-                await Task.Delay(1000);
+                await Task.Delay(100);
                 cancellationTokenSource.Cancel();
             });
 
             Mock<IFunctionInstance> mockFunctionInstance = new Mock<IFunctionInstance>(MockBehavior.Strict);
-            FunctionDescriptor functionDescriptor = GetFunctionDescriptor();
+            FunctionDescriptor functionDescriptor = GetFunctionDescriptor(100, 5);
             mockFunctionInstance.Setup(x => x.FunctionDescriptor).Returns(functionDescriptor);
 
             Func<IFunctionInstance> instanceFactory = () => mockFunctionInstance.Object;
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
         public async Task TryExecuteWithRetries_Call_RetryNotifier()
         {
             Mock<IFunctionInstance> mockFunctionInstance = new Mock<IFunctionInstance>(MockBehavior.Strict);
-            FunctionDescriptor functionDescriptor = GetFunctionDescriptor();
+            FunctionDescriptor functionDescriptor = GetFunctionDescriptor(100, 5);
             mockFunctionInstance.Setup(x => x.FunctionDescriptor).Returns(functionDescriptor);
 
             Func<IFunctionInstance> instanceFactory = () => mockFunctionInstance.Object;
@@ -78,10 +78,9 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             Assert.Equal(retryCompletedCallsCount, 1);
         }
 
-        private FunctionDescriptor GetFunctionDescriptor()
+        private FunctionDescriptor GetFunctionDescriptor(int maxRetryCount, int delayInMs)
         {
-            int maxRetryCount = 5;
-            TimeSpan delay = TimeSpan.FromMilliseconds(1000);
+            TimeSpan delay = TimeSpan.FromMilliseconds(delayInMs);
             var mockRetryStrategy = new Mock<IRetryStrategy>();
             mockRetryStrategy.Setup(p => p.MaxRetryCount).Returns(maxRetryCount);
             mockRetryStrategy.Setup(p => p.GetNextDelay(It.IsAny<RetryContext>())).Returns(delay);

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/FunctionExecutorTestHelper.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/FunctionExecutorTestHelper.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Azure.WebJobs.Host.Indexers;
+using Microsoft.Azure.WebJobs.Host.Protocols;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
+{
+    class FunctionExecutorTestHelper
+    {
+        public static FunctionDescriptor GetFunctionDescriptor()
+        {
+            var method = typeof(FunctionExecutorTestHelper).GetMethod(nameof(TestFunction), BindingFlags.NonPublic | BindingFlags.Static);
+            return FunctionIndexer.FromMethod(method, new ConfigurationBuilder().Build());
+        }
+
+        public static IFunctionInstance CreateFunctionInstance(Guid id, IDictionary<string, string> triggerDetails, bool invocationThrows, FunctionDescriptor descriptor, int delayInMilliseconds = 0)
+        {
+            var serviceScopeFactoryMock = new Mock<IServiceScopeFactory>(MockBehavior.Strict);
+            var serviceScopeMock = new Mock<IServiceScope>();
+            serviceScopeFactoryMock.Setup(s => s.CreateScope()).Returns(serviceScopeMock.Object);
+            Mock<IFunctionInvoker> mockInvoker = new Mock<IFunctionInvoker>();
+            int invocationCount = 0;
+            mockInvoker.Setup(i => i.InvokeAsync(It.IsAny<object>(), It.IsAny<object[]>()))
+                .Returns(async () =>
+                {
+                    invocationCount++;
+                    await Task.Delay(delayInMilliseconds);
+                    if (invocationThrows)
+                    {
+                        throw new Exception($"Test retry exception. invocationCount:{invocationCount}");
+                    }
+                    return Task.FromResult<object>(null);
+                });
+            mockInvoker.Setup(m => m.ParameterNames).Returns(new List<string>());
+            var mockBindingSource = new Mock<IBindingSource>();
+            var valueProviders = Task.Run(() =>
+            {
+                IDictionary<string, IValueProvider> d = new Dictionary<string, IValueProvider>();
+                IReadOnlyDictionary<string, IValueProvider> red = new ReadOnlyDictionary<string, IValueProvider>(d);
+                return red;
+            });
+            mockBindingSource.Setup(p => p.BindAsync(It.IsAny<ValueBindingContext>())).Returns(valueProviders);
+            return new FunctionInstance(id, triggerDetails, null, new ExecutionReason(), mockBindingSource.Object, mockInvoker.Object, descriptor, serviceScopeFactoryMock.Object);
+        }
+
+        [FixedDelayRetry(5, "00:00:01")]
+        private static void TestFunction()
+        {
+            // used for a FunctionDescriptor
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
@@ -292,7 +292,9 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 "ICacheAwareWriteObject",
                 "IFunctionDataCache",
                 "SharedMemoryAttribute",
-                "SharedMemoryMetadata"
+                "SharedMemoryMetadata",
+                "FunctionActivityStatus",
+                "IFunctionActivityStatusProvider"
             };
 
             TestHelpers.AssertPublicTypes(expected, assembly);


### PR DESCRIPTION
Implement a new Functions Host drain status API that DataRole will poll to determine when it's safe to reclaim a draining instance.

Internal work [item](https://dev.azure.com/azfunctions/Planning/_workitems/edit/827/) and [design](https://microsoft.sharepoint.com/teams/Antares/_layouts/OneNote.aspx?id=%2fteams%2fAntares%2fShared%20Documents%2fAntares%20Feature%20Crew&wd=target%28Azure%20Functions.one%7cBD6BD264-4C3E-463B-8B54-35FCCBE73FA1%2fFunctions%20Retry%5c%2fDrain%20Issue%7cBA4C3DBF-F9CB-4FD2-B495-6232391B0020%2f%29)

The change also addresses Azure/azure-functions-host#7188 

Related function host PR Azure/azure-functions-host/pull/7760

