### PR TITLE
Roranjan/tranmission status

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Constants/LoggingConstants.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Constants/LoggingConstants.cs
@@ -8,5 +8,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
         public const string ZeroIpAddress = "0.0.0.0";
         public const string Unknown = "[Unknown]";
         public const string ClientIpKey = "ClientIp";
+        public const string HostDiagnosticSourcePrefix = "Microsoft.Azure.Functions.Host.";
+        public const string HostDiagnosticSourceDebugEventNamePrefix = "debug-";
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
@@ -80,6 +80,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<ITelemetryInitializer, MetricSdkVersionTelemetryInitializer>();
             services.AddSingleton<QuickPulseInitializationScheduler>();
             services.AddSingleton<QuickPulseTelemetryModule>();
+            services.AddSingleton<ITelemetryModule, TransmissionStatusTelemetryModule>();
 
             services.AddSingleton<ITelemetryModule>(provider =>
             {

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/TransmissionStatusTelemetryModule.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/TransmissionStatusTelemetryModule.cs
@@ -1,0 +1,149 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.ApplicationInsights.Extensibility.Implementation;
+using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
+using Newtonsoft.Json;
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
+{
+    /// <summary>
+    /// Transmission Status Telemetry Module 
+    /// </summary>
+    internal class TransmissionStatusTelemetryModule : ITelemetryModule, IDisposable
+    {
+        private bool isInitialized = false;
+        DiagnosticListener source = new DiagnosticListener(LoggingConstants.HostDiagnosticSourcePrefix + "ApplicationInsights");
+        string debugTracingEventName = LoggingConstants.HostDiagnosticSourceDebugEventNamePrefix + "TransmissionStatus";
+        JsonSerializerSettings options = new JsonSerializerSettings() { Error = (sender, error) => error.ErrorContext.Handled = true, NullValueHandling = NullValueHandling.Ignore };
+
+
+        /// <summary>
+        /// Initializes the telemetry module.
+        /// </summary>
+        /// <param name="configuration">Telemetry configuration to use for initialization.</param>
+        public void Initialize(TelemetryConfiguration configuration)
+        {
+            // Prevent the telemetry module from being initialized multiple times.
+            if (isInitialized)
+            {
+                return;
+            }
+            (configuration.TelemetryChannel as ServerTelemetryChannel).TransmissionStatusEvent += Handler;
+            isInitialized = true;
+        }
+
+        /// <summary>
+        /// Disposes the object.
+        /// </summary>
+        public void Dispose()
+        {
+            source.Dispose();
+        }
+
+        public void Handler(object sender, TransmissionStatusEventArgs args)
+        {
+            // Do not block the main thread
+            Task.Run(() =>
+            {
+                if (sender != null && args != null)
+                {
+                    // Always log if the response is non-success
+                    if (args.Response.StatusCode != 200)
+                    {
+                        var transmission = sender as Transmission;
+                        string id = null;
+                        if (transmission != null)
+                        {                        
+                            id = transmission.Id;
+                        }
+
+                        var log = new
+                        {
+                            statusCode = args.Response?.StatusCode,
+                            description = args.Response?.StatusDescription,
+                            id
+                        };
+                        source.Write("TransmissionStatus", JsonConvert.SerializeObject(log, options));
+                    }
+
+                    // Log everything if the debug trace feature flag is enabled
+                    if (source.IsEnabled(debugTracingEventName))
+                    {
+                        source.Write(debugTracingEventName, FormattedLog(sender, args));
+                    }
+                }
+            });
+        }
+        internal string FormattedLog(object sender, TransmissionStatusEventArgs args)
+        {
+            var transmission = sender as Transmission;
+            if (transmission != null)
+            {
+                var items = transmission.TelemetryItems.GroupBy(n => n.GetEnvelopeName())
+                            .Select(n => new
+                            {
+                                type = n.Key,
+                                count = n.Count()
+                            });
+
+                BackendResponse backendResponse = null;
+                if (!string.IsNullOrWhiteSpace(args.Response?.Content))
+                {
+                    backendResponse = JsonConvert.DeserializeObject<BackendResponse>(args.Response.Content, options);
+                }
+                string topErrorMessage = null;
+                int? topStatusCode = null;
+                if (backendResponse?.Errors != null && backendResponse.Errors.Count() > 0)
+                {
+                    topErrorMessage = backendResponse.Errors[0].Message;
+                    topStatusCode = backendResponse?.Errors[0].StatusCode;
+                }
+
+                var log = new
+                {
+                    items = items,
+                    statusCode = args.Response?.StatusCode,
+                    statusDescription = args.Response?.StatusDescription,
+                    retryAfterHeader = args.Response?.RetryAfterHeader,
+                    id = transmission.Id,
+                    timeout = transmission.Timeout,
+                    responseTimeInMs = args.ResponseDurationInMs,
+                    received = backendResponse?.ItemsReceived,
+                    accepted = backendResponse?.ItemsAccepted,
+                    errorMessage = topErrorMessage,
+                    errorCode = topStatusCode,
+                };
+                return JsonConvert.SerializeObject(log, options);
+            }
+            return "Unable to parse transmission status response";
+        }
+    }
+
+    internal class BackendResponse
+    {
+        [JsonProperty("itemsReceived")]
+        public int ItemsReceived { get; set; }
+
+        [JsonProperty("itemsAccepted")]
+        public int ItemsAccepted { get; set; }
+
+        [JsonProperty("errors")]
+        public Error[] Errors { get; set; }
+        public class Error
+        {
+
+            [JsonProperty("statusCode")]
+            public int StatusCode { get; set; }
+
+            [JsonProperty("message")]
+            public string Message { get; set; }
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
@@ -82,13 +82,14 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                 var modules = host.Services.GetServices<ITelemetryModule>().ToList();
 
                 // Verify Modules
-                Assert.Equal(5, modules.Count);
+                Assert.Equal(6, modules.Count);
                 Assert.Single(modules.OfType<DependencyTrackingTelemetryModule>());
 
                 Assert.Single(modules.OfType<QuickPulseTelemetryModule>());
                 Assert.Single(modules.OfType<PerformanceCollectorModule>());
                 Assert.Single(modules.OfType<AppServicesHeartbeatTelemetryModule>());
                 Assert.Single(modules.OfType<RequestTrackingTelemetryModule>());
+                Assert.Single(modules.OfType<TransmissionStatusTelemetryModule>());
 
                 var dependencyModule = modules.OfType<DependencyTrackingTelemetryModule>().Single();
 
@@ -159,13 +160,14 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                 var modules = host.Services.GetServices<ITelemetryModule>().ToList();
 
                 // Verify Modules
-                Assert.Equal(5, modules.Count);
+                Assert.Equal(6, modules.Count);
                 Assert.Single(modules.OfType<DependencyTrackingTelemetryModule>());
 
                 Assert.Single(modules.OfType<QuickPulseTelemetryModule>());
                 Assert.Single(modules.OfType<PerformanceCollectorModule>());
                 Assert.Single(modules.OfType<AppServicesHeartbeatTelemetryModule>());
                 Assert.Single(modules.OfType<RequestTrackingTelemetryModule>());
+                Assert.Single(modules.OfType<TransmissionStatusTelemetryModule>());
 
                 var dependencyModule = modules.OfType<DependencyTrackingTelemetryModule>().Single();
 

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/TransmissionStatusTelemetryModuleTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/TransmissionStatusTelemetryModuleTest.cs
@@ -1,0 +1,91 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.ApplicationInsights.Extensibility.Implementation;
+using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
+using Microsoft.Azure.WebJobs.Logging.ApplicationInsights;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Text;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
+{
+    public class TransmissionStatusTelemetryModuleTest
+    {
+        [Fact]
+        public void Initializer_Delegate()
+        {
+            TransmissionStatusTelemetryModule module = new TransmissionStatusTelemetryModule();
+            TelemetryConfiguration config = new TelemetryConfiguration("", new ServerTelemetryChannel());
+            module.Initialize(config);
+            Assert.Equal("Handler", ((ServerTelemetryChannel)config.TelemetryChannel).TransmissionStatusEvent.Method.Name);
+        }
+
+        [Fact]
+        public void FormattedLog_Failure()
+        {
+            TransmissionStatusTelemetryModule module = new TransmissionStatusTelemetryModule();
+            Transmission transmission = new Transmission(new Uri("https://test"), new List<ITelemetry>() { new RequestTelemetry(), new EventTelemetry() }, new TimeSpan(500));
+            HttpWebResponseWrapper response = new HttpWebResponseWrapper()
+            {
+                StatusCode = 400,
+                StatusDescription = "Invalid IKey",
+                Content = null
+            };
+            
+            TransmissionStatusEventArgs args = new TransmissionStatusEventArgs(response, 100);
+            JObject log = JsonConvert.DeserializeObject<JObject>(module.FormattedLog(transmission, args));
+            
+            Assert.Equal(400, log.Value<int>("statusCode"));
+            Assert.Equal("Invalid IKey", log.Value<string>("statusDescription"));
+            Assert.Equal("00:00:00.0000500", log.Value<string>("timeout"));
+            Assert.Equal(100, log.Value<int>("responseTimeInMs"));
+            Assert.True(log.ContainsKey("id"));
+        }
+        [Fact]
+        public void FormattedLog_PartialResponse()
+        {
+            TransmissionStatusTelemetryModule module = new TransmissionStatusTelemetryModule();
+            Transmission transmission = new Transmission(new Uri("https://test"), new List<ITelemetry>() { new RequestTelemetry(), new EventTelemetry() }, new TimeSpan(500));
+            BackendResponse backendResponse = new BackendResponse()
+            {
+                Errors = new BackendResponse.Error[2] 
+                { 
+                    new BackendResponse.Error() { Message = "Invalid IKey", StatusCode = 206}, 
+                    new BackendResponse.Error() { Message = "Invalid IKey", StatusCode = 206 } 
+                },
+                ItemsAccepted = 100,
+                ItemsReceived = 102
+            };
+            HttpWebResponseWrapper response = new HttpWebResponseWrapper()
+            {
+                StatusCode = 206,
+                StatusDescription = "Invalid IKey",
+                Content = JsonConvert.SerializeObject(backendResponse)
+            };
+
+            TransmissionStatusEventArgs args = new TransmissionStatusEventArgs(response, 100);
+            string st = module.FormattedLog(transmission, args);
+            JObject log = JsonConvert.DeserializeObject<JObject>(module.FormattedLog(transmission, args));
+
+            Assert.Equal(206, log.Value<int>("statusCode"));
+            Assert.Equal("Invalid IKey", log.Value<string>("statusDescription"));
+            Assert.Equal("00:00:00.0000500", log.Value<string>("timeout"));
+            Assert.Equal(100, log.Value<int>("responseTimeInMs"));
+            Assert.True(log.ContainsKey("id"));
+
+            Assert.Equal("Invalid IKey", log.Value<string>("errorMessage"));
+            Assert.Equal(206, log.Value<int>("errorCode")); 
+            Assert.Equal(100, log.Value<int>("accepted"));
+            Assert.Equal(102, log.Value<int>("received"));
+        }
+    }
+}


### PR DESCRIPTION
Fixes [this](https://github.com/Azure/azure-webjobs-sdk/issues/2649) issue.

Track ApplicationInsights ingestion service response by subscribing to transmission event. It will only log in case of non-sucess response or if the debug trace feature flag (EnableDebugTracing) is enabled, this will log all the request.

e.g. 
```sh
Diagnostic source 'Microsoft.Azure.Functions.Host.ApplicationInsights' emitted event 'TransmissionStatus': {"statusCode":400,"statusDescription":"Invalid instrumentation key","id":"vkZu1wA1u3c=","items":[{"type":"AppTraces","count":3},{"type":"AppRequests","count":1},{"type":"AppMetrics","count":12}],"responseTimeInMs":65,"timeout":"00:01:40"}
```