### PR TITLE
Log Details of Storage Blob/Queue Listeners

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Listeners/BlobListenerFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Storage/Blobs/Listeners/BlobListenerFactory.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
             SharedBlobQueueListener sharedBlobQueueListener = _sharedContextProvider.GetOrCreateInstance<SharedBlobQueueListener>(
                 new SharedBlobQueueListenerFactory(_hostAccount, sharedQueueWatcher, hostBlobTriggerQueue,
                     _queueOptions, _exceptionHandler, _loggerFactory, sharedBlobListener.BlobWritterWatcher, _functionDescriptor));
-            var queueListener = new BlobListener(sharedBlobQueueListener);
+            var queueListener = new BlobListener(sharedBlobQueueListener, _container, _loggerFactory);
 
             // determine which client to use for the poison queue
             // by default this should target the same storage account
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
                 // want a single instance of the blob poll/scan logic to be running
                 // across host instances
                 var singletonBlobListener = _singletonManager.CreateHostSingletonListener(
-                    new BlobListener(sharedBlobListener), SingletonBlobListenerScopeId);
+                    new BlobListener(sharedBlobListener, _container, _loggerFactory), SingletonBlobListenerScopeId);
                 _sharedContextProvider.SetValue(SingletonBlobListenerScopeId, true);
 
                 return new CompositeListener(singletonBlobListener, queueListener);


### PR DESCRIPTION
Log the details of a storage blob/queue listener on start/stop operations. Addresses this WI: https://dev.azure.com/FunctionsExtensions/Functions%20Extensions/_workitems/edit/36 and https://github.com/Azure/azure-webjobs-sdk/issues/2660