### PR TITLE
Bumping up to 3.0.36

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- Packages can have independent versions and only increment when released -->
-    <Version>3.0.35$(VersionSuffix)</Version>
+    <Version>3.0.36$(VersionSuffix)</Version>
     <HostStorageVersion>5.0.0-beta.2$(VersionSuffix)</HostStorageVersion>
     <LoggingVersion>4.0.3$(VersionSuffix)</LoggingVersion>
     


### PR DESCRIPTION
Need to release a new version web jobs sdk.
3.0.35 is not released to nuget yet but the label is created.

