### PR TITLE
Update Application Insights flushing method to be FlushAsync

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
         public bool EnableDependencyTracking { get; set; } = true;
 
         /// <summary>
-        /// Configuration for dependency tracking. The dependecny tracking configuration only takes effect if EnableDependencyTracking is set to true
+        /// Configuration for dependency tracking. The dependency tracking configuration only takes effect if EnableDependencyTracking is set to true
         /// </summary>
         public DependencyTrackingOptions DependencyTrackingOptions { get; set; }
 

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerProvider.cs
@@ -15,11 +15,11 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
     {
         internal const string Alias = "ApplicationInsights";
         // Allow for subscribing to flushing exceptions
-        public const string ApplicationInsightsFlushingIssues = "ApplicationInsightsFlushingIssues";
+        public const string SourceName = ApplicationInsightsDiagnosticConstants.ApplicationInsightsDiagnosticSourcePrefix + "ApplicationInsightsLoggerProvider";
 
         private readonly TelemetryClient _client;
         private readonly ApplicationInsightsLoggerOptions _loggerOptions;
-        private DiagnosticListener _source = new DiagnosticListener(ApplicationInsightsFlushingIssues);
+        private DiagnosticListener _source = new DiagnosticListener(SourceName);
         private bool _disposed;
 
         public ApplicationInsightsLoggerProvider(TelemetryClient client, IOptions<ApplicationInsightsLoggerOptions> loggerOptions)
@@ -70,9 +70,9 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
         {
             // We must include this check, otherwise the payload will be created even though nothing is listening
             // for the data: see https://github.com/dotnet/runtime/blob/main/src/libraries/System.Diagnostics.DiagnosticSource/src/DiagnosticSourceUsersGuide.md
-            if (_source.IsEnabled(ApplicationInsightsFlushingIssues))
+            if (_source.IsEnabled(SourceName))
             {
-                _source.Write(ApplicationInsightsFlushingIssues, value);
+                _source.Write(SourceName, value);
             }
         }
     }

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerProvider.cs
@@ -3,9 +3,7 @@
 
 using System;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.ApplicationInsights;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -30,7 +28,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
             _client = client ?? throw new ArgumentNullException(nameof(client));
             _loggerOptions = loggerOptions?.Value ?? throw new ArgumentNullException(nameof(loggerOptions));
         }
-
+            
         // Constructor for testing purposes only
         internal ApplicationInsightsLoggerProvider(
             TelemetryClient client,
@@ -54,7 +52,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                         _cancellationTokenSource = new CancellationTokenSource(2000);
                         var task = _client.FlushAsync(_cancellationTokenSource.Token);
 
-                        // Wait for the flush to complete or for 5 seconds to pass, whichever comes first. This method throws and AggregateException with a
+                        // Wait for the flush to complete or for 2 seconds to pass, whichever comes first. This method throws an AggregateException with a
                         // TaskCanceledException object in the InnerExceptions collection if the flush is canceled
                         task.Wait();
                         
@@ -66,7 +64,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                     }
                     catch (Exception)
                     {
-                        WriteDiagnosticFlushingIssue($"Flushing failed. CancelationTokenSource.IsCancellationRequested: {_cancellationTokenSource.IsCancellationRequested}");
+                        WriteDiagnosticFlushingIssue($"Flushing failed. CancellationTokenSource.IsCancellationRequested: {_cancellationTokenSource.IsCancellationRequested}");
                     }
                     finally
                     {

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerProvider.cs
@@ -32,14 +32,12 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
         }
 
         // Constructor for testing purposes only
-        public ApplicationInsightsLoggerProvider(
+        internal ApplicationInsightsLoggerProvider(
             TelemetryClient client,
-            DiagnosticSource source,
-            CancellationTokenSource cancellationTokenSource)
+            DiagnosticSource source)
         {
             _client = client;
             _source = source;
-            _cancellationTokenSource = cancellationTokenSource;
         }
 
         public ILogger CreateLogger(string categoryName) => new ApplicationInsightsLogger(_client, categoryName, _loggerOptions);
@@ -52,8 +50,8 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                 {
                     try
                     {
-                        // Default timeout of 5 seconds
-                        _cancellationTokenSource = _cancellationTokenSource ?? new CancellationTokenSource(new TimeSpan(hours: 0, minutes: 0, seconds: 2));
+                        // Default timeout of 2 seconds
+                        _cancellationTokenSource = new CancellationTokenSource(2000);
                         var task = _client.FlushAsync(_cancellationTokenSource.Token);
 
                         // Wait for the flush to complete or for 5 seconds to pass, whichever comes first. This method throws and AggregateException with a

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerProvider.cs
@@ -69,6 +69,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                     finally
                     {
                         _cancellationTokenSource.Dispose();
+                        (_source as IDisposable)?.Dispose();
                     }
                 }
 

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerProvider.cs
@@ -34,15 +34,13 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                 {
                     try
                     {
-                        _client.Flush();
-
-                        // This sleep isn't ideal, but the flush is async so it's the best we have right now. This is
-                        // being tracked at https://github.com/Microsoft/ApplicationInsights-dotnet/issues/407
-                        Thread.Sleep(2000);
+                        // Flushing logs upon disposal should not be canceled
+                        var task = _client.FlushAsync(CancellationToken.None);
+                        task.Wait();
                     }
                     catch
                     {
-                        // Ignore failures on dispose
+                        // Log flushing failures
                     }
                 }
 

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerProvider.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using Microsoft.ApplicationInsights;
 using Microsoft.Extensions.Logging;

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerProvider.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
     public class ApplicationInsightsLoggerProvider : ILoggerProvider
     {
         internal const string Alias = "ApplicationInsights";
-        // Allow SDK to subscribe to flushing exceptions
+        // Allow for subscribing to flushing exceptions
         public const string ApplicationInsightsFlushingExceptions = "ApplicationInsightsFlushingExceptions";
 
         private readonly TelemetryClient _client;

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Constants/ApplicationInsightsDiagnosticConstants.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Constants/ApplicationInsightsDiagnosticConstants.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
+{
+    public static class ApplicationInsightsDiagnosticConstants
+    {
+        public const string ApplicationInsightsDiagnosticSourcePrefix = "Microsoft.Azure.WebJobs.Logging.ApplicationInsights.";
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <Version>3.0.34$(VersionSuffix)</Version>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PackageId>Microsoft.Azure.WebJobs.Logging.ApplicationInsights</PackageId>
     <Description>This package contains the runtime assemblies for Microsoft.Azure.WebJobs.Logging.ApplicationInsights. For more information, please visit http://go.microsoft.com/fwlink/?LinkID=320971</Description>
     <AssemblyName>Microsoft.Azure.WebJobs.Logging.ApplicationInsights</AssemblyName>

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <Version>3.0.34$(VersionSuffix)</Version>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Microsoft.Azure.WebJobs.Logging.ApplicationInsights</PackageId>
     <Description>This package contains the runtime assemblies for Microsoft.Azure.WebJobs.Logging.ApplicationInsights. For more information, please visit http://go.microsoft.com/fwlink/?LinkID=320971</Description>
     <AssemblyName>Microsoft.Azure.WebJobs.Logging.ApplicationInsights</AssemblyName>

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsLoggerProviderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsLoggerProviderTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                 channel => channel.FlushAsync(It.IsAny<CancellationToken>()))
                     .Returns<CancellationToken>(async cancellationToken =>
                         {
-                            // Sleep for the set amount of time
+                            // Delay for the set amount of time
                             await Task.Delay(millisecondsTimeout, cancellationToken);
                             return flushSucceeded;
                         });
@@ -76,11 +76,11 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                     SetupDelayedFlushAsync(mockChannel, 0, false);
                     break;
                 case FlushResult.Timeout:
-                    expectedDiagnosticLog = "Flushing failed. CancelationTokenSource.IsCancellationRequested: True";
+                    expectedDiagnosticLog = "Flushing failed. CancellationTokenSource.IsCancellationRequested: True";
                     SetupDelayedFlushAsync(mockChannel, 4000, true);
                     break;
                 case FlushResult.Exception:
-                    expectedDiagnosticLog = "Flushing failed. CancelationTokenSource.IsCancellationRequested: False";
+                    expectedDiagnosticLog = "Flushing failed. CancellationTokenSource.IsCancellationRequested: False";
                     mockChannel.As<IAsyncFlushable>().Setup(
                         channel => channel.FlushAsync(It.IsAny<CancellationToken>()))
                             .Throws(new Exception(expectedDiagnosticLog));

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsLoggerProviderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsLoggerProviderTests.cs
@@ -1,0 +1,121 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.Azure.WebJobs.Logging.ApplicationInsights;
+using Moq;
+using Xunit;
+
+
+namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
+{
+    public class ApplicationInsightsLoggerProviderTests
+    {
+        private const string DiagnosticSourceName = ApplicationInsightsLoggerProvider.SourceName;
+
+        public enum FlushResult
+        {
+            Success,
+            Incomplete,
+            Timeout,
+            Exception
+        }
+
+        // TODO: Remove this method once an interface is implemented for Microsoft.ApplicationInsights.TelemetryClient
+        // or another client is used. For now, we rely on mocking the underlying ITelemetryChannel and IAsyncFlushable
+        // interfaces, which are used in the implementation of TelemetryClient.FlushAsync().
+        // See https://github.com/microsoft/ApplicationInsights-dotnet/blob/main/BASE/src/Microsoft.ApplicationInsights/TelemetryClient.cs
+        // for further detail.
+        private TelemetryClient InitializeTestTelemetryClient(Mock<ITelemetryChannel> channel)
+        {
+            var config = new TelemetryConfiguration
+            {
+                TelemetryChannel = channel.Object,
+                InstrumentationKey = "some key"
+            };
+            return new TelemetryClient(config);
+        }
+
+        private void SetupDelayedFlushAsync(Mock<ITelemetryChannel> mockChannel, int millisecondsTimeout, bool flushSucceeded)
+        {
+            mockChannel.As<IAsyncFlushable>().Setup(
+                channel => channel.FlushAsync(It.IsAny<CancellationToken>()))
+                    .Returns(new Task<bool>(() =>
+                        {
+                            // Sleep for 6 seconds to exceed the timeout
+                            Thread.Sleep(millisecondsTimeout);
+                            return flushSucceeded;
+                        }));
+        }
+
+        [Theory]
+        [InlineData(FlushResult.Success)]
+        [InlineData(FlushResult.Incomplete)]
+        [InlineData(FlushResult.Timeout)]
+        [InlineData(FlushResult.Exception)]
+        public void ApplicationInsightsLoggerProviderDisposal_EmitsAppropriateDiagnostics(
+            FlushResult flushResult)
+        {
+            var mockChannel = new Mock<ITelemetryChannel>();
+            var mockListener = new Mock<DiagnosticSource>();
+            string expectedDiagnosticLog = "";
+
+            switch (flushResult)
+            {
+                case FlushResult.Success:
+                    mockChannel.As<IAsyncFlushable>().Setup(
+                        channel => channel.FlushAsync(It.IsAny<CancellationToken>()).Result)
+                            .Returns(true);
+                    break;
+                case FlushResult.Incomplete:
+                    expectedDiagnosticLog = "Flushing did not complete successfully";
+                    mockChannel.As<IAsyncFlushable>().Setup(
+                        channel => channel.FlushAsync(It.IsAny<CancellationToken>()).Result)
+                            .Returns(false);
+                    break;
+                case FlushResult.Timeout:
+                    expectedDiagnosticLog = "Flushing did not complete within 5s timeout";
+                    SetupDelayedFlushAsync(mockChannel, 6000, true);
+                    break;
+                case FlushResult.Exception:
+                    expectedDiagnosticLog = "Some exception";
+                    mockChannel.As<IAsyncFlushable>().Setup(
+                        channel => channel.FlushAsync(It.IsAny<CancellationToken>()))
+                            .Throws(new Exception(expectedDiagnosticLog));
+                    break;
+                default:
+                    throw new Exception("Unexpected flush result");
+            }
+
+            if (!string.IsNullOrEmpty(expectedDiagnosticLog))
+            {
+                mockListener.Setup(listener =>
+                    listener.IsEnabled(DiagnosticSourceName)).Returns(true);
+                mockListener.Setup(listener =>
+                    listener.Write(DiagnosticSourceName, It.IsAny<string>()));
+            }
+
+            var client = InitializeTestTelemetryClient(mockChannel);
+            var loggerProvider = new ApplicationInsightsLoggerProvider(client, mockListener.Object, new CancellationTokenSource());
+            loggerProvider.Dispose();
+
+            if (flushResult == FlushResult.Success)
+            {
+                // No diagnostic logs should be emitted
+                mockListener.Verify(listener => listener.IsEnabled(DiagnosticSourceName), Times.Never);
+            }
+            else
+            {
+                // There should only be one check for each diagnostic log emitted
+                mockListener.Verify(listener => listener.IsEnabled(DiagnosticSourceName), Times.Once);
+                mockListener.Verify(listener => listener.Write(DiagnosticSourceName, expectedDiagnosticLog), Times.Once);
+            }
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsLoggerProviderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsLoggerProviderTests.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                     break;
                 case FlushResult.Timeout:
                     expectedDiagnosticLog = "Flushing did not complete within 5s timeout";
-                    SetupDelayedFlushAsync(mockChannel, 6000, true);
+                    SetupDelayedFlushAsync(mockChannel, 8000, true);
                     break;
                 case FlushResult.Exception:
                     expectedDiagnosticLog = "Some exception";

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
@@ -39,7 +39,6 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             {
                 "FunctionId",
                 "ActivationEvent",
-                "ApplicationInsightsDiagnosticConstants",
                 "FunctionInstanceLogItem",
                 "FunctionInstanceStatus",
                 "FunctionStatusExtensions",
@@ -319,6 +318,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             var expected = new[]
             {
                 "ApplicationInsightsLoggerOptions",
+                "ApplicationInsightsDiagnosticConstants",
                 "HttpAutoCollectionOptions",
                 "ApplicationInsightsLoggerProvider",
                 "ApplicationInsightsLoggingBuilderExtensions",

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             {
                 "FunctionId",
                 "ActivationEvent",
+                "ApplicationInsightsDiagnosticConstants",
                 "FunctionInstanceLogItem",
                 "FunctionInstanceStatus",
                 "FunctionStatusExtensions",

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.22" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="Moq" Version="4.7.145" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta3-build3705" />


### PR DESCRIPTION
Addresses issue #2847 and adds a `DiagnosticListener` so consumers of the SDK can subscribe to events where flushing fails upon disposal of the `ApplicationInsightsLoggerProvider`.