### PR TITLE
Check if lease is available before trying to acquire

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host.Storage/Singleton/BlobLeaseDistributedLockManager.cs
+++ b/src/Microsoft.Azure.WebJobs.Host.Storage/Singleton/BlobLeaseDistributedLockManager.cs
@@ -167,8 +167,11 @@ namespace Microsoft.Azure.WebJobs.Host
             bool blobDoesNotExist = false;
             try
             {
-                // Check if a lease is available before trying to acquire. The blob may
-                // not yet exist; if it doesn't we handle the 404, create it, and retry below
+                // Check if a lease is available before trying to acquire. The blob may not
+                // yet exist; if it doesn't we handle the 404, create it, and retry below.
+                // The reason we're checking to see if the lease is available before trying
+                // to acquire is to avoid the flood of 409 errors that Application Insights
+                // picks up when a lease cannot be acquired due to conflict; see issue #2318.
                 var blobProperties = await ReadLeaseBlobMetadata(blobClient, cancellationToken);
 
                 switch (blobProperties?.LeaseState)

--- a/src/Microsoft.Azure.WebJobs.Host.Storage/Singleton/BlobLeaseDistributedLockManager.cs
+++ b/src/Microsoft.Azure.WebJobs.Host.Storage/Singleton/BlobLeaseDistributedLockManager.cs
@@ -152,6 +152,12 @@ namespace Microsoft.Azure.WebJobs.Host
             return blobClient.GetBlobLeaseClient(proposedLeaseId);
         }
 
+        // // Allows the extension method to be mocked for testing
+        protected virtual BlobProperties GetBlobProperties(BlobClient blobClient)
+        {
+            return blobClient.GetProperties();
+        }
+
         // Allows the extension method to be mocked for testing
         protected virtual BlobContainerClient GetParentBlobContainerClient(BlobClient blobClient)
         {
@@ -167,10 +173,15 @@ namespace Microsoft.Azure.WebJobs.Host
             bool blobDoesNotExist = false;
             try
             {
-                // Optimistically try to acquire the lease. The blob may not yet
-                // exist. If it doesn't we handle the 404, create it, and retry below
-                var leaseResponse = await GetBlobLeaseClient(blobClient, proposedLeaseId).AcquireAsync(leasePeriod, cancellationToken: cancellationToken);
-                return leaseResponse.Value.LeaseId;
+                // Check if a lease is available before trying to acquire.
+                // If it doesn't we handle the 404, create it, and retry below
+                var blobProperties = GetBlobProperties(blobClient);
+
+                if (blobProperties?.LeaseState != LeaseState.Leased)
+                {
+                    var leaseResponse = await GetBlobLeaseClient(blobClient, proposedLeaseId).AcquireAsync(leasePeriod, cancellationToken: cancellationToken);
+                    return leaseResponse.Value.LeaseId;
+                }
             }
             catch (RequestFailedException exception)
             {

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionExecutor.cs
@@ -509,7 +509,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             SingletonLock singleton = null;
             if (parameterHelper.HasSingleton)
             {
-                // if the function is a Singleton, aquire the lock
+                // if the function is a Singleton, acquire the lock
                 singleton = await parameterHelper.GetSingletonLockAsync();
                 await singleton.AcquireAsync(functionCancellationTokenSource.Token);
             }

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/Singleton/SingletonLockTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/Singleton/SingletonLockTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Singleton
         }
 
         [Fact]
-        public async Task AquireAsync_InvokesSingletonManager_WithExpectedValues()
+        public async Task AcquireAsync_InvokesSingletonManager_WithExpectedValues()
         {
             CancellationToken cancellationToken = new CancellationToken();
             SingletonAttribute attribute = new SingletonAttribute();

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/Singleton/SingletonManagerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/Singleton/SingletonManagerTests.cs
@@ -405,6 +405,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Singleton
                 throw new RequestFailedException(409, "Failed to get lease in test");
             });
 
+            mockAccount.BlobClient.Setup(p => p.GetPropertiesAsync(It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(mockAccount.CreateInternalAzureBlobResponse<BlobProperties>()));
+
             SingletonAttribute attribute = new SingletonAttribute();
             SingletonLockHandle lockHandle = await _singletonManager.TryLockInternalAsync(TestLockId, TestInstanceId, attribute, cancellationToken, retry: false);
 
@@ -440,6 +442,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Singleton
             {
                 ++count;
             }, () => throw new RequestFailedException(409, "Failed to get lease in test"));
+
+            mockAccount.BlobClient.Setup(p => p.GetPropertiesAsync(It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(mockAccount.CreateInternalAzureBlobResponse<BlobProperties>()));
 
             SingletonAttribute attribute = new SingletonAttribute();
             TimeoutException exception = await Assert.ThrowsAsync<TimeoutException>(async () => await _singletonManager.LockAsync(TestLockId, TestInstanceId, attribute, cancellationToken));


### PR DESCRIPTION
Addressing concerns in this issue #2318 where there is a lot of noise around lease acquisition when using more than 1 instance.

This PR makes it so that we check if we can acquire a lease before trying to, this should reduce the log noise for 409 errors when non-primary instances continue to try and acquire a lease.