### PR TITLE
Adjust contrast of warning text in dashboard ux

### DIFF
--- a/src/Dashboard/Content/bootstrap/css/bootstrap.css
+++ b/src/Dashboard/Content/bootstrap/css/bootstrap.css
@@ -5053,7 +5053,7 @@ a.thumbnail:focus {
 }
 
 .alert-warning {
-  color: #c09853;
+  color: #6d572c;
   background-color: #fcf8e3;
   border-color: #fbeed5;
 }

--- a/src/Dashboard/Content/bootstrap/css/bootstrap.css
+++ b/src/Dashboard/Content/bootstrap/css/bootstrap.css
@@ -5053,7 +5053,7 @@ a.thumbnail:focus {
 }
 
 .alert-warning {
-  color: #6d572c;
+  color: #533F23;
   background-color: #fcf8e3;
   border-color: #fbeed5;
 }


### PR DESCRIPTION
Before: https://webaim.org/resources/contrastchecker/?fcolor=C09853&bcolor=FCF8E3
![image](https://user-images.githubusercontent.com/10663/150857447-66a71f53-fd26-4f25-8dea-8e6e0c20cbc9.png)


After: https://webaim.org/resources/contrastchecker/?fcolor=533F23&bcolor=FCF8E3
![image](https://user-images.githubusercontent.com/10663/150857526-08454da5-d252-41ae-95b2-8cce02a5b224.png)
