### PR TITLE
Performance: Cache NonCircularContractResolver

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Protocols/PolymorphicJsonConverter.cs
+++ b/src/Microsoft.Azure.WebJobs.Protocols/PolymorphicJsonConverter.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Azure.WebJobs.Host.Protocols
             // Now that we've handled the type, temporarily remove this converter so we can serialize this element and
             // its children without infinite recursion.
             IContractResolver originalContractResolver = serializer.ContractResolver;
-            serializer.ContractResolver = _nonCircularResolverCache.GetOrAdd(valueType, static type => new NonCircularContractResolver(type));
+            serializer.ContractResolver = _nonCircularResolverCache.GetOrAdd(valueType, type => new NonCircularContractResolver(type));
 
             JObject json = JObject.FromObject(value, serializer);
 

--- a/src/Microsoft.Azure.WebJobs.Protocols/PolymorphicJsonConverter.cs
+++ b/src/Microsoft.Azure.WebJobs.Protocols/PolymorphicJsonConverter.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.WebJobs.Host.Protocols
         private readonly string _typePropertyName;
         private readonly IDictionary<string, Type> _nameToTypeMap;
         private readonly IDictionary<Type, string> _typeToNameMap;
-        private static readonly ConcurrentDictionary<Type, NonCircularContractResolver> _nonCircularResolverCache = new ();
+        private static readonly ConcurrentDictionary<Type, NonCircularContractResolver> _nonCircularResolverCache = new ConcurrentDictionary<Type, NonCircularContractResolver>();
 
         /// <summary>Initializes a new instance of the <see cref="PolymorphicJsonConverter"/> class.</summary>
         /// <param name="typeMapping">The type names to use when serializing types.</param>

--- a/src/Microsoft.Azure.WebJobs.Protocols/PolymorphicJsonConverter.cs
+++ b/src/Microsoft.Azure.WebJobs.Protocols/PolymorphicJsonConverter.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -28,6 +29,7 @@ namespace Microsoft.Azure.WebJobs.Host.Protocols
         private readonly string _typePropertyName;
         private readonly IDictionary<string, Type> _nameToTypeMap;
         private readonly IDictionary<Type, string> _typeToNameMap;
+        private static ConcurrentDictionary<Type, NonCircularContractResolver> _nonCircularResolverCache = new ();
 
         /// <summary>Initializes a new instance of the <see cref="PolymorphicJsonConverter"/> class.</summary>
         /// <param name="typeMapping">The type names to use when serializing types.</param>
@@ -130,7 +132,7 @@ namespace Microsoft.Azure.WebJobs.Host.Protocols
             // Now that we've handled the type, temporarily remove this converter so we can serialize this element and
             // its children without infinite recursion.
             IContractResolver originalContractResolver = serializer.ContractResolver;
-            serializer.ContractResolver = new NonCircularContractResolver(valueType);
+            serializer.ContractResolver = _nonCircularResolverCache.GetOrAdd(valueType, static type => new NonCircularContractResolver(type));
 
             JObject json = JObject.FromObject(value, serializer);
 

--- a/src/Microsoft.Azure.WebJobs.Protocols/PolymorphicJsonConverter.cs
+++ b/src/Microsoft.Azure.WebJobs.Protocols/PolymorphicJsonConverter.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.WebJobs.Host.Protocols
         private readonly string _typePropertyName;
         private readonly IDictionary<string, Type> _nameToTypeMap;
         private readonly IDictionary<Type, string> _typeToNameMap;
-        private static ConcurrentDictionary<Type, NonCircularContractResolver> _nonCircularResolverCache = new ();
+        private static readonly ConcurrentDictionary<Type, NonCircularContractResolver> _nonCircularResolverCache = new ();
 
         /// <summary>Initializes a new instance of the <see cref="PolymorphicJsonConverter"/> class.</summary>
         /// <param name="typeMapping">The type names to use when serializing types.</param>


### PR DESCRIPTION
Currently this resolver is being created on every write. These are intended to be cached/reusable (see guidance: https://www.newtonsoft.com/json/help/html/contractresolver.htm). These are a huge portion of some production stack traces, so let's eliminate the cost here both in generation and GC cleanup.

I can't access production yet, but context from the earlier analysis is in the "Microsoft.Azure.WebJobs.Host.Protocols.PolymorphicJsonConverter" email thread (thanks Feng Yuan!) - I'm not sure if the tooling is public, so didn't paste screenshots here.

Note: scoping this to the main issue - there are some other opportunities in this class to simplify and make it a bit faster. Given how much it's called, I'll make another separate pass here. A .NET 6.0 TFM addition (see #2794) would add a few more on top of current.


#### Baseline Benchmark
|       Method |     Mean |     Error |   StdDev |  Gen 0 | Allocated |
|------------- |---------:|----------:|---------:|-------:|----------:|
|    CreatePer | 27.98 ns | 18.767 ns | 1.029 ns | 0.0239 |     400 B |
| CachedLookup | 17.82 ns |  8.738 ns | 0.479 ns |      - |         - |

LinqPad sample run:
```cs
#LINQPad optimize+     // Enable compiler optimizations

void Main()
{
	Util.AutoScrollResults = true;
	BenchmarkRunner.Run<ContractResolverBenchmarks>();
}

[ShortRunJob]
[MemoryDiagnoser]
public class ContractResolverBenchmarks
{
	private static readonly ConcurrentDictionary<Type, NonCircularContractResolver> _nonCircularResolverCache = new ConcurrentDictionary<Type, NonCircularContractResolver>();

	[Benchmark]
	public NonCircularContractResolver CreatePer()
	{
		var valueType = typeof(SimpleType);
		return new NonCircularContractResolver(valueType);
	}

	[Benchmark]
	public NonCircularContractResolver CachedLookup()
	{
		var valueType = typeof(SimpleType);
		return _nonCircularResolverCache.GetOrAdd(valueType, type => new NonCircularContractResolver(type));
	}
}

public class NonCircularContractResolver : DefaultContractResolver
{
	private readonly Type _contractType;

	public NonCircularContractResolver(Type contractType)
	{
		Debug.Assert(contractType != null, "contract type must not be null");
		_contractType = contractType;
	}

	protected override JsonContract CreateContract(Type objectType)
	{
		JsonContract contract = base.CreateContract(objectType);

		if (_contractType.IsAssignableFrom(objectType))
		{
			contract.Converter = null;
		}

		return contract;
	}
}

public class SimpleType
{
	public string Foo { get; set; }
	public string Bar { get; set; }
	
	public SimpleType Child { get; set; }
}
```