### PR TITLE
Bumping System.Memory.Data due to vulnerability in 1.0.1

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
+++ b/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.8.0" />
-    <PackageReference Include="System.Memory.Data" Version="1.0.1" />
+    <PackageReference Include="System.Memory.Data" Version="1.0.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
System.Memory.Data 1.0.2 uses System.Text.Encodings.Web 4.7.2 which is not vulnerable

Ref:
https://security.snyk.io/vuln/SNYK-DOTNET-SYSTEMTEXTENCODINGSWEB-1253267