### PR TITLE
Log Details of Storage Blob/Queue Listeners

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Listeners/BlobListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Listeners/BlobListener.cs
@@ -20,6 +20,11 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
         private bool _disposed;
         private Lazy<string> _details;
 
+        // for mock test purposes only
+        internal BlobListener(ISharedListener sharedListener)
+        {
+        }
+
         public BlobListener(ISharedListener sharedListener, CloudBlobContainer container, ILoggerFactory loggerFactory)
         {
             _sharedListener = sharedListener;

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Listeners/BlobListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Listeners/BlobListener.cs
@@ -6,31 +6,46 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Azure.WebJobs.Host.Scale;
+using Microsoft.Azure.Storage.Blob;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
 {
     internal sealed class BlobListener : IListener, IScaleMonitorProvider
     {
         private readonly ISharedListener _sharedListener;
+        private readonly ILogger<BlobListener> _logger;
 
         private bool _started;
         private bool _disposed;
+        private Lazy<string> _details;
 
-        public BlobListener(ISharedListener sharedListener)
+        public BlobListener(ISharedListener sharedListener, CloudBlobContainer container, ILoggerFactory loggerFactory)
         {
             _sharedListener = sharedListener;
+            _details = new Lazy<string>(() => $"blob container={container.Name}, storage account name={container.ServiceClient.GetAccountName()}");
+            _logger = loggerFactory.CreateLogger<BlobListener>();
         }
 
         public Task StartAsync(CancellationToken cancellationToken)
         {
-            ThrowIfDisposed();
-
-            if (_started)
+            try
             {
-                throw new InvalidOperationException("The listener has already been started.");
-            }
+                ThrowIfDisposed();
 
-            return StartAsyncCore(cancellationToken);
+                if (_started)
+                {
+                    throw new InvalidOperationException("The listener has already been started.");
+                }
+
+                _logger.LogDebug($"Storage blob listener started ({_details.Value})");
+                return StartAsyncCore(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, $"Storage blob listener exception during starting ({_details.Value})");
+                throw;
+            }
         }
 
         private async Task StartAsyncCore(CancellationToken cancellationToken)
@@ -43,15 +58,27 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
 
         public Task StopAsync(CancellationToken cancellationToken)
         {
-            ThrowIfDisposed();
-
-            if (!_started)
+            try
             {
-                throw new InvalidOperationException(
-                    "The listener has not yet been started or has already been stopped.");
-            }
+                ThrowIfDisposed();
 
-            return StopAsyncCore(cancellationToken);
+                if (!_started)
+                {
+                    throw new InvalidOperationException(
+                        "The listener has not yet been started or has already been stopped.");
+                }
+
+                return StopAsyncCore(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, $"storage blob listener exception during stopping ({_details.Value})");
+                throw;
+            }
+            finally
+            {
+                _logger.LogDebug($"Storage blob listener stopped ({_details.Value})");
+            }
         }
 
         private async Task StopAsyncCore(CancellationToken cancellationToken)

--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Listeners/BlobListenerFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Listeners/BlobListenerFactory.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
             SharedBlobQueueListener sharedBlobQueueListener = _sharedContextProvider.GetOrCreateInstance<SharedBlobQueueListener>(
                 new SharedBlobQueueListenerFactory(_hostAccount, sharedQueueWatcher, hostBlobTriggerQueue,
                     _queueOptions, _exceptionHandler, _loggerFactory, sharedBlobListener.BlobWritterWatcher, _functionDescriptor));
-            var queueListener = new BlobListener(sharedBlobQueueListener);
+            var queueListener = new BlobListener(sharedBlobQueueListener, _container, _loggerFactory);
 
             // determine which client to use for the poison queue
             // by default this should target the same storage account
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
                 // want a single instance of the blob poll/scan logic to be running
                 // across host instances
                 var singletonBlobListener = _singletonManager.CreateHostSingletonListener(
-                    new BlobListener(sharedBlobListener), SingletonBlobListenerScopeId);
+                    new BlobListener(sharedBlobListener, _container, _loggerFactory), SingletonBlobListenerScopeId);
                 _sharedContextProvider.SetValue(SingletonBlobListenerScopeId, true);
 
                 return new CompositeListener(singletonBlobListener, queueListener);


### PR DESCRIPTION
Log the details of a storage blob/queue listener on start/stop operations. Addresses this WI: https://dev.azure.com/FunctionsExtensions/Functions%20Extensions/_workitems/edit/36 and https://github.com/Azure/azure-webjobs-sdk/issues/2660