### PR TITLE
Update parameter binding default type

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingProviders/TriggerAdapterBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingProviders/TriggerAdapterBindingProvider.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
 
                 // We should only be requesting ParameterBindingData if it is supported by the
                 // extension we're binding against. In theory, this should never happen.
-                throw new ArgumentException($"Converter for {requestedType} not found.");
+                throw new InvalidOperationException($"Converter for {requestedType} not found.");
             }
 
             foreach (var target in targets)

--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingProviders/TriggerAdapterBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/BindingProviders/TriggerAdapterBindingProvider.cs
@@ -35,7 +35,6 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
         // Listed in precedence for providing via DefaultType.
         // Precedence is more important than how we produce the default type (a direct conversion vs. a converter)
         private static readonly Type[] _defaultTypes = new Type[] {
-            typeof(ParameterBindingData),
             typeof(byte[]),
             typeof(JObject),
             typeof(JArray),
@@ -45,19 +44,33 @@ namespace Microsoft.Azure.WebJobs.Host.Bindings
         // Listed in precedence for providing via DefaultType.
         // Precedence is more important than how we produce the default type (a direct conversion vs. a converter)
         private static readonly Type[] _defaultBatchTypes = new Type[] {
-            typeof(ParameterBindingData[]),
             typeof(byte[][]),
             typeof(JObject[]),
             typeof(JArray),
             typeof(string[])
         };
 
+        // TODO: Refactor GetDefaultType so that a) we don't need a special case for ParameterBindingData
+        // and b) we are taking `requestedType` into account when checking if we have a converter
+        // GitHub issue: https://github.com/Azure/azure-webjobs-sdk/issues/2930
         public Type GetDefaultType(Attribute attribute, FileAccess access, Type requestedType)
         {
             // If the requestedType is a batch type, we need to return the batch version of default types
             IEnumerable<Type> targets = requestedType.IsArray && !_defaultTypes.Contains(requestedType)
                 ? _defaultBatchTypes
                 : _defaultTypes;
+
+            if (requestedType == typeof(ParameterBindingData) || requestedType == typeof(ParameterBindingData[]))
+            {
+                if (_converterManager.HasConverter<TAttribute>(typeof(TTriggerValue), requestedType))
+                {
+                    return requestedType;
+                }
+
+                // We should only be requesting ParameterBindingData if it is supported by the
+                // extension we're binding against. In theory, this should never happen.
+                throw new ArgumentException($"Converter for {requestedType} not found.");
+            }
 
             foreach (var target in targets)
             {

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostMetadataProviderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostMetadataProviderTests.cs
@@ -293,7 +293,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             var attr = new Test9Attribute(null);
             Action act = () => metadataProvider.GetDefaultType(attr, FileAccess.Write, typeof(ParameterBindingData));
 
-            ArgumentException exception = Assert.Throws<ArgumentException>(act);
+            var exception = Assert.Throws<InvalidOperationException>(act);
             Assert.Equal($"Converter for {typeof(ParameterBindingData)} not found.", exception.Message);
         }
 

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostMetadataProviderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostMetadataProviderTests.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             }
         }
 
-        // Verify for a Jobject-only collector.
+        // Verify for a JObject-only collector.
         [Fact]
         public void DefaultTypeForJObjectCollector()
         {
@@ -135,7 +135,6 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                     BindToCollector<JObject>(attr => (IAsyncCollector<JObject>)null);
             }
         }
-
 
         [Fact]
         public void DefaultTypeForJArrayTrigger()
@@ -186,7 +185,6 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             // The trigger handles Open type, which means it will first pull byte[].
             Assert.Equal(typeof(byte[]), type);
         }
-
 
         public class OpenTypeTriggerExtension : IExtensionConfigProvider
         {
@@ -298,7 +296,6 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             ArgumentException exception = Assert.Throws<ArgumentException>(act);
             Assert.Equal($"Converter for {typeof(ParameterBindingData)} not found.", exception.Message);
         }
-
 
         public class StringTriggerExtension : IExtensionConfigProvider
         {

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostMetadataProviderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/JobHostMetadataProviderTests.cs
@@ -9,12 +9,10 @@ using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Description;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Config;
-using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Indexers;
 using Microsoft.Azure.WebJobs.Host.Protocols;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Options;
 using Moq;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -25,7 +23,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
     {
         [Fact]
         public async Task Test()
-        {          
+        {
             var ext = new TestExtension();
 
             var host = new HostBuilder()
@@ -37,11 +35,11 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             IJobHostMetadataProvider metadataProvider = host.CreateMetadataProvider();
             Assert.Equal(1, ext._counter);
 
-            // Callable            
+            // Callable
             await host.GetJobHost<MyProg>().CallAsync("Test");
             Assert.Equal(1, ext._counter);
 
-            // Fact that we registered a Widget converter is enough to add the assembly 
+            // Fact that we registered a Widget converter is enough to add the assembly
             Assembly asm;
             bool resolved;
 
@@ -49,20 +47,20 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             Assert.True(resolved);
             Assert.Same(asm, typeof(Widget).Assembly);
 
-            // check with full name 
+            // check with full name
             resolved = metadataProvider.TryResolveAssembly(typeof(Widget).Assembly.GetName().FullName, out asm);
             Assert.True(resolved);
             Assert.Same(asm, typeof(Widget).Assembly);
 
-            // This requires the target attribute to be unique within the assembly. 
+            // This requires the target attribute to be unique within the assembly.
             var attrType = metadataProvider.GetAttributeTypeFromName("Test9");
             Assert.Equal(typeof(Test9Attribute), attrType);
 
-            // JObject --> Attribute 
+            // JObject --> Attribute
             var attr = GetAttr<Test9Attribute>(metadataProvider, new { Flag = "xyz" });
             Assert.Equal("xyz", attr.Flag);
 
-            // Getting default type. 
+            // Getting default type.
             var defaultType = metadataProvider.GetDefaultType(attr, FileAccess.Read, null);
             Assert.Equal(typeof(JObject), defaultType);
 
@@ -76,7 +74,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             return (T)attribute;
         }
 
-        // This is a setup used by CosmoDb. 
+        // This is a setup used by CosmoDb.
         [Fact]
         public void DefaultTypeForOpenTypeCollector()
         {
@@ -93,7 +91,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             var attr = new Test9Attribute(null);
             var type = metadataProvider.GetDefaultType(attr, FileAccess.Write, null);
 
-            // The collector handles Open type, which means it will first pull byte[]. 
+            // The collector handles Open type, which means it will first pull byte[].
             Assert.Equal(typeof(IAsyncCollector<byte[]>), type);
         }
 
@@ -102,12 +100,12 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
         {
             public void Initialize(ExtensionConfigContext context)
             {
-                var ignored = typeof(object); // not used 
+                var ignored = typeof(object); // not used
                 context.AddBindingRule<Test9Attribute>().BindToCollector<OpenType>(ignored);
             }
         }
 
-        // Verify for a Jobject-only collector. 
+        // Verify for a Jobject-only collector.
         [Fact]
         public void DefaultTypeForJObjectCollector()
         {
@@ -125,7 +123,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             var attr = new Test9Attribute(null);
             var type = metadataProvider.GetDefaultType(attr, FileAccess.Write, null);
 
-            // Explicitly should be Jobject since that's all the collector is registered as.
+            // Explicitly should be JObject since that's all the collector is registered as.
             Assert.Equal(typeof(IAsyncCollector<JObject>), type);
         }
 
@@ -140,16 +138,16 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
 
 
         [Fact]
-        public void DefaultTypeForTrigger()
+        public void DefaultTypeForJArrayTrigger()
         {
             var ext = new JArrayTriggerExtension();
             var host = new HostBuilder()
-                 .ConfigureDefaultTestHost(b =>
-                 {
-                     b.AddExtension(ext);
-                 })
-                 .ConfigureTypeLocator() // empty 
-                 .Build();
+                        .ConfigureDefaultTestHost(b =>
+                        {
+                            b.AddExtension(ext);
+                        })
+                        .ConfigureTypeLocator() // empty
+                        .Build();
 
             IJobHostMetadataProvider metadataProvider = host.CreateMetadataProvider();
 
@@ -185,9 +183,10 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             var attr = new Test9Attribute(null);
             var type = metadataProvider.GetDefaultType(attr, FileAccess.Write, null);
 
-            // The trigger handles Open type, which means it will first pull ParameterBindingData.
-            Assert.Equal(typeof(ParameterBindingData), type);
+            // The trigger handles Open type, which means it will first pull byte[].
+            Assert.Equal(typeof(byte[]), type);
         }
+
 
         public class OpenTypeTriggerExtension : IExtensionConfigProvider
         {
@@ -196,6 +195,117 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 var rule = context.AddBindingRule<Test9Attribute>();
                 rule.BindToTrigger<string>();
                 rule.AddOpenConverter<string, OpenType>((a, b, c) => null);
+            }
+        }
+
+        [Fact]
+        public void DefaultTypeForObjectTrigger()
+        {
+            var ext = new ObjectTriggerExtension();
+            var host = new HostBuilder()
+                        .ConfigureDefaultTestHost(b =>
+                        {
+                            b.AddExtension(ext);
+                        })
+                        .ConfigureTypeLocator() // empty
+                        .Build();
+
+            IJobHostMetadataProvider metadataProvider = host.CreateMetadataProvider();
+
+            var attr = new Test9Attribute(null);
+            var type = metadataProvider.GetDefaultType(attr, FileAccess.Write, typeof(object));
+
+            Assert.Equal(typeof(object), type);
+        }
+
+        public class ObjectTriggerExtension : IExtensionConfigProvider
+        {
+            public void Initialize(ExtensionConfigContext context)
+            {
+                var rule = context.AddBindingRule<Test9Attribute>();
+                rule.BindToTrigger<object>();
+            }
+        }
+
+        [Fact]
+        public void DefaultTypeForParameterBindingDataTrigger()
+        {
+            var ext = new ParameterBindingDataTriggerExtension();
+            var host = new HostBuilder()
+                        .ConfigureDefaultTestHost(b =>
+                        {
+                            b.AddExtension(ext);
+                        })
+                        .ConfigureTypeLocator() // empty
+                        .Build();
+
+            IJobHostMetadataProvider metadataProvider = host.CreateMetadataProvider();
+
+            var attr = new Test9Attribute(null);
+            var type = metadataProvider.GetDefaultType(attr, FileAccess.Write, typeof(ParameterBindingData));
+
+            Assert.Equal(typeof(ParameterBindingData), type);
+        }
+
+        [Fact]
+        public void DefaultTypeForParameterBindingDataArrayTrigger()
+        {
+            var ext = new ParameterBindingDataTriggerExtension();
+            var host = new HostBuilder()
+                        .ConfigureDefaultTestHost(b =>
+                        {
+                            b.AddExtension(ext);
+                        })
+                        .ConfigureTypeLocator() // empty
+                        .Build();
+
+            IJobHostMetadataProvider metadataProvider = host.CreateMetadataProvider();
+
+            var attr = new Test9Attribute(null);
+            var type = metadataProvider.GetDefaultType(attr, FileAccess.Write, typeof(ParameterBindingData[]));
+
+            Assert.Equal(typeof(ParameterBindingData[]), type);
+        }
+
+        public class ParameterBindingDataTriggerExtension : IExtensionConfigProvider
+        {
+            public void Initialize(ExtensionConfigContext context)
+            {
+                var rule = context.AddBindingRule<Test9Attribute>();
+                rule.BindToTrigger<string>();
+                rule.AddConverter<string, ParameterBindingData>(input => (ParameterBindingData)null);
+                rule.AddConverter<string, ParameterBindingData[]>(input => (ParameterBindingData[])null);
+            }
+        }
+
+        [Fact]
+        public void DefaultTypeForParameterBindingDataTrigger_Throws_IfConverterNotFound()
+        {
+            var ext = new StringTriggerExtension();
+            var host = new HostBuilder()
+                        .ConfigureDefaultTestHost(b =>
+                        {
+                            b.AddExtension(ext);
+                        })
+                        .ConfigureTypeLocator() // empty
+                        .Build();
+
+            IJobHostMetadataProvider metadataProvider = host.CreateMetadataProvider();
+
+            var attr = new Test9Attribute(null);
+            Action act = () => metadataProvider.GetDefaultType(attr, FileAccess.Write, typeof(ParameterBindingData));
+
+            ArgumentException exception = Assert.Throws<ArgumentException>(act);
+            Assert.Equal($"Converter for {typeof(ParameterBindingData)} not found.", exception.Message);
+        }
+
+
+        public class StringTriggerExtension : IExtensionConfigProvider
+        {
+            public void Initialize(ExtensionConfigContext context)
+            {
+                var rule = context.AddBindingRule<Test9Attribute>();
+                rule.BindToTrigger<string>();
             }
         }
 
@@ -227,8 +337,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             Assert.Equal(functionMetadata.IsDisabled, true);
         }
 
-        // Give this a unique name within the assembly so that the name --> type 
-        // reverse lookup can be unambiguous. 
+        // Give this a unique name within the assembly so that the name --> type
+        // reverse lookup can be unambiguous.
         [Binding]
         public class Test9Attribute : Attribute
         {


### PR DESCRIPTION
We should only be trying to bind to ParameterBindingData if it is the requestedType, otherwise fallback to default behaviour