### PR TITLE
do not format ObjectDisposedExceptions

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Protocols/FunctionFailure.cs
+++ b/src/Microsoft.Azure.WebJobs.Protocols/FunctionFailure.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.WebJobs.Host.Protocols
             {
                 Exception = ex,
                 ExceptionType = ex.GetType().FullName,
-                ExceptionDetails = ex.ToDetails()
+                ExceptionDetails = ex is ObjectDisposedException ? ex.ToString() : ex.ToDetails() // Do not format ObjectDisposedExceptions to aid in debugging
             };
         }
     }


### PR DESCRIPTION
One part of improving https://github.com/Azure/azure-functions-host/issues/7873.

Our `HostDisposedException` grabs the full stack trace -- but the formatting done here overwrites that. This skips the special formatting if it's an `ObjectDisposedException`, which I'm updating `HostDisposedException` to derive from.