### PR TITLE
Update ReleaseAsync call to not pass the function cancellation token when there is an exception

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionExecutor.cs
@@ -345,7 +345,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
                             SingletonLock singleton = await parameterHelper.GetSingletonLockAsync();
                             if (singleton != null && singleton.IsHeld)
                             {
-                                await singleton.ReleaseAsync(cancellationToken);
+                                await singleton.ReleaseAsync(CancellationToken.None);
                             }
                         }
 

--- a/src/Microsoft.Azure.WebJobs.Host/Singleton/SingletonManager.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Singleton/SingletonManager.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Azure.WebJobs.Host
                 await handle.LeaseRenewalTimer.StopAsync(cancellationToken);
             }
 
-            await _lockManager.ReleaseLockAsync(handle.InnerLock, CancellationToken.None);
+            await _lockManager.ReleaseLockAsync(handle.InnerLock, cancellationToken);
 
             string msg = string.Format(CultureInfo.InvariantCulture, "Singleton lock released ({0})", handle.InnerLock.LockId);
             _logger?.LogDebug(msg);

--- a/src/Microsoft.Azure.WebJobs.Host/Singleton/SingletonManager.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Singleton/SingletonManager.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Azure.WebJobs.Host
                 await handle.LeaseRenewalTimer.StopAsync(cancellationToken);
             }
 
-            await _lockManager.ReleaseLockAsync(handle.InnerLock, cancellationToken);
+            await _lockManager.ReleaseLockAsync(handle.InnerLock, CancellationToken.None);
 
             string msg = string.Format(CultureInfo.InvariantCulture, "Singleton lock released ({0})", handle.InnerLock.LockId);
             _logger?.LogDebug(msg);

--- a/src/Microsoft.Azure.WebJobs.Host/Timers/TaskSeriesTimer.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Timers/TaskSeriesTimer.cs
@@ -72,11 +72,7 @@ namespace Microsoft.Azure.WebJobs.Host.Timers
                 throw new InvalidOperationException("The timer has already been stopped.");
             }
 
-            if (!_cancellationTokenSource.IsCancellationRequested)
-            {
-                _cancellationTokenSource.Cancel();
-            }
-
+            Cancel();
             return StopAsyncCore(cancellationToken);
         }
 
@@ -97,7 +93,11 @@ namespace Microsoft.Azure.WebJobs.Host.Timers
         public void Cancel()
         {
             ThrowIfDisposed();
-            _cancellationTokenSource.Cancel();
+
+            if (!_cancellationTokenSource.IsCancellationRequested)
+            {
+                _cancellationTokenSource.Cancel();
+            }
         }
 
         public void Dispose()

--- a/src/Microsoft.Azure.WebJobs.Host/Timers/TaskSeriesTimer.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Timers/TaskSeriesTimer.cs
@@ -72,7 +72,11 @@ namespace Microsoft.Azure.WebJobs.Host.Timers
                 throw new InvalidOperationException("The timer has already been stopped.");
             }
 
-            _cancellationTokenSource.Cancel();
+            if (!_cancellationTokenSource.IsCancellationRequested)
+            {
+                _cancellationTokenSource.Cancel();
+            }
+
             return StopAsyncCore(cancellationToken);
         }
 


### PR DESCRIPTION
resolves #2961

In the scenario where a function is using a `[Singleton]` attribute and the function cancellation token source is cancelled, we get an exception from Azure.Core when trying to release the singleton lock blob via `ReleaseLockAsync`. This is because we are passing in the function cancellation token through and it has already been cancelled. As a result, we end up calling the `ReleaseLockAsync` again for a second time which leads to another exception as we try to stop the lease renewal timer again.

I don't see any benefit to us passing our function cancellation token to the blob clients `ReleaseLockAsync` function. I feel in any scenario, we will want to release that singleton lock. I have updated the code to not pass in a cancellation token here. 

Open to better suggestions on how to address this.