### PR TITLE
Adding RetryOptions for host level default retry configuration.

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Config/RetryOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Config/RetryOptions.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Azure.WebJobs.Host.Config
+{
+    public class RetryOptions
+    {
+        public RetryStrategy Strategy { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum number of retries allowed per function execution
+        /// </summary>
+        public int? MaxRetryCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the delay that will be used between retries when using <see cref="RetryStrategy.FixedDelay"/> strategy
+        /// </summary>
+        public TimeSpan? DelayInterval { get; set; }
+
+        /// <summary>
+        /// Gets or sets the minimum retry delay when using <see cref="RetryStrategy.ExponentialBackoff"/> strategy
+        /// </summary>
+        public TimeSpan? MinimumInterval { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum retry delay when using <see cref="RetryStrategy.ExponentialBackoff"/> strategy
+        /// </summary>
+        public TimeSpan? MaximumInterval { get; set; }
+
+        /// <summary>
+        /// Converts to <see cref="RetryAttribute"/> attribute
+        /// </summary>
+        /// <returns></returns>
+        public RetryAttribute ToAttribute()
+        {
+            switch (Strategy)
+            {
+                case RetryStrategy.FixedDelay:
+                    if (MaxRetryCount.HasValue && DelayInterval.HasValue)
+                    {
+                        return new FixedDelayRetryAttribute(MaxRetryCount.Value, DelayInterval.ToString());
+                    }
+                    break;
+                case RetryStrategy.ExponentialBackoff:
+                    if (MaxRetryCount.HasValue && MinimumInterval.HasValue && MaximumInterval.HasValue)
+                    {
+                        return new ExponentialBackoffRetryAttribute(MaxRetryCount.Value, MinimumInterval.ToString(), MaximumInterval.ToString());
+                    }
+                    break;
+            }
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Config/RetryOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Config/RetryOptions.cs
@@ -36,10 +36,10 @@ namespace Microsoft.Azure.WebJobs.Host
         public TimeSpan? MaximumInterval { get; set; }
 
         /// <summary>
-        /// Converts to <see cref="RetryAttribute"/> attribute
+        /// Returns <see cref="RetryAttribute"/> or null if retry policy is not defined
         /// </summary>
         /// <returns></returns>
-        public RetryAttribute ToAttribute()
+        internal RetryAttribute ToAttributeOrNull()
         {
             switch (Strategy)
             {

--- a/src/Microsoft.Azure.WebJobs.Host/Config/RetryOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Config/RetryOptions.cs
@@ -3,10 +3,16 @@
 
 using System;
 
-namespace Microsoft.Azure.WebJobs.Host.Config
+namespace Microsoft.Azure.WebJobs.Host
 {
+    /// <summary>
+    /// Configuration options for controlling function execution retry behavior
+    /// </summary>
     public class RetryOptions
     {
+        /// <summary>
+        /// Gets or sets built-in retry strategy
+        /// </summary>
         public RetryStrategy Strategy { get; set; }
 
         /// <summary>

--- a/src/Microsoft.Azure.WebJobs.Host/Config/RetryStrategy.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Config/RetryStrategy.cs
@@ -1,11 +1,21 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-namespace Microsoft.Azure.WebJobs.Host.Config
+namespace Microsoft.Azure.WebJobs.Host
 {
+    /// <summary>
+    /// Enumeration of built-in retry strategies. <see cref="RetryOptions.Strategy"/>
+    /// </summary>
     public enum RetryStrategy
     {
+        /// <summary>
+        /// Retry policy is set using <see cref="FixedDelayRetryAttribute"/>
+        /// </summary>
         ExponentialBackoff = 0,
+
+        /// <summary>
+        /// Retry policy is set using <see cref="ExponentialBackoffRetryAttribute"/>
+        /// </summary>
         FixedDelay = 1
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Config/RetryStrategy.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Config/RetryStrategy.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Host.Config
+{
+    public enum RetryStrategy
+    {
+        ExponentialBackoff = 0,
+        FixedDelay = 1
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexProvider.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Bindings;
-using Microsoft.Azure.WebJobs.Host.Config;
 using Microsoft.Azure.WebJobs.Host.Dispatch;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Triggers;

--- a/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexProvider.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
             _defaultTimeout = timeoutOptions.Value.ToAttribute();
             _allowPartialHostStartup = hostOptions.Value.AllowPartialHostStartup;
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
-            _defaultRetryStrategy = retryOptions.Value.ToAttribute();
+            _defaultRetryStrategy = retryOptions.Value.ToAttributeOrNull();
         }
 
         public async Task<IFunctionIndex> GetAsync(CancellationToken cancellationToken)

--- a/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexProvider.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Azure.WebJobs.Host.Config;
 using Microsoft.Azure.WebJobs.Host.Dispatch;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Triggers;
@@ -45,7 +46,7 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
             IOptions<JobHostOptions> hostOptions,
             IConfiguration configuration,
             IServiceScopeFactory serviceScopeFactory,
-            IRetryStrategy defaultRetryStrategy = null)
+            IOptions<RetryOptions> retryOptions)
         {
             _typeLocator = typeLocator ?? throw new ArgumentNullException(nameof(typeLocator));
             _triggerBindingProvider = triggerBindingProvider ?? throw new ArgumentNullException(nameof(triggerBindingProvider));
@@ -59,7 +60,7 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
             _defaultTimeout = timeoutOptions.Value.ToAttribute();
             _allowPartialHostStartup = hostOptions.Value.AllowPartialHostStartup;
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
-            _defaultRetryStrategy = defaultRetryStrategy;
+            _defaultRetryStrategy = retryOptions.Value.ToAttribute();
         }
 
         public async Task<IFunctionIndex> GetAsync(CancellationToken cancellationToken)

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncChainEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncChainEndToEndTests.cs
@@ -140,6 +140,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     "Microsoft.Azure.WebJobs.Host.EndToEndTests.AsyncChainEndToEndTests.BlobToBlobAsync",
                     "Microsoft.Azure.WebJobs.Host.EndToEndTests.AsyncChainEndToEndTests.ReadResultBlob",
                     "Microsoft.Azure.WebJobs.Host.EndToEndTests.AsyncChainEndToEndTests.SystemParameterBindingOutput",
+                    "Microsoft.Azure.WebJobs.Host.EndToEndTests.AsyncChainEndToEndTests.RetryJob_NoAttribute",
                     "Function 'AsyncChainEndToEndTests.DisabledJob' is disabled",
                     "Job host started",
                     "Executing 'AsyncChainEndToEndTests.WriteStartDataMessageToQueue' (Reason='This function was programmatically called via the host APIs.', Id=",

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncChainEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/AsyncChainEndToEndTests.cs
@@ -548,6 +548,53 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             Assert.Empty(exceptionHandler.UnhandledExceptionInfos);
         }
 
+        [Fact]
+        public async Task Retry_UsingOptions()
+        {
+            _hostBuilder.ConfigureServices(services =>
+            {
+                services.Configure<RetryOptions>(o =>
+                {
+                    o.DelayInterval = TimeSpan.FromSeconds(1);
+                    o.Strategy = RetryStrategy.FixedDelay;
+                    o.MaxRetryCount = 3;
+                });
+
+                services.AddSingleton<IWebJobsExceptionHandlerFactory, CapturingExceptionHandlerFactory>();
+            });
+
+            JobHost jobHost = null;
+            try
+            {
+                IHost host = _hostBuilder.Build();
+                jobHost = host.GetJobHost();
+
+                await jobHost.StartAsync();
+
+                MethodInfo methodInfo = GetType().GetMethod(nameof(RetryJob_NoAttribute));
+
+                Exception ex = await Assert.ThrowsAnyAsync<Exception>(async () =>
+                {
+                    await jobHost.CallAsync(methodInfo);
+                });
+
+                Assert.Equal(ex.InnerException.Message, "Test exception");
+
+                // Validate Logger
+                var loggerProvider = host.GetTestLoggerProvider();
+                
+                int executionsCount = loggerProvider.GetAllLogMessages().Where(x => 
+                x.Exception?.Message == $"Exception while executing function: {nameof(AsyncChainEndToEndTests)}.{nameof(RetryJob_NoAttribute)}" &&
+                    x.Category.Contains(nameof(RetryJob_NoAttribute))).Count();
+
+                Assert.Equal(executionsCount, 4);
+            }
+            finally
+            {
+                await jobHost?.StopAsync();
+            }
+        }
+
         private async Task RunTimeoutTest(IHost host, Type expectedExceptionType, string functionName)
         {
             JobHost jobHost = host.GetJobHost();
@@ -672,6 +719,11 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             log.Info("Completed");
         }
 
+        [NoAutomaticTrigger]
+        public static void RetryJob_NoAttribute(CancellationToken cancellationToken)
+        {
+            throw new Exception("Test exception");
+        }
 
         public static async Task QueueToQueueAsync(
             [QueueTrigger(Queue1Name)] string message,

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
@@ -294,7 +294,9 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 "SharedMemoryAttribute",
                 "SharedMemoryMetadata",
                 "FunctionActivityStatus",
-                "IFunctionActivityStatusProvider"
+                "IFunctionActivityStatusProvider",
+                "RetryOptions",
+                "RetryStrategy"
             };
 
             TestHelpers.AssertPublicTypes(expected, assembly);


### PR DESCRIPTION
Corresponding host PR:
https://github.com/Azure/azure-functions-host/pull/7824

Moving `RetryOptions` from `WebJobs.Script.Abstractions` to web jobs sdk to get default retry configuration from host.json for  precompiled functions.

Fixes:
Azure/azure-functions-host/issues/7232