### PR TITLE
Performance Improvements - Logging

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
@@ -138,14 +138,14 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                     case MetricCountKey when entry.Value is int count:
                         telemetry.Count = count;
                         break;
-                    case MetricMinKey when entry.Value is double min:
-                        telemetry.Min = min;
+                    case MetricMinKey:
+                        telemetry.Min = Convert.ToDouble(entry.Value);
                         break;
-                    case MetricMaxKey when entry.Value is double max:
-                        telemetry.Max = max;
+                    case MetricMaxKey:
+                        telemetry.Max = Convert.ToDouble(entry.Value);
                         break;
-                    case MetricStandardDeviationKey when entry.Value is double dev:
-                        telemetry.StandardDeviation = dev;
+                    case MetricStandardDeviationKey:
+                        telemetry.StandardDeviation = Convert.ToDouble(entry.Value);
                         break;
                     default:
                         // Otherwise, it's a custom property.

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
@@ -122,11 +122,11 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                 // next entry if found.
                 switch (entry.Key)
                 {
-                    case LogConstants.NameKey:
-                            telemetry.Name = entry.Value.ToString();
+                    case LogConstants.NameKey when entry.Value is string name:
+                        telemetry.Name = name;
                         continue;
-                    case LogConstants.MetricValueKey:
-                        telemetry.Sum = (double)entry.Value;
+                    case LogConstants.MetricValueKey when entry.Value is double sum:
+                        telemetry.Sum = sum;
                         continue;
                     default:
                         break;
@@ -135,17 +135,17 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                 // Now check for case-insensitive matches
                 switch (entry.Key.ToLowerInvariant())
                 {
-                    case MetricCountKey:
-                        telemetry.Count = Convert.ToInt32(entry.Value);
+                    case MetricCountKey when entry.Value is int count:
+                        telemetry.Count = count;
                         break;
-                    case MetricMinKey:
-                        telemetry.Min = Convert.ToDouble(entry.Value);
+                    case MetricMinKey when entry.Value is double min:
+                        telemetry.Min = min;
                         break;
-                    case MetricMaxKey:
-                        telemetry.Max = Convert.ToDouble(entry.Value);
+                    case MetricMaxKey when entry.Value is double max:
+                        telemetry.Max = max;
                         break;
-                    case MetricStandardDeviationKey:
-                        telemetry.StandardDeviation = Convert.ToDouble(entry.Value);
+                    case MetricStandardDeviationKey when entry.Value is double dev:
+                        telemetry.StandardDeviation = dev;
                         break;
                     default:
                         // Otherwise, it's a custom property.
@@ -171,8 +171,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                     }
                 }
 
-                string invocationId = scopeProperties.GetValueOrDefault<string>(ScopeKeys.FunctionInvocationId);
-                if (invocationId != null)
+                if (scopeProperties.GetValueOrDefault<string>(ScopeKeys.FunctionInvocationId) is string invocationId)
                 {
                     telemetry.Context.Properties[LogConstants.InvocationIdKey] = invocationId;
                 }               
@@ -325,8 +324,8 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
             {
                 switch (value.Key)
                 {
-                    case LogConstants.NameKey:
-                        functionName = value.Value.ToString();
+                    case LogConstants.NameKey when value.Value is string name:
+                        functionName = name;
                         break;
                     case LogConstants.TimestampKey:
                     case LogConstants.OriginalFormatKey:

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
@@ -342,7 +342,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                         // Timestamp is created automatically
                         // We won't use the format string here
                         break;
-                    default:                        
+                    default:
                         if (value.Value is int intValue) 
                         {
                             metrics.Add(value.Key, Convert.ToDouble(intValue));

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
         // Applies scope properties; filters most system properties, which are used internally
         private static void ApplyScopeProperties(ITelemetry telemetry)
         {
-            var scopeProperties = DictionaryLoggerScope.GetMergedStateDictionaryOrNull();            
+            var scopeProperties = DictionaryLoggerScope.GetMergedStateDictionaryOrNull();
             if (scopeProperties != null)
             {
                 foreach (var scopeProperty in scopeProperties)

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
@@ -256,8 +256,17 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
         {
             properties[LogConstants.CategoryNameKey] = _categoryName;
             properties[LogConstants.LogLevelKey] = ((LogLevel?)logLevel).ToString();
-            properties[LogConstants.EventIdKey] = Convert.ToString(eventId.Id);
-            properties[LogConstants.EventNameKey] = eventId.Name;
+            if (eventId != null)
+            {
+                if (eventId.Id != 0)
+                {
+                    properties[LogConstants.EventIdKey] = Convert.ToString(eventId.Id);
+                }
+                if (!string.IsNullOrEmpty(eventId.Name))
+                {
+                    properties[LogConstants.EventNameKey] = eventId.Name;
+                }
+            }
         }
         internal static void ApplyProperty(IDictionary<string, string> properties, string key, object value, bool applyPrefix = false)
         {

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
         // Applies scope properties; filters most system properties, which are used internally
         private static void ApplyScopeProperties(ITelemetry telemetry)
         {
-            var scopeProperties = DictionaryLoggerScope.GetMergedStateDictionaryOrNull();            
+            var scopeProperties = DictionaryLoggerScope.GetMergedStateDictionaryOrNull();
             if (scopeProperties != null)
             {
                 foreach (var scopeProperty in scopeProperties)
@@ -262,16 +262,14 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
         {
             properties[LogConstants.CategoryNameKey] = _categoryName;
             properties[LogConstants.LogLevelKey] = LogLevelEnumHelper.ToStringOptimized(logLevel);
-            if (eventId != null)
+            
+            if (eventId.Id != 0)
             {
-                if (eventId.Id != 0)
-                {
-                    properties[LogConstants.EventIdKey] = Convert.ToString(eventId.Id);
-                }
-                if (!string.IsNullOrEmpty(eventId.Name))
-                {
-                    properties[LogConstants.EventNameKey] = eventId.Name;
-                }
+                properties[LogConstants.EventIdKey] = Convert.ToString(eventId.Id);
+            }
+            if (!string.IsNullOrEmpty(eventId.Name))
+            {
+                properties[LogConstants.EventNameKey] = eventId.Name;
             }
         }
         internal static void ApplyProperty(IDictionary<string, string> properties, string key, object objectValue, bool applyPrefix = false)
@@ -289,7 +287,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
             {
                 stringValue = value;
             }
-            if (objectValue is DateTime date)
+            else if (objectValue is DateTime date)
             {
                 stringValue = date.ToUniversalTime().ToString(DateTimeFormatString);
             }

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/DictionaryLoggerScope.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/DictionaryLoggerScope.cs
@@ -12,18 +12,15 @@ namespace Microsoft.Azure.WebJobs.Logging
     internal class DictionaryLoggerScope
     {
         private static AsyncLocal<DictionaryLoggerScope> _value = new AsyncLocal<DictionaryLoggerScope>();
-        
-        // Cache merged dictionary. Invalidate cache on push/dispose 
-        private IDictionary<string, object> _currentScope;
-        // Maintain a count of all the items in the nested scope
-        private int _itemCount;
-        internal IReadOnlyDictionary<string, object> State { get; private set; }
+
+        // Cache merged dictionary.  
+        internal IReadOnlyDictionary<string, object> CurrentScope { get; private set; }
 
         internal DictionaryLoggerScope Parent { get; private set; }
 
-        private DictionaryLoggerScope(IReadOnlyDictionary<string, object> state, DictionaryLoggerScope parent)
+        private DictionaryLoggerScope(IReadOnlyDictionary<string, object> currentScope, DictionaryLoggerScope parent)
         {
-            State = state;
+            CurrentScope = currentScope;
             Parent = parent;
         }
         public static DictionaryLoggerScope Current
@@ -41,32 +38,21 @@ namespace Microsoft.Azure.WebJobs.Logging
 
         public static IDisposable Push(object state)
         {
-            int beforeCount = 0;
-            if (Current != null)
-            {
-                Current._currentScope = null;
-                beforeCount = Current._itemCount;
-            }
-            
             if (state is IDictionary<string, object> currentState)
             {
-                Current = new DictionaryLoggerScope(new ReadOnlyDictionary<string, object>(currentState), Current)
-                {
-                    _itemCount = currentState.Count + beforeCount
-                };
+                BuildCurrentScope(currentState);
             }
             else if (state is IEnumerable<KeyValuePair<string, object>> stateEnum)
             {
-                IDictionary<string, object> stateValues;            
-                // Convert this to a dictionary as we have scenarios where we cannot have duplicates. In this
-                // case, if there are dupes, the later entry wins.
+                IDictionary<string, object> stateValues;
+                // Convert this to a dictionary as we have scenarios where we cannot have duplicates.
+                // In this case, if there are dupes, the later entry wins.
                 stateValues = new Dictionary<string, object>();
                 foreach (var entry in stateEnum)
                 {
                     stateValues[entry.Key] = entry.Value;
                 }
-                Current._itemCount = stateValues.Count + beforeCount;
-                Current = new DictionaryLoggerScope(new ReadOnlyDictionary<string, object>(stateValues), Current);
+                BuildCurrentScope(stateValues);
             }
             else
             {
@@ -76,45 +62,45 @@ namespace Microsoft.Azure.WebJobs.Logging
             return new DisposableScope();
         }
 
-        // Builds a state dictionary of all scopes. If an inner scope
-        // contains the same key as an outer scope, it overwrites the value.
-        public static IDictionary<string, object> GetMergedStateDictionaryOrNull()
+        private static void BuildCurrentScope(IDictionary<string, object> state)
         {
-            if (Current == null)
+            int itemCount = state.Count;
+            if (Current != null)
+            {
+                itemCount += Current.CurrentScope.Count;
+            }
+            IDictionary<string, object> scopeInfo = new Dictionary<string, object>(itemCount);
+
+            // Copy the current scope to the new scope dictionary
+            if (Current != null && Current.CurrentScope != null)
+            {
+                foreach (var entry in Current.CurrentScope)
+                {
+                    scopeInfo.Add(entry);
+                }
+            }
+            // If the state contains the same key as current scope, it overwrites the value.
+            foreach (var entry in state)
+            {
+                scopeInfo[entry.Key] = entry.Value;
+            }
+            Current = new DictionaryLoggerScope(new ReadOnlyDictionary<string, object>(scopeInfo), Current);
+        }
+                
+        public static IReadOnlyDictionary<string, object> GetMergedStateDictionaryOrNull()
+        {
+            if (Current == null || Current.CurrentScope == null)
             {
                 return null;
             }
-            if (Current._currentScope == null)
-            {
-                 IDictionary<string, object> scopeInfo = new Dictionary<string, object>(Current._itemCount); 
-                var current = Current;
-                while (current != null)
-                {
-                    foreach (var entry in current.State)
-                    {
-                        // inner scopes win
-                        if (!scopeInfo.Keys.Contains(entry.Key))
-                        {
-                            scopeInfo.Add(entry);
-                        }
-                    }
-                    current = current.Parent;
-                }
-                Current._currentScope = scopeInfo;
-                return scopeInfo;
-            }
-            else
-            {
-                return Current._currentScope;
-            }
+            return Current.CurrentScope;
         }
 
         private class DisposableScope : IDisposable
         {
             public void Dispose()
             {
-                Current._currentScope = null;
-                Current = Current.Parent;                
+                Current = Current.Parent;
             }
         }
     }

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/DictionaryLoggerScope.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/DictionaryLoggerScope.cs
@@ -63,32 +63,34 @@ namespace Microsoft.Azure.WebJobs.Logging
 
         private static void BuildCurrentScope(IDictionary<string, object> state)
         {
-            int itemCount = state.Count;
-            if (Current != null)
-            {
-                itemCount += Current.CurrentScope.Count;
-            }
-            IDictionary<string, object> scopeInfo = new Dictionary<string, object>(itemCount);
+            IDictionary<string, object> scopeInfo;
 
             // Copy the current scope to the new scope dictionary
             if (Current != null && Current.CurrentScope != null)
             {
+                scopeInfo = new Dictionary<string, object>(state.Count + Current.CurrentScope.Count, StringComparer.Ordinal);
+
                 foreach (var entry in Current.CurrentScope)
                 {
-                    scopeInfo.Add(entry);
+                    scopeInfo[entry.Key] = entry.Value;
+                    //scopeInfo.Add(entry);
+                }
+                // If the state contains the same key as current scope, it overwrites the value.
+                foreach (var entry in state)
+                {
+                    scopeInfo[entry.Key] = entry.Value;
                 }
             }
-            // If the state contains the same key as current scope, it overwrites the value.
-            foreach (var entry in state)
+            else
             {
-                scopeInfo[entry.Key] = entry.Value;
+                scopeInfo = new Dictionary<string, object>(state, StringComparer.Ordinal);
             }
             Current = new DictionaryLoggerScope(new ReadOnlyDictionary<string, object>(scopeInfo), Current);
         }
                 
         public static IReadOnlyDictionary<string, object> GetMergedStateDictionaryOrNull()
         {
-            if (Current == null || Current.CurrentScope == null)
+            if (Current == null)
             {
                 return null;
             }

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/DictionaryLoggerScope.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/DictionaryLoggerScope.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Linq;
 using System.Threading;
 
 namespace Microsoft.Azure.WebJobs.Logging

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/DictionaryLoggerScope.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/DictionaryLoggerScope.cs
@@ -39,10 +39,10 @@ namespace Microsoft.Azure.WebJobs.Logging
 
         public static IDisposable Push(object state)
         {
-            if (state is IDictionary<string, object> dic)
+            if (state is IDictionary<string, object> currentState)
             {
-                Current = new DictionaryLoggerScope(new ReadOnlyDictionary<string, object>(dic), Current);
-                _itemCount += dic.Count;
+                Current = new DictionaryLoggerScope(new ReadOnlyDictionary<string, object>(currentState), Current);
+                _itemCount += currentState.Count;
             }
             else if (state is IEnumerable<KeyValuePair<string, object>> stateEnum)
             {

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/DictionaryLoggerScope.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/DictionaryLoggerScope.cs
@@ -72,8 +72,7 @@ namespace Microsoft.Azure.WebJobs.Logging
 
                 foreach (var entry in Current.CurrentScope)
                 {
-                    scopeInfo[entry.Key] = entry.Value;
-                    //scopeInfo.Add(entry);
+                    scopeInfo.Add(entry);
                 }
                 // If the state contains the same key as current scope, it overwrites the value.
                 foreach (var entry in state)

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/DictionaryLoggerScope.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/DictionaryLoggerScope.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Azure.WebJobs.Logging
             State = state;
             Parent = parent;
         }
+        // Cache merged dictionary. Invalidate cache on push/dispose 
         private static IDictionary<string, object> _currentScope;
         private static int _itemCount;
         internal IReadOnlyDictionary<string, object> State { get; private set; }

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/DictionaryLoggerScope.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/DictionaryLoggerScope.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Azure.WebJobs.Logging
             CurrentScope = currentScope;
             Parent = parent;
         }
+
         public static DictionaryLoggerScope Current
         {
             get

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/DictionaryLoggerScope.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/DictionaryLoggerScope.cs
@@ -12,12 +12,7 @@ namespace Microsoft.Azure.WebJobs.Logging
     internal class DictionaryLoggerScope
     {
         private static AsyncLocal<DictionaryLoggerScope> _value = new AsyncLocal<DictionaryLoggerScope>();
-
-        private DictionaryLoggerScope(IReadOnlyDictionary<string, object> state, DictionaryLoggerScope parent)
-        {
-            State = state;
-            Parent = parent;
-        }
+        
         // Cache merged dictionary. Invalidate cache on push/dispose 
         private IDictionary<string, object> _currentScope;
         // Maintain a count of all the items in the nested scope
@@ -26,6 +21,11 @@ namespace Microsoft.Azure.WebJobs.Logging
 
         internal DictionaryLoggerScope Parent { get; private set; }
 
+        private DictionaryLoggerScope(IReadOnlyDictionary<string, object> state, DictionaryLoggerScope parent)
+        {
+            State = state;
+            Parent = parent;
+        }
         public static DictionaryLoggerScope Current
         {
             get

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/LogLevelEnumHelper.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/LogLevelEnumHelper.cs
@@ -8,31 +8,30 @@ using System;
 
 namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights.Extensions
 {
-    internal class LogLevelEnumHelper
+    internal static class LogLevelEnumHelper
     {
-        private static readonly string[] LogLevelEnumStrings;
-
-        static LogLevelEnumHelper()
-        {
-            LogLevelEnumStrings = GetEnumOrderedStrings();
-        }
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static string ToStringOptimized(LogLevel enumValue)
+        internal static string ToStringOptimized(this LogLevel logLevel)
         {
-            return LogLevelEnumStrings[(int)enumValue];
-        }
-        private static string[] GetEnumOrderedStrings()
-        {
-            var list = Enum.GetValues(typeof(LogLevel));
-            string[] enumOrderedStrings = new string[list.Length];
-            int index = 0;
-            foreach (var item in list)
+            switch (logLevel)
             {
-                enumOrderedStrings[index] = item.ToString();
-                index++;
+                case LogLevel.Trace:
+                    return "Trace";
+                case LogLevel.Debug:
+                    return "Debug";
+                case LogLevel.Information:
+                    return "Information";
+                case LogLevel.Warning:
+                    return "Warning";
+                case LogLevel.Error:
+                    return "Error";
+                case LogLevel.Critical:
+                    return "Critical";
+                case LogLevel.None:
+                    return "None";
+                default:
+                    return logLevel.ToString();
             }
-            return enumOrderedStrings;
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/LogLevelEnumHelper.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/LogLevelEnumHelper.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System;
+
+namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights.Extensions
+{
+    internal class LogLevelEnumHelper
+    {
+        private static readonly string[] LogLevelEnumStrings;
+
+        static LogLevelEnumHelper()
+        {
+            LogLevelEnumStrings = GetEnumOrderedStrings();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string ToStringOptimized(LogLevel enumValue)
+        {
+            return LogLevelEnumStrings[(int)enumValue];
+        }
+        private static string[] GetEnumOrderedStrings()
+        {
+            var list = Enum.GetValues(typeof(LogLevel));
+            string[] enumOrderedStrings = new string[list.Length];
+            int index = 0;
+            foreach (var item in list)
+            {
+                enumOrderedStrings[index] = item.ToString();
+                index++;
+            }
+            return enumOrderedStrings;
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/LogLevelExtension.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/LogLevelExtension.cs
@@ -5,10 +5,11 @@ using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System;
+using System.Globalization;
 
 namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights.Extensions
 {
-    internal static class LogLevelEnumHelper
+    internal static class LogLevelExtension
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static string ToStringOptimized(this LogLevel logLevel)
@@ -30,7 +31,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights.Extensions
                 case LogLevel.None:
                     return "None";
                 default:
-                    return logLevel.ToString();
+                    return logLevel.ToString(CultureInfo.InvariantCulture);
             }
         }
     }

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/WebJobsTelemetryInitializer.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/WebJobsTelemetryInitializer.cs
@@ -49,56 +49,55 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
             {
                 telemetryContext.Location.Ip = LoggingConstants.ZeroIpAddress;
             }
-
             telemetryContext.Properties[LogConstants.ProcessIdKey] = _currentProcessId;
+            
+            // Apply our special scope properties
+            IReadOnlyDictionary<string, object> scopeProps = DictionaryLoggerScope.GetMergedStateDictionaryOrNull();
 
-            if (telemetry is DependencyTelemetry)
+            // this could be telemetry tracked in scope of function call - then we should apply the logger scope
+            // or RequestTelemetry tracked by the WebJobs SDK or AppInsight SDK - then we should apply Activity.Tags
+            if (scopeProps?.Count > 0)
             {
-                // Apply our special scope properties
-                IReadOnlyDictionary<string, object> scopeProps = DictionaryLoggerScope.GetMergedStateDictionaryOrNull();
-
-                // this could be telemetry tracked in scope of function call - then we should apply the logger scope
-                // or RequestTelemetry tracked by the WebJobs SDK or AppInsight SDK - then we should apply Activity.Tags
-                if (scopeProps != null && scopeProps.Count > 0)
+                if (!telemetryContext.Properties.ContainsKey(LogConstants.InvocationIdKey))
                 {
                     if (scopeProps?.GetValueOrDefault<string>(ScopeKeys.FunctionInvocationId) is string invocationId)
                     {
                         telemetryContext.Properties[LogConstants.InvocationIdKey] = invocationId;
                     }
+                }
 
-                    telemetryContext.Operation.Name = scopeProps.GetValueOrDefault<string>(ScopeKeys.FunctionName);
+                telemetryContext.Operation.Name = scopeProps.GetValueOrDefault<string>(ScopeKeys.FunctionName);
 
-                    // Apply Category, LogLevel event details to all telemetry
-                    if (!telemetryContext.Properties.ContainsKey(LogConstants.CategoryNameKey))
+                // Apply Category, LogLevel event details to all telemetry
+                if (!telemetryContext.Properties.ContainsKey(LogConstants.CategoryNameKey))
+                {
+                    if (scopeProps.GetValueOrDefault<string>(LogConstants.CategoryNameKey) is string category)
                     {
-                        if (scopeProps.GetValueOrDefault<string>(LogConstants.CategoryNameKey) is string category)
-                        {
-                            telemetryContext.Properties[LogConstants.CategoryNameKey] = category;
-                        }
+                        telemetryContext.Properties[LogConstants.CategoryNameKey] = category;
                     }
+                }
 
-                    if (!telemetryContext.Properties.ContainsKey(LogConstants.LogLevelKey))
+                if (!telemetryContext.Properties.ContainsKey(LogConstants.LogLevelKey))
+                {
+                    if (scopeProps.GetValueOrDefault<LogLevel?>(LogConstants.LogLevelKey) is LogLevel logLevel)
                     {
-                        if (scopeProps.GetValueOrDefault<LogLevel?>(LogConstants.LogLevelKey) is LogLevel logLevel)
-                        {
-                            telemetryContext.Properties[LogConstants.LogLevelKey] = logLevel.ToStringOptimized();
-                        }
+                        telemetryContext.Properties[LogConstants.LogLevelKey] = logLevel.ToStringOptimized();
                     }
+                }
 
-                    if (!telemetryContext.Properties.ContainsKey(LogConstants.EventIdKey))
+                if (!telemetryContext.Properties.ContainsKey(LogConstants.EventIdKey))
+                {
+                    if (scopeProps.GetValueOrDefault<int>(LogConstants.EventIdKey) is int eventId && eventId != 0)
                     {
-                        if (scopeProps.GetValueOrDefault<int>(LogConstants.EventIdKey) is int eventId && eventId != 0)
-                        {
-                            telemetryContext.Properties[LogConstants.EventIdKey] = eventId.ToString(CultureInfo.InvariantCulture);
-                        }
+                        telemetryContext.Properties[LogConstants.EventIdKey] = eventId.ToString(CultureInfo.InvariantCulture);
                     }
+                }
 
-                    if (!telemetryContext.Properties.ContainsKey(LogConstants.EventNameKey))
+                if (!telemetryContext.Properties.ContainsKey(LogConstants.EventNameKey))
+                {
+                    if (scopeProps.GetValueOrDefault<string>(LogConstants.EventNameKey) is string eventName)
                     {
-                        if (scopeProps.GetValueOrDefault<string>(LogConstants.EventNameKey) is string eventName)
-                        {
-                            telemetryContext.Properties[LogConstants.EventNameKey] = eventName;
-                        }
+                        telemetryContext.Properties[LogConstants.EventNameKey] = eventName;
                     }
                 }
             }

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/WebJobsTelemetryInitializer.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/WebJobsTelemetryInitializer.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
             if (telemetry is DependencyTelemetry)
             {
                 // Apply our special scope properties
-                IDictionary<string, object> scopeProps = DictionaryLoggerScope.GetMergedStateDictionaryOrNull();
+                IReadOnlyDictionary<string, object> scopeProps = DictionaryLoggerScope.GetMergedStateDictionaryOrNull();
 
                 string invocationId = scopeProps?.GetValueOrDefault<string>(ScopeKeys.FunctionInvocationId);
                 if (invocationId != null)

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/WebJobsTelemetryInitializer.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/WebJobsTelemetryInitializer.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
-using System.Linq;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/WebJobsTelemetryInitializer.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/WebJobsTelemetryInitializer.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
 
                     if (!telemetryContext.Properties.ContainsKey(LogConstants.EventIdKey))
                     {
-                        if (scopeProps.GetValueOrDefault<int?>(LogConstants.EventIdKey).Value is int eventId && eventId != 0)
+                        if (scopeProps.GetValueOrDefault<int>(LogConstants.EventIdKey) is int eventId && eventId != 0)
                         {
                             telemetryContext.Properties[LogConstants.EventIdKey] = eventId.ToString(CultureInfo.InvariantCulture);
                         }

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/WebJobsTelemetryInitializer.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/WebJobsTelemetryInitializer.cs
@@ -49,8 +49,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                 telemetryContext.Location.Ip = LoggingConstants.ZeroIpAddress;
             }
 
-            IDictionary<string, string> telemetryProps = telemetryContext.Properties;
-            telemetryProps[LogConstants.ProcessIdKey] = _currentProcessId;
+            telemetryContext.Properties[LogConstants.ProcessIdKey] = _currentProcessId;
 
             if (telemetry is DependencyTelemetry)
             {
@@ -60,7 +59,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                 string invocationId = scopeProps?.GetValueOrDefault<string>(ScopeKeys.FunctionInvocationId);
                 if (invocationId != null)
                 {
-                    telemetryProps[LogConstants.InvocationIdKey] = invocationId;
+                    telemetryContext.Properties[LogConstants.InvocationIdKey] = invocationId;
                 }
 
                 // this could be telemetry tracked in scope of function call - then we should apply the logger scope
@@ -70,39 +69,39 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                     telemetryContext.Operation.Name = scopeProps.GetValueOrDefault<string>(ScopeKeys.FunctionName);
 
                     // Apply Category, LogLevel event details to all telemetry
-                    if (!telemetryProps.ContainsKey(LogConstants.CategoryNameKey))
+                    if (!telemetryContext.Properties.ContainsKey(LogConstants.CategoryNameKey))
                     {
                         string category = scopeProps.GetValueOrDefault<string>(LogConstants.CategoryNameKey);
                         if (category != null)
                         {
-                            telemetryProps[LogConstants.CategoryNameKey] = category;
+                            telemetryContext.Properties[LogConstants.CategoryNameKey] = category;
                         }
                     }
 
-                    if (!telemetryProps.ContainsKey(LogConstants.LogLevelKey))
+                    if (!telemetryContext.Properties.ContainsKey(LogConstants.LogLevelKey))
                     {
                         LogLevel? logLevel = scopeProps.GetValueOrDefault<LogLevel?>(LogConstants.LogLevelKey);
                         if (logLevel != null)
                         {
-                            telemetryProps[LogConstants.LogLevelKey] = logLevel.Value.ToString();
+                            telemetryContext.Properties[LogConstants.LogLevelKey] = logLevel.Value.ToString();
                         }
                     }
 
-                    if (!telemetryProps.ContainsKey(LogConstants.EventIdKey))
+                    if (!telemetryContext.Properties.ContainsKey(LogConstants.EventIdKey))
                     {
                         int? eventId = scopeProps.GetValueOrDefault<int?>(LogConstants.EventIdKey);
                         if (eventId != null && eventId.HasValue && eventId.Value != 0)
                         {
-                            telemetryProps[LogConstants.EventIdKey] = eventId.Value.ToString();
+                            telemetryContext.Properties[LogConstants.EventIdKey] = eventId.Value.ToString();
                         }
                     }
 
-                    if (!telemetryProps.ContainsKey(LogConstants.EventNameKey))
+                    if (!telemetryContext.Properties.ContainsKey(LogConstants.EventNameKey))
                     {
                         string eventName = scopeProps.GetValueOrDefault<string>(LogConstants.EventNameKey);
                         if (eventName != null)
                         {
-                            telemetryProps[LogConstants.EventNameKey] = eventName;
+                            telemetryContext.Properties[LogConstants.EventNameKey] = eventName;
                         }
                     }
                 }

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/WebJobsTelemetryInitializer.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/WebJobsTelemetryInitializer.cs
@@ -52,44 +52,59 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
             IDictionary<string, string> telemetryProps = telemetryContext.Properties;
             telemetryProps[LogConstants.ProcessIdKey] = _currentProcessId;
 
-            // Apply our special scope properties
-            IDictionary<string, object> scopeProps = DictionaryLoggerScope.GetMergedStateDictionaryOrNull();
-
-            string invocationId = scopeProps?.GetValueOrDefault<string>(ScopeKeys.FunctionInvocationId);
-            if (invocationId != null)
+            if (telemetry is DependencyTelemetry)
             {
-                telemetryProps[LogConstants.InvocationIdKey] = invocationId;
-            }
+                // Apply our special scope properties
+                IDictionary<string, object> scopeProps = DictionaryLoggerScope.GetMergedStateDictionaryOrNull();
 
-            // this could be telemetry tracked in scope of function call - then we should apply the logger scope
-            // or RequestTelemetry tracked by the WebJobs SDK or AppInsight SDK - then we should apply Activity.Tags
-            if (scopeProps != null && scopeProps.Count > 0)
-            {
-                telemetryContext.Operation.Name = scopeProps.GetValueOrDefault<string>(ScopeKeys.FunctionName);
-
-                // Apply Category and LogLevel to all telemetry
-                string category = scopeProps.GetValueOrDefault<string>(LogConstants.CategoryNameKey);
-                if (category != null)
+                string invocationId = scopeProps?.GetValueOrDefault<string>(ScopeKeys.FunctionInvocationId);
+                if (invocationId != null)
                 {
-                    telemetryProps[LogConstants.CategoryNameKey] = category;
+                    telemetryProps[LogConstants.InvocationIdKey] = invocationId;
                 }
 
-                LogLevel? logLevel = scopeProps.GetValueOrDefault<LogLevel?>(LogConstants.LogLevelKey);
-                if (logLevel != null)
+                // this could be telemetry tracked in scope of function call - then we should apply the logger scope
+                // or RequestTelemetry tracked by the WebJobs SDK or AppInsight SDK - then we should apply Activity.Tags
+                if (scopeProps != null && scopeProps.Count > 0)
                 {
-                    telemetryProps[LogConstants.LogLevelKey] = logLevel.Value.ToString();
-                }
+                    telemetryContext.Operation.Name = scopeProps.GetValueOrDefault<string>(ScopeKeys.FunctionName);
 
-                int? eventId = scopeProps.GetValueOrDefault<int?>(LogConstants.EventIdKey);
-                if (eventId != null && eventId.HasValue && eventId.Value != 0)
-                {
-                    telemetryProps[LogConstants.EventIdKey] = eventId.Value.ToString();
-                }
+                    // Apply Category, LogLevel event details to all telemetry
+                    if (!telemetryProps.ContainsKey(LogConstants.CategoryNameKey))
+                    {
+                        string category = scopeProps.GetValueOrDefault<string>(LogConstants.CategoryNameKey);
+                        if (category != null)
+                        {
+                            telemetryProps[LogConstants.CategoryNameKey] = category;
+                        }
+                    }
 
-                string eventName = scopeProps.GetValueOrDefault<string>(LogConstants.EventNameKey);
-                if (eventName != null)
-                {
-                    telemetryProps[LogConstants.EventNameKey] = eventName;
+                    if (!telemetryProps.ContainsKey(LogConstants.LogLevelKey))
+                    {
+                        LogLevel? logLevel = scopeProps.GetValueOrDefault<LogLevel?>(LogConstants.LogLevelKey);
+                        if (logLevel != null)
+                        {
+                            telemetryProps[LogConstants.LogLevelKey] = logLevel.Value.ToString();
+                        }
+                    }
+
+                    if (!telemetryProps.ContainsKey(LogConstants.EventIdKey))
+                    {
+                        int? eventId = scopeProps.GetValueOrDefault<int?>(LogConstants.EventIdKey);
+                        if (eventId != null && eventId.HasValue && eventId.Value != 0)
+                        {
+                            telemetryProps[LogConstants.EventIdKey] = eventId.Value.ToString();
+                        }
+                    }
+
+                    if (!telemetryProps.ContainsKey(LogConstants.EventNameKey))
+                    {
+                        string eventName = scopeProps.GetValueOrDefault<string>(LogConstants.EventNameKey);
+                        if (eventName != null)
+                        {
+                            telemetryProps[LogConstants.EventNameKey] = eventName;
+                        }
+                    }
                 }
             }
 

--- a/src/Microsoft.Azure.WebJobs.Shared/DictionaryExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Shared/DictionaryExtensions.cs
@@ -15,4 +15,17 @@ namespace System.Collections.Generic
             return default(T);
         }
     }
+
+    internal static class ReadOnlyDictionaryExtensions
+    {
+        public static T GetValueOrDefault<T>(this IReadOnlyDictionary<string, object> dictionary, string key)
+        {
+            object value;
+            if (dictionary != null && dictionary.TryGetValue(key, out value))
+            {
+                return (T)value;
+            }
+            return default(T);
+        }
+    }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsLoggerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsLoggerTests.cs
@@ -933,7 +933,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             var level1 = new Dictionary<string, object>
             {
                 ["AsyncLocal"] = asyncLocalSetting,
-                ["1"] = 1
+                ["1"] = 1,
+                ["shared"] = "Level1"
             };
 
             ILogger logger = CreateLogger(_functionCategoryName);
@@ -953,14 +954,16 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
 
             var level2 = new Dictionary<string, object>
             {
-                ["2"] = 2
+                ["2"] = 2,
+                ["shared"] = "Level2"
             };
 
             var expectedLevel2 = new Dictionary<string, object>
             {
                 ["1"] = 1,
                 ["2"] = 2,
-                ["AsyncLocal"] = asyncLocalSetting
+                ["AsyncLocal"] = asyncLocalSetting,
+                ["shared"] = "Level2"
             };
 
             ILogger logger2 = CreateLogger(_functionCategoryName);
@@ -982,7 +985,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             var level3 = new Dictionary<string, object>
             {
                 ["1"] = 11,
-                ["3"] = 3
+                ["3"] = 3,
+                ["shared"] = "Level3"
             };
 
             var expectedLevel3 = new Dictionary<string, object>
@@ -990,7 +994,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                 ["1"] = 11,
                 ["2"] = 2,
                 ["3"] = 3,
-                ["AsyncLocal"] = asyncLocalSetting
+                ["AsyncLocal"] = asyncLocalSetting,
+                ["shared"] = "Level3"
             };
 
             ILogger logger3 = CreateLogger(_functionCategoryName);


### PR DESCRIPTION
This PR addresses the issue [#2842](https://github.com/Azure/azure-webjobs-sdk/issues/2824). 
Enabling Application Insights has significant performance and throughput overhead. Function supports adding context to log/metric telemetry using BeginScope(). Each call to BeginScope() creates another level of nesting, so that logs/metrics produced within the scope can be tagged with information about where they came from. While this is done extensively in host, customers can create scopes as well (.Net In-Proc) . Nick did an [investigation](https://github.com/Azure/azure-webjobs-sdk/issues/2824) to highlight the performance overhead of using scopes. This is primarily due to multiple Dictionaries that get allocated to support scope. One at the time of passing the scope attributes, another when these attributes are received and wrapped in ReadOnlyDictionary. There’s another set of allocation when the current scope is built where-in it recursively iterate through the nested scopes.

Improvements in this PR
1.	`ApplicationInsightsLogger.cs`
a.	Removed `BeginScope` from the `Log()` method. All the `known properties` are passed as param and added to the telemetry property. This reduces the level of nesting and also reduces the cost of building `scopeInfo`.
b.     Reduced the numer of times `GetMergedStateDictionaryOrNull` is called.
c.	Removed Linq from `ApplyScopeProperties()`. 
d.     Saved some boxing/unboxing and made type casting more efficient.

2.	`LogLevelEnumHelper .cs`
Enum helper to convert `enum` into `string`. This uses a cached string array. No allocation and very efficient compared to `ToString()`. 

3.	`WebJobsTelemetryInitializer.cs`
a.     Restricted the call to `GetMergedStateDictionaryOrNull()` for only `DependencyTelemetry`. 
b.     Category, LogLevel, EventId and EventName are set in `ApplicationInsightsLogger.Log()` method.

4.	`DictionaryLoggerScope.cs`
a.	`Push()` - If state is a dictionary, then use it otherwise build a new dictionary.
b.	`GetMergedStateDictionaryOrNull()` – Return null if `Current` is `null`. 
c.      Cached the `scopeInfo` and return from cache if exist. The cache is tied to the current scope.
e.	`_itemCount` – to avoid dictionary resizing.

**Benchmarking**:
Memory Allocation:
- Dictionary<string, object> allocation is down by ~99.75%. 
- Resize is almost negligible.
 
![image](https://user-images.githubusercontent.com/90008725/224613186-65c4a74f-d4d2-4920-addb-6c82781f36e9.png)

- Req/sec and avg response time is down by ~8%
<img width="972" alt="Screenshot 2023-03-10 112101" src="https://user-images.githubusercontent.com/90008725/224613394-426eb9af-4653-4ef3-a33e-dcef99a370b4.png">

<img width="853" alt="image" src="https://user-images.githubusercontent.com/90008725/214270085-9ea5180a-5a75-4c66-9705-f4009b2f94ab.png">

Execution Time
![image](https://user-images.githubusercontent.com/90008725/224613164-b22e92a9-8dea-4639-b1b7-9c35a89cf5a4.png)