### PR TITLE
Add telemetry for retry enabled functions

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexer.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexer.cs
@@ -460,7 +460,12 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
         {
             if (descr.RetryStrategy != null)
             {
-                logger?.LogDebug($"Retry strategy is defined for function '{descr?.ShortName}' with trigger binding type '{triggerBinding?.GetType().Name}'. Strategy = '{JsonConvert.SerializeObject(descr?.RetryStrategy)}'");
+                string functionName = descr?.ShortName;
+                string triggerBindingName = triggerBinding?.GetType().Name;
+                string strategy = JsonConvert.SerializeObject(descr?.RetryStrategy);
+
+                logger?.LogDebug("Retry strategy is defined for function '{FunctionName}' with trigger binding type 'TriggerBindingName'. Strategy = '{Strategy}'", 
+                    functionName, triggerBindingName, strategy);
 
                 //Temporary comment: https://github.com/Azure/azure-webjobs-sdk/issues/2788
                 //if (triggerBinding != null && triggerBinding.GetType().GetCustomAttribute<SupportsRetryAttribute>() == null)

--- a/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexer.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexer.cs
@@ -460,11 +460,11 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
         {
             if (descr.RetryStrategy != null)
             {
-                string functionName = descr?.ShortName;
+                string functionName = descr.ShortName;
                 string triggerBindingName = triggerBinding?.GetType().Name;
-                string strategy = JsonConvert.SerializeObject(descr?.RetryStrategy);
+                string strategy = JsonConvert.SerializeObject(descr.RetryStrategy);
 
-                logger?.LogDebug("Retry strategy is defined for function '{FunctionName}' with trigger binding type 'TriggerBindingName'. Strategy = '{Strategy}'", 
+                logger?.LogDebug("Retry strategy is defined for function '{FunctionName}' with trigger binding type '{TriggerBindingName}'. Strategy = '{Strategy}'", 
                     functionName, triggerBindingName, strategy);
 
                 //Temporary comment: https://github.com/Azure/azure-webjobs-sdk/issues/2788

--- a/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexer.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexer.cs
@@ -21,6 +21,7 @@ using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 
 namespace Microsoft.Azure.WebJobs.Host.Indexers
 {
@@ -429,9 +430,8 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
             ITriggerBinding triggerBinding, IReadOnlyDictionary<string, IBinding> nonTriggerBindings, string sharedListenerId)
         {
             var descr = FromMethod(method, _configuration, this._activator, _nameResolver, _defaultTimeout, _defaultRetryStrategy);
-
-            // Temporary comment: https://github.com/Azure/azure-webjobs-sdk/issues/2788
-            // CheckRetrySupport(triggerBinding, descr, _logger);
+            
+            CheckRetrySupport(triggerBinding, descr, _logger);
 
             List<ParameterDescriptor> parameters = new List<ParameterDescriptor>();
 
@@ -458,10 +458,16 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
 
         internal static void CheckRetrySupport(ITriggerBinding triggerBinding, FunctionDescriptor descr, ILogger logger)
         {
-            if (descr.RetryStrategy != null && triggerBinding != null && triggerBinding.GetType().GetCustomAttribute<SupportsRetryAttribute>() == null)
+            if (descr.RetryStrategy != null)
             {
-                logger?.LogWarning($"Retries are not supported by the trigger binding for { descr.ShortName}.");
-                descr.RetryStrategy = null; // Need to fix tests
+                logger?.LogDebug($"Retry strategy is defined for function '{descr?.ShortName}' with trigger binding type '{triggerBinding?.GetType().Name}'. Strategy = '{JsonConvert.SerializeObject(descr?.RetryStrategy)}'");
+
+                //Temporary comment: https://github.com/Azure/azure-webjobs-sdk/issues/2788
+                //if (triggerBinding != null && triggerBinding.GetType().GetCustomAttribute<SupportsRetryAttribute>() == null)
+                //{                    
+                    //logger?.LogWarning($"Retries are not supported by the trigger binding for '{ descr.ShortName}'.");
+                    //descr.RetryStrategy = null; // Need to fix tests
+                //}
             }
         }
 

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/Indexers/FunctionIndexerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/Indexers/FunctionIndexerTests.cs
@@ -316,7 +316,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Indexers
             Assert.Equal("TestSharedListenerId", result);
         }
 
-        [Fact(Skip = "https://github.com/Azure/azure-webjobs-sdk/issues/2788")]        
+        [Fact]
         public void CheckRetrySupport_SetsRetryToNull()
         {
             // Arrange
@@ -325,16 +325,20 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Indexers
 
             FunctionDescriptor desc = new FunctionDescriptor()
             {
-                RetryStrategy = new FixedDelayRetryAttribute(5, "00:00:01")
+                RetryStrategy = new FixedDelayRetryAttribute(5, "00:00:01"),
+                ShortName = "Test"
             };
 
             // Act & Assert
             FunctionIndexer.CheckRetrySupport(new TestTriggerBinding(), desc, logger);
-            Assert.Null(desc.RetryStrategy);
-            Assert.Contains(loggerProvider.GetAllLogMessages(), x => x.FormattedMessage.Contains("Retries are not supported by the trigger binding for ") && x.Level == LogLevel.Warning);
+            Assert.Contains(loggerProvider.GetAllLogMessages(), x => x.FormattedMessage.Contains("Retry strategy is defined for function ") && x.Level == LogLevel.Debug);
+
+            //Temporary comment: https://github.com/Azure/azure-webjobs-sdk/issues/2788
+            //Assert.Null(desc.RetryStrategy);
+            //Assert.Contains(loggerProvider.GetAllLogMessages(), x => x.FormattedMessage.Contains("Retries are not supported by the trigger binding for ") && x.Level == LogLevel.Warning);
         }
 
-        [Fact(Skip = "https://github.com/Azure/azure-webjobs-sdk/issues/2788")]
+        [Fact]
         public void CheckRetrySupport_LeavesRetry()
         {
             // Arrange
@@ -348,8 +352,11 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Indexers
 
             // Act & Assert
             FunctionIndexer.CheckRetrySupport(new SupportRetryTestTriggerBinding(), desc, logger);
-            Assert.NotNull(desc.RetryStrategy);
-            Assert.DoesNotContain(loggerProvider.GetAllLogMessages(), x => x.FormattedMessage.Contains("Retries are not supported by the trigger binding for "));
+            Assert.Contains(loggerProvider.GetAllLogMessages(), x => x.FormattedMessage.Contains("Retry strategy is defined for function ") && x.Level == LogLevel.Debug);
+
+            //Temporary comment: https://github.com/Azure/azure-webjobs-sdk/issues/2788
+            //Assert.NotNull(desc.RetryStrategy);
+            //Assert.DoesNotContain(loggerProvider.GetAllLogMessages(), x => x.FormattedMessage.Contains("Retries are not supported by the trigger binding for "));
         }
 
         public class ClassA


### PR DESCRIPTION
Adding telemetry that can help to identify how many customers are using retries and on what triggers