### PR TITLE
updating AI assembly version

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
@@ -1,8 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\Microsoft.Azure.WebJobs.Shared\WebJobs.Shared.projitems" Label="Shared" />
   <Import Project="..\..\build\common.props" />
+
   <PropertyGroup>
-    <Version>3.0.34$(VersionSuffix)</Version>
+    <Version>3.0.35$(VersionSuffix)</Version>
+    <InformationalVersion>$(Version) Commit hash: $(CommitHash)</InformationalVersion>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Microsoft.Azure.WebJobs.Logging.ApplicationInsights</PackageId>
     <Description>This package contains the runtime assemblies for Microsoft.Azure.WebJobs.Logging.ApplicationInsights. For more information, please visit http://go.microsoft.com/fwlink/?LinkID=320971</Description>


### PR DESCRIPTION
In a recent release investigation, I realized this AssemblyInfo wasn't correct after I disconnected the App Insights assembly version from the rest of WebJobs (#2916). This will now use the correct `InformationalVersion` (in 3.0.34 it actually says 3.0.35 here).

Also bumping this to 3.0.35 as 3.0.34 will be pushed to nuget soon.