### PR TITLE
Allow to restart task series timer

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Timers/TaskSeriesTimer.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Timers/TaskSeriesTimer.cs
@@ -56,20 +56,21 @@ namespace Microsoft.Azure.WebJobs.Host.Timers
 
             _run = RunAsync(_cancellationTokenSource.Token);
             _started = true;
+            _stopped = false;
         }
 
         public Task StopAsync(CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
 
-            if (!_started)
-            {
-                throw new InvalidOperationException("The timer has not yet been started.");
-            }
-
             if (_stopped)
             {
                 throw new InvalidOperationException("The timer has already been stopped.");
+            }
+
+            if (!_started)
+            {
+                throw new InvalidOperationException("The timer has not yet been started.");
             }
 
             _cancellationTokenSource.Cancel();
@@ -88,6 +89,7 @@ namespace Microsoft.Azure.WebJobs.Host.Timers
             }
 
             _stopped = true;
+            _started = false;
         }
 
         public void Cancel()

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Timers/TaskSeriesTimerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Timers/TaskSeriesTimerTests.cs
@@ -303,7 +303,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Timers
         }
 
         [Fact]
-        public void StopAsync_TriggersCommandCancellationToken()
+        public async Task StopAsync_TriggersCommandCancellationToken()
         {
             // Arrange
             using (EventWaitHandle executeStarted = new ManualResetEvent(initialState: false))
@@ -331,7 +331,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Timers
 
                     // Assert
                     Assert.NotNull(task);
-                    task.GetAwaiter().GetResult();
+                    await task;
                     Assert.True(executeFinished.WaitOne(1000)); // Guard
                     Assert.True(cancellationTokenSignalled);
                 }
@@ -339,7 +339,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Timers
         }
 
         [Fact]
-        public void StopAsync_WaitsForExecuteToFinishToCompleteTask()
+        public async Task StopAsync_WaitsForExecuteToFinishToCompleteTask()
         {
             // Arrange
             bool executeFinished = false;
@@ -370,7 +370,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Timers
 
                     // Assert
                     Assert.NotNull(task);
-                    task.GetAwaiter().GetResult();
+                    await task;
                     Assert.True(executeFinished);
                 }
             }
@@ -465,7 +465,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Timers
         }
 
         [Fact]
-        public void StopAsync_TriggersNotExecutingAgain()
+        public async Task StopAsync_TriggersNotExecutingAgain()
         {
             // Arrange
             using (EventWaitHandle executedOnceWaitHandle = new ManualResetEvent(initialState: false))
@@ -501,14 +501,14 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Timers
                     // Assert
                     Assert.True(executed); // Guard
                     Assert.NotNull(stop);
-                    stop.GetAwaiter().GetResult();
+                    await stop;
                     Assert.False(executedTwice);
                 }
             }
         }
 
         [Fact]
-        public void StopAsync_WaitsForTaskCompletionToCompleteTask()
+        public async Task StopAsync_WaitsForTaskCompletionToCompleteTask()
         {
             // Arrange
             bool executedOnce = false;
@@ -545,14 +545,14 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Timers
 
                     // Assert
                     Assert.NotNull(stopTask);
-                    stopTask.GetAwaiter().GetResult();
+                    await stopTask;
                     Assert.True(taskCompleted);
                 }
             }
         }
 
         [Fact]
-        public void StopAsync_WhenExecuteTaskCompletesCanceled_DoesNotThrowOrFault()
+        public async Task StopAsync_WhenExecuteTaskCompletesCanceled_DoesNotThrowOrFault()
         {
             // Arrange
             bool executedOnce = false;
@@ -588,13 +588,13 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Timers
 
                     // Assert
                     Assert.NotNull(task);
-                    task.GetAwaiter().GetResult();
+                    await task;
                 }
             }
         }
 
         [Fact]
-        public void StopAsync_WhenExecuteTaskCompletesFaulted_DoesNotThrowOrFault()
+        public async Task StopAsync_WhenExecuteTaskCompletesFaulted_DoesNotThrowOrFault()
         {
             // Arrange
             bool executedOnce = false;
@@ -631,7 +631,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Timers
 
                     // Assert
                     Assert.NotNull(task);
-                    task.GetAwaiter().GetResult();
+                    await task;
                 }
             }
         }
@@ -667,7 +667,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Timers
         }
 
         [Fact]
-        public void StopAsync_IfAlreadyStopped_Throws()
+        public async Task StopAsync_IfAlreadyStopped_Throws()
         {
             // Arrange
             ITaskSeriesCommand command = CreateStubCommand(TimeSpan.Zero);
@@ -675,7 +675,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Timers
             using (ITaskSeriesTimer product = CreateProductUnderTest(command))
             {
                 product.Start();
-                product.StopAsync(CancellationToken.None).GetAwaiter().GetResult();
+                await product.StopAsync(CancellationToken.None);
 
                 CancellationToken cancellationToken = CancellationToken.None;
 
@@ -686,7 +686,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Timers
         }
 
         [Fact]
-        public void Cancel_TriggersCommandCancellationToken()
+        public async Task Cancel_TriggersCommandCancellationToken()
         {
             // Arrange
             using (EventWaitHandle executeStarted = new ManualResetEvent(initialState: false))
@@ -715,7 +715,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Timers
                     Assert.True(cancellationTokenSignalled);
 
                     // Cleanup
-                    product.StopAsync(CancellationToken.None).GetAwaiter().GetResult();
+                    await product.StopAsync(CancellationToken.None);
                 }
             }
         }
@@ -756,13 +756,13 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Timers
         }
 
         [Fact]
-        public void Dispose_IfStopped_DoesNotThrow()
+        public async Task Dispose_IfStopped_DoesNotThrow()
         {
             // Arrange
             ITaskSeriesCommand command = CreateStubCommand(TimeSpan.Zero);
             ITaskSeriesTimer product = CreateProductUnderTest(command);
             product.Start();
-            product.StopAsync(CancellationToken.None).GetAwaiter().GetResult();
+            await product.StopAsync(CancellationToken.None);
 
             // Act & Assert
             ExceptionAssert.DoesNotThrow(() => product.Dispose());

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Timers/TaskSeriesTimerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Timers/TaskSeriesTimerTests.cs
@@ -290,6 +290,19 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Timers
         }
 
         [Fact]
+        public void Start_IfStopped_DoesNotThrow()
+        {
+            // Arrange
+            ITaskSeriesCommand command = CreateStubCommand(TimeSpan.Zero);
+            ITaskSeriesTimer product = CreateProductUnderTest(command);
+            product.Start();
+            product.StopAsync(CancellationToken.None).GetAwaiter().GetResult();
+
+            // Act & Assert
+            ExceptionAssert.DoesNotThrow(() => product.Start());
+        }
+
+        [Fact]
         public void StopAsync_TriggersCommandCancellationToken()
         {
             // Arrange

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Timers/TaskSeriesTimerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Timers/TaskSeriesTimerTests.cs
@@ -290,13 +290,13 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Timers
         }
 
         [Fact]
-        public void Start_IfStopped_DoesNotThrow()
+        public async Task Start_IfStopped_DoesNotThrow()
         {
             // Arrange
             ITaskSeriesCommand command = CreateStubCommand(TimeSpan.Zero);
             ITaskSeriesTimer product = CreateProductUnderTest(command);
             product.Start();
-            product.StopAsync(CancellationToken.None).GetAwaiter().GetResult();
+            await product.StopAsync(CancellationToken.None);
 
             // Act & Assert
             ExceptionAssert.DoesNotThrow(() => product.Start());


### PR DESCRIPTION
A listener can be stopped and start again but if there is a TaskSeriesTimer under the listener.
This pr allow to start and stop and start again a listener when we want (really usefull for testing purpose).