### PR TITLE
Ensure SingletonListener stops inner listener before releasing lock

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Singleton/SingletonListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Singleton/SingletonListener.cs
@@ -74,18 +74,20 @@ namespace Microsoft.Azure.WebJobs.Host.Listeners
 
         public async Task StopAsync(CancellationToken cancellationToken)
         {
+            if (_isListening)
+            {
+                // first stop the inner listener, to ensure that its work is complete
+                // BEFORE we release the lock
+                await _innerListener.StopAsync(cancellationToken);
+                _isListening = false;
+            }
+
             if (LockTimer != null)
             {
                 LockTimer.Stop();
             }
 
             await ReleaseLockAsync(cancellationToken);
-
-            if (_isListening)
-            {
-                await _innerListener.StopAsync(cancellationToken);
-                _isListening = false;
-            }
         }
 
         public void Cancel()

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/Singleton/SingletonListenerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/Singleton/SingletonListenerTests.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Reflection;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Executors;
@@ -181,6 +183,31 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Singleton
 
             _mockSingletonManager.VerifyAll();
             _mockInnerListener.VerifyAll();
+        }
+
+        [Fact]
+        public async Task StopAsync_StopsListener_BeforeReleasingLock()
+        {
+            CancellationToken cancellationToken = new CancellationToken();
+            var lockHandle = new RenewableLockHandle(new SingletonLockHandle(), null);
+            _mockSingletonManager.Setup(p => p.TryLockAsync(_lockId, null, _attribute, cancellationToken, false))
+                .ReturnsAsync(lockHandle);
+            _mockInnerListener.Setup(p => p.StartAsync(cancellationToken)).Returns(Task.FromResult(true));
+
+            await _listener.StartAsync(cancellationToken);
+
+            List<string> trace = new List<string>();
+            _mockSingletonManager.Setup(p => p.ReleaseLockAsync(lockHandle, cancellationToken)).Callback(() => trace.Add("Lock released")).Returns(Task.FromResult(true));
+            _mockInnerListener.Setup(p => p.StopAsync(cancellationToken)).Callback(() => trace.Add("Inner listener stopped")).Returns(Task.FromResult(true));
+
+            await _listener.StopAsync(cancellationToken);
+
+            _mockSingletonManager.VerifyAll();
+            _mockInnerListener.VerifyAll();
+
+            Assert.Equal(2, trace.Count);
+            Assert.Equal("Inner listener stopped", trace[0]);
+            Assert.Equal("Lock released", trace[1]);
         }
 
         [Fact]


### PR DESCRIPTION
Part of the work to address https://github.com/Azure/azure-webjobs-sdk-extensions/issues/791.