### PR TITLE
Updates to ConfigureWebJobs host builder extension

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsHostBuilderExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsHostBuilderExtensions.cs
@@ -2,9 +2,12 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Hosting;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.EnvironmentVariables;
+using Microsoft.Extensions.Configuration.Json;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -12,39 +15,112 @@ namespace Microsoft.Extensions.Hosting
 {
     public static class WebJobsHostBuilderExtensions
     {
+        /// <summary>
+        /// Applies WebJobs configuration to the specified <see cref="IHostBuilder"/>.
+        /// </summary>
+        /// <remarks>
+        /// In addition to WebJobs service registrations, this method will also apply the following default configuration sources
+        /// if they haven't already been specified:
+        ///     - Json file ("appsettings.json")
+        ///     - Environment variables
+        /// </remarks>
+        /// <param name="builder">The <see cref="IHostBuilder"/> to configure.</param>
+        /// <returns>The <see cref="IHostBuilder"/>.</returns>
         public static IHostBuilder ConfigureWebJobs(this IHostBuilder builder)
         {
             return builder.ConfigureWebJobs(o => { }, o => { });
         }
 
+        /// <summary>
+        /// Applies WebJobs configuration to the specified <see cref="IHostBuilder"/>.
+        /// </summary>
+        /// <remarks>
+        /// In addition to WebJobs service registrations, this method will also apply the following default configuration sources
+        /// if they haven't already been specified:
+        ///     - Json file ("appsettings.json")
+        ///     - Environment variables
+        /// </remarks>
+        /// <param name="builder">The <see cref="IHostBuilder"/> to configure.</param>
+        /// <param name="configure">Configuration action to perform as part of service configuration.</param>
+        /// <returns>The <see cref="IHostBuilder"/>.</returns>
         public static IHostBuilder ConfigureWebJobs(this IHostBuilder builder, Action<IWebJobsBuilder> configure)
         {
             return builder.ConfigureWebJobs(configure, o => { });
         }
 
+        /// <summary>
+        /// Applies WebJobs configuration to the specified <see cref="IHostBuilder"/>.
+        /// </summary>
+        /// <remarks>
+        /// In addition to WebJobs service registrations, this method will also apply the following default configuration sources
+        /// if they haven't already been specified:
+        ///     - Json file ("appsettings.json")
+        ///     - Environment variables
+        /// </remarks>
+        /// <param name="builder">The <see cref="IHostBuilder"/> to configure.</param>
+        /// <param name="configure">Configuration action to perform as part of service configuration.</param>
+        /// <param name="configureOptions">Configuration action for <see cref="JobHostOptions"/>.</param>
+        /// <returns>The <see cref="IHostBuilder"/>.</returns>
         public static IHostBuilder ConfigureWebJobs(this IHostBuilder builder, Action<IWebJobsBuilder> configure, Action<JobHostOptions> configureOptions)
         {
             return builder.ConfigureWebJobs((context, b) => configure(b), configureOptions);
         }
 
+        /// <summary>
+        /// Applies WebJobs configuration to the specified <see cref="IHostBuilder"/>.
+        /// </summary>
+        /// <remarks>
+        /// In addition to WebJobs service registrations, this method will also apply the following default configuration sources
+        /// if they haven't already been specified:
+        ///     - Json file ("appsettings.json")
+        ///     - Environment variables
+        /// </remarks>
+        /// <param name="builder">The <see cref="IHostBuilder"/> to configure.</param>
+        /// <param name="configure">Configuration action to perform as part of service configuration.</param>
+        /// <returns>The <see cref="IHostBuilder"/>.</returns>
         public static IHostBuilder ConfigureWebJobs(this IHostBuilder builder, Action<HostBuilderContext, IWebJobsBuilder> configure)
         {
             return builder.ConfigureWebJobs(configure, o => { });
         }
 
+        /// <summary>
+        /// Applies WebJobs configuration to the specified <see cref="IHostBuilder"/>.
+        /// </summary>
+        /// <remarks>
+        /// In addition to WebJobs service registrations, this method will also apply the following default configuration sources
+        /// if they haven't already been specified:
+        ///     - Json file ("appsettings.json")
+        ///     - Environment variables
+        /// </remarks>
+        /// <param name="builder">The <see cref="IHostBuilder"/> to configure.</param>
+        /// <param name="configure">Configuration action to perform as part of service configuration.</param>
+        /// <param name="configureOptions">Configuration action for <see cref="JobHostOptions"/>.</param>
+        /// <returns>The <see cref="IHostBuilder"/>.</returns>
         public static IHostBuilder ConfigureWebJobs(this IHostBuilder builder, Action<HostBuilderContext, IWebJobsBuilder> configure, Action<JobHostOptions> configureOptions)
         {
             return ConfigureWebJobs(builder, configure, configureOptions, (c, b) => { });
         }
 
+        /// <summary>
+        /// Applies WebJobs configuration to the specified <see cref="IHostBuilder"/>.
+        /// </summary>
+        /// <remarks>
+        /// In addition to WebJobs service registrations, this method will also apply the following default configuration sources
+        /// if they haven't already been specified:
+        ///     - Json file ("appsettings.json")
+        ///     - Environment variables
+        /// </remarks>
+        /// <param name="builder">The <see cref="IHostBuilder"/> to configure.</param>
+        /// <param name="configure">Configuration action to perform as part of service configuration.</param>
+        /// <param name="configureOptions">Configuration action for <see cref="JobHostOptions"/>.</param>
+        /// <param name="configureAppConfiguration">Additional action to perform as part of app configuration.</param>
+        /// <returns>The <see cref="IHostBuilder"/>.</returns>
         public static IHostBuilder ConfigureWebJobs(this IHostBuilder builder, Action<HostBuilderContext, IWebJobsBuilder> configure,
             Action<JobHostOptions> configureOptions, Action<HostBuilderContext, IWebJobsConfigurationBuilder> configureAppConfiguration)
         {
             builder.ConfigureAppConfiguration((context, config) =>
             {
-                config.AddJsonFile("appsettings.json", optional: true);
-                config.AddEnvironmentVariables();
-
+                config.TryAddDefaultConfigurationSources();
                 configureAppConfiguration?.Invoke(context, new WebJobsConfigurationBuilder(config));
             });
 
@@ -57,6 +133,23 @@ namespace Microsoft.Extensions.Hosting
             });
 
             return builder;
+        }
+
+        private static IConfigurationBuilder TryAddDefaultConfigurationSources(this IConfigurationBuilder config)
+        {
+            if (!config.Sources.OfType<JsonConfigurationSource>().Any(p => string.Equals(p.Path, "appsettings.json", StringComparison.OrdinalIgnoreCase)))
+            {
+                // only add the Json file provider if it hasn't been added already
+                config.AddJsonFile("appsettings.json", optional: true);
+            }
+
+            if (!config.Sources.OfType<EnvironmentVariablesConfigurationSource>().Any())
+            {
+                // only add the environment variables provider if it hasn't been added already
+                config.AddEnvironmentVariables();
+            }
+
+            return config;
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Hosting/HostBuilderExtensionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Hosting/HostBuilderExtensionsTests.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.EnvironmentVariables;
+using Microsoft.Extensions.Configuration.Json;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Host.UnitTests.Hosting
+{
+    public class HostBuilderExtensionsTests
+    {
+        [Fact]
+        public void ConfigureWebJobs_RegistersDefaultConfigSources()
+        {
+            IConfigurationBuilder configBuilder = null;
+
+            var builder = new HostBuilder()
+                .ConfigureAppConfiguration(b =>
+                {
+                    configBuilder = b;
+                })
+                .ConfigureWebJobs();
+
+            IHost host = builder.Build();
+
+            var configSources = configBuilder.Sources.ToArray();
+            Assert.Equal(3, configSources.Length);
+
+            var jsonConfigSource = (JsonConfigurationSource)configSources.OfType<JsonConfigurationSource>().Single();
+            Assert.Equal("appsettings.json", jsonConfigSource.Path);
+            Assert.True(jsonConfigSource.Optional);
+            Assert.False(jsonConfigSource.ReloadOnChange);
+
+            var envVarConfigSource = (EnvironmentVariablesConfigurationSource)configSources.OfType<EnvironmentVariablesConfigurationSource>().Single();
+            Assert.Null(envVarConfigSource.Prefix);
+        }
+
+        [Fact]
+        public void ConfigureWebJobs_DoesNotRegisterDefaultConfigSources_WhenAlreadyPresent()
+        {
+            IConfigurationBuilder configBuilder = null;
+
+            var builder = new HostBuilder()
+                .ConfigureAppConfiguration(b =>
+                {
+                    configBuilder = b;
+
+                    // register our own and change defaults
+                    b.AddJsonFile("appsettings.json", optional: false, reloadOnChange: true);
+                    b.AddEnvironmentVariables("custom");
+
+                    Dictionary<string, string> inMemoryConfig = new Dictionary<string, string>();
+                    b.AddInMemoryCollection(inMemoryConfig);
+                })
+                .ConfigureWebJobs();
+
+            IHost host = builder.Build();
+
+            var configSources = configBuilder.Sources.ToArray();
+            Assert.Equal(4, configSources.Length);
+
+            var jsonConfigSource = (JsonConfigurationSource)configSources.OfType<JsonConfigurationSource>().Single();
+            Assert.Equal("appsettings.json", jsonConfigSource.Path);
+            Assert.False(jsonConfigSource.Optional);
+            Assert.True(jsonConfigSource.ReloadOnChange);
+
+            var envVarConfigSource = (EnvironmentVariablesConfigurationSource)configSources.OfType<EnvironmentVariablesConfigurationSource>().Single();
+            Assert.Equal("custom", envVarConfigSource.Prefix);
+        }
+    }
+}


### PR DESCRIPTION
Update ConfigureWebJobs to add default config providers only if they haven't already been added. This supports scenarios where customers may want to add these providers themselves with their own custom options.

These changes  are for https://github.com/Azure/azure-webjobs-sdk/issues/1931. There are more extensive changes we're considering as part of that issue - the changes here are just a first step to alleviating some customer confusion/issues.