### PR TITLE
Performance: de-async IFunctionInstanceLogger

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionExecutor.cs
@@ -121,8 +121,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
 
                     // If function started was logged, don't cancel calls to log function completed.
                     bool loggedStartedEvent = functionStartedMessageId != null;
-                    var logCompletedCancellationToken = loggedStartedEvent ? CancellationToken.None : cancellationToken;
-                    await _functionInstanceLogger.LogFunctionCompletedAsync(functionStartedMessage, logCompletedCancellationToken);
+                    _functionInstanceLogger.LogFunctionCompleted(functionStartedMessage);
 
                     if (instanceLogEntry != null)
                     {
@@ -133,7 +132,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
 
                     if (loggedStartedEvent)
                     {
-                        await _functionInstanceLogger.DeleteLogFunctionStartedAsync(functionStartedMessageId, cancellationToken);
+                        _functionInstanceLogger.DeleteLogFunctionStarted(functionStartedMessageId);
                     }
                 }
 
@@ -301,7 +300,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
 
                     // Log started events
                     CompleteStartedMessage(message, outputDefinition, parameterHelper);
-                    string startedMessageId = await _functionInstanceLogger.LogFunctionStartedAsync(message, cancellationToken);
+                    string startedMessageId = _functionInstanceLogger.LogFunctionStarted(message);
 
                     instanceLogEntry.Arguments = message.Arguments;
                     await _functionEventCollector.AddAsync(instanceLogEntry);

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/HostMessageExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/HostMessageExecutor.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             {
                 // Log that the function failed.
                 FunctionCompletedMessage failedMessage = CreateFailedMessage(message);
-                await _functionInstanceLogger.LogFunctionCompletedAsync(failedMessage, cancellationToken);
+                _functionInstanceLogger.LogFunctionCompleted(failedMessage);
             }
         }
 

--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/CompositeFunctionInstanceLogger.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/CompositeFunctionInstanceLogger.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Protocols;
 
 namespace Microsoft.Azure.WebJobs.Host.Loggers

--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/CompositeFunctionInstanceLogger.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/CompositeFunctionInstanceLogger.cs
@@ -17,13 +17,13 @@ namespace Microsoft.Azure.WebJobs.Host.Loggers
             _loggers = loggers;
         }
 
-        public async Task<string> LogFunctionStartedAsync(FunctionStartedMessage message, CancellationToken cancellationToken)
+        public string LogFunctionStarted(FunctionStartedMessage message)
         {
             string startedMessageId = null;
 
             foreach (IFunctionInstanceLogger logger in _loggers)
             {
-                var messageId = await logger.LogFunctionStartedAsync(message, cancellationToken);
+                var messageId = logger.LogFunctionStarted(message);
                 if (!String.IsNullOrEmpty(messageId))
                 {
                     if (String.IsNullOrEmpty(startedMessageId))
@@ -40,19 +40,19 @@ namespace Microsoft.Azure.WebJobs.Host.Loggers
             return startedMessageId;
         }
 
-        public async Task LogFunctionCompletedAsync(FunctionCompletedMessage message, CancellationToken cancellationToken)
+        public void LogFunctionCompleted(FunctionCompletedMessage message)
         {
             foreach (IFunctionInstanceLogger logger in _loggers)
             {
-                await logger.LogFunctionCompletedAsync(message, cancellationToken);
+                logger.LogFunctionCompleted(message);
             }
         }
 
-        public async Task DeleteLogFunctionStartedAsync(string startedMessageId, CancellationToken cancellationToken)
+        public void DeleteLogFunctionStarted(string startedMessageId)
         {
             foreach (IFunctionInstanceLogger logger in _loggers)
             {
-                await logger.DeleteLogFunctionStartedAsync(startedMessageId, cancellationToken);
+                logger.DeleteLogFunctionStarted(startedMessageId);
             }
         }
     }

--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/FunctionInstanceLogger.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/FunctionInstanceLogger.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.WebJobs.Host.Loggers
             _loggerFactory = loggerFactory;
         }
 
-        public Task<string> LogFunctionStartedAsync(FunctionStartedMessage message, CancellationToken cancellationToken)
+        public string LogFunctionStarted(FunctionStartedMessage message)
         {
             var logger = GetLogger(message.Function);
             Log.FunctionStarted(
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.WebJobs.Host.Loggers
                 LogTemplatizedTriggerDetails(logger, message);
             }
 
-            return Task.FromResult<string>(null);
+            return null;
         }
 
         private static void LogTemplatizedTriggerDetails(ILogger logger, FunctionStartedMessage message)
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.WebJobs.Host.Loggers
             logger.LogInformation(messageTemplate, templateValues);
         }
 
-        public Task LogFunctionCompletedAsync(FunctionCompletedMessage message, CancellationToken cancellationToken)
+        public void LogFunctionCompleted(FunctionCompletedMessage message)
         {
             var logger = GetLogger(message.Function);
             Log.FunctionCompleted(
@@ -68,13 +68,10 @@ namespace Microsoft.Azure.WebJobs.Host.Loggers
                 message.EndTime.Subtract(message.StartTime),
                 message.Succeeded,
                 message.Failure);
-
-            return Task.CompletedTask;
         }
 
-        public Task DeleteLogFunctionStartedAsync(string startedMessageId, CancellationToken cancellationToken)
+        public void DeleteLogFunctionStarted(string startedMessageId)
         {
-            return Task.CompletedTask;
         }
 
         private ILogger GetLogger(FunctionDescriptor descriptor)

--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/FunctionInstanceLogger.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/FunctionInstanceLogger.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Linq;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Protocols;
 using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Extensions.Logging;

--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/IFunctionInstanceLogger.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/IFunctionInstanceLogger.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Protocols;
 
 namespace Microsoft.Azure.WebJobs.Host.Loggers
@@ -10,10 +8,10 @@ namespace Microsoft.Azure.WebJobs.Host.Loggers
     // This is a DI interface.
     internal interface IFunctionInstanceLogger
     {
-        Task<string> LogFunctionStartedAsync(FunctionStartedMessage message, CancellationToken cancellationToken);
+        string LogFunctionStarted(FunctionStartedMessage message);
 
-        Task LogFunctionCompletedAsync(FunctionCompletedMessage message, CancellationToken cancellationToken);
+        void LogFunctionCompleted(FunctionCompletedMessage message);
 
-        Task DeleteLogFunctionStartedAsync(string startedMessageId, CancellationToken cancellationToken);
+        void DeleteLogFunctionStarted(string startedMessageId);
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/TestDoubles/ExpectInstanceFailureTaskFunctionInstanceLogger.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/TestDoubles/ExpectInstanceFailureTaskFunctionInstanceLogger.cs
@@ -18,12 +18,12 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests.TestDoubles
             _taskSource = taskSource;
         }
 
-        public Task<string> LogFunctionStartedAsync(FunctionStartedMessage message, CancellationToken cancellationToken)
+        public string LogFunctionStarted(FunctionStartedMessage message)
         {
-            return Task.FromResult(string.Empty);
+            return string.Empty;
         }
 
-        public Task LogFunctionCompletedAsync(FunctionCompletedMessage message, CancellationToken cancellationToken)
+        public void LogFunctionCompleted(FunctionCompletedMessage message)
         {
             if (message != null)
             {
@@ -32,13 +32,10 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests.TestDoubles
                 // A faulted task is reserved for unexpected failures (like unhandled background exceptions).
                 _taskSource.SetResult(message.Failure != null ? message.Failure.Exception : null);
             }
-
-            return Task.FromResult(0);
         }
 
-        public Task DeleteLogFunctionStartedAsync(string startedMessageId, CancellationToken cancellationToken)
+        public void DeleteLogFunctionStarted(string startedMessageId)
         {
-            return Task.FromResult(0);
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/TestDoubles/ExpectInstanceFailureTaskFunctionInstanceLogger.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/TestDoubles/ExpectInstanceFailureTaskFunctionInstanceLogger.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Loggers;
 using Microsoft.Azure.WebJobs.Host.Protocols;

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/TestDoubles/ExpectInstanceSuccessTaskFunctionInstanceLogger.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/TestDoubles/ExpectInstanceSuccessTaskFunctionInstanceLogger.cs
@@ -18,12 +18,12 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests.TestDoubles
             _taskSource = taskSource;
         }
 
-        public Task<string> LogFunctionStartedAsync(FunctionStartedMessage message, CancellationToken cancellationToken)
+        public string LogFunctionStarted(FunctionStartedMessage message)
         {
-            return Task.FromResult(String.Empty);
+            return string.Empty;
         }
 
-        public Task LogFunctionCompletedAsync(FunctionCompletedMessage message, CancellationToken cancellationToken)
+        public void LogFunctionCompleted(FunctionCompletedMessage message)
         {
             if (message != null && message.Failure != null)
             {
@@ -33,13 +33,10 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests.TestDoubles
             {
                 _taskSource.SetResult(null);
             }
-
-            return Task.FromResult(0);
         }
 
-        public Task DeleteLogFunctionStartedAsync(string startedMessageId, CancellationToken cancellationToken)
+        public void DeleteLogFunctionStarted(string startedMessageId)
         {
-            return Task.FromResult(0);
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/TestDoubles/ExpectInstanceSuccessTaskFunctionInstanceLogger.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/TestDoubles/ExpectInstanceSuccessTaskFunctionInstanceLogger.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Loggers;
 using Microsoft.Azure.WebJobs.Host.Protocols;

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/ExpectManualCompletionTaskFunctionInstanceLogger.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/ExpectManualCompletionTaskFunctionInstanceLogger.cs
@@ -30,12 +30,12 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests.TestDoubles
                 new HashSet<string>(ignoreFailureFunctions) : new HashSet<string>();
         }
 
-        Task<string> IFunctionInstanceLogger.LogFunctionStartedAsync(FunctionStartedMessage message, CancellationToken cancellationToken)
+        string IFunctionInstanceLogger.LogFunctionStarted(FunctionStartedMessage message)
         {
-            return Task.FromResult(String.Empty);
+            return string.Empty;
         }
 
-        Task IFunctionInstanceLogger.LogFunctionCompletedAsync(FunctionCompletedMessage message, CancellationToken cancellationToken)
+        void IFunctionInstanceLogger.LogFunctionCompleted(FunctionCompletedMessage message)
         {
             if (message != null && message.Failure != null && message.Function != null &&
                 !_ignoreFailureFunctions.Contains(message.Function.FullName))
@@ -47,13 +47,10 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests.TestDoubles
             {
                 _taskSource.SetResult(default(TResult));
             }
-
-            return Task.CompletedTask;
         }
 
-        public Task DeleteLogFunctionStartedAsync(string startedMessageId, CancellationToken cancellationToken)
+        public void DeleteLogFunctionStarted(string startedMessageId)
         {
-            return Task.FromResult(0);
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/ExpectManualCompletionTaskFunctionInstanceLogger.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/ExpectManualCompletionTaskFunctionInstanceLogger.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Loggers;
 using Microsoft.Azure.WebJobs.Host.Protocols;

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/Fakes/NullFunctionInstanceLogger.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/Fakes/NullFunctionInstanceLogger.cs
@@ -10,22 +10,17 @@ namespace Microsoft.Azure.WebJobs.Host.TestCommon
 {
     public class NullFunctionInstanceLogger : IFunctionInstanceLogger
     {
-        Task<string> IFunctionInstanceLogger.LogFunctionStartedAsync(FunctionStartedMessage message,
-            CancellationToken cancellationToken)
+        string IFunctionInstanceLogger.LogFunctionStarted(FunctionStartedMessage message)
         {
-            return Task.FromResult(string.Empty);
+            return string.Empty;
         }
 
-        Task IFunctionInstanceLogger.LogFunctionCompletedAsync(FunctionCompletedMessage message,
-            CancellationToken cancellationToken)
+        void IFunctionInstanceLogger.LogFunctionCompleted(FunctionCompletedMessage message)
         {
-            return Task.FromResult(0);
         }
 
-        Task IFunctionInstanceLogger.DeleteLogFunctionStartedAsync(string startedMessageId,
-            CancellationToken cancellationToken)
+        void IFunctionInstanceLogger.DeleteLogFunctionStarted(string startedMessageId)
         {
-            return Task.FromResult(0);
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/Fakes/NullFunctionInstanceLogger.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/Fakes/NullFunctionInstanceLogger.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Loggers;
 using Microsoft.Azure.WebJobs.Host.Protocols;
 

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/FunctionInstanceLoggerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/FunctionInstanceLoggerTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
         }
 
         [Fact]
-        public async Task LogFunctionStarted_CallsLogger()
+        public void LogFunctionStarted_CallsLogger()
         {
             Dictionary<string, string> triggerDetails = new Dictionary<string, string>()
             {
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                 $"DequeueCount: {triggerDetails["DequeueCount"]}, " +
                 $"InsertionTime: {triggerDetails["InsertionTime"]}";
 
-            await _instanceLogger.LogFunctionStartedAsync(message, CancellationToken.None);
+            _instanceLogger.LogFunctionStarted(message);
 
             string expectedCategory = LogCategories.CreateFunctionCategory(message.Function.LogName);
 
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
         }
 
         [Fact]
-        public async Task LogFunctionCompleted_CallsLogger()
+        public void LogFunctionCompleted_CallsLogger()
         {
             FunctionDescriptor descriptor = new FunctionDescriptor
             {
@@ -112,8 +112,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                 EndTime = DateTime.UtcNow + new TimeSpan(0, 0, 0, 0, 20)
             };
 
-            await _instanceLogger.LogFunctionCompletedAsync(successMessage, CancellationToken.None);
-            await _instanceLogger.LogFunctionCompletedAsync(failureMessage, CancellationToken.None);
+            _instanceLogger.LogFunctionCompleted(successMessage);
+            _instanceLogger.LogFunctionCompleted(failureMessage);
 
             LogMessage[] logMessages = _provider.GetAllLogMessages().ToArray();
 

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/FunctionInstanceLoggerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/FunctionInstanceLoggerTests.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Loggers;
 using Microsoft.Azure.WebJobs.Host.Protocols;
 using Microsoft.Azure.WebJobs.Host.TestCommon;


### PR DESCRIPTION
Part of #2794. In the logging path we pay overhead in async/await quite a bit around logging a function via various `IFunctionInstanceLogger` implementations, but since it's internal and none of them are actually async, we can eliminate the overhead there.