### PR TITLE
Change RPC packages to 3.0.37

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Rpc/WebJobs.Extensions.Rpc.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Rpc/WebJobs.Extensions.Rpc.csproj
@@ -3,6 +3,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <Version>3.0.37$(VersionSuffix)</Version>
     <LangVersion>latest</LangVersion>
     <PackageId>Microsoft.Azure.WebJobs.Extensions.Rpc</PackageId>
     <AssemblyName>Microsoft.Azure.WebJobs.Extensions.Rpc</AssemblyName>

--- a/src/Microsoft.Azure.WebJobs.Rpc.Core/WebJobs.Rpc.Core.csproj
+++ b/src/Microsoft.Azure.WebJobs.Rpc.Core/WebJobs.Rpc.Core.csproj
@@ -3,6 +3,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <Version>3.0.37$(VersionSuffix)</Version>
     <LangVersion>latest</LangVersion>
     <PackageId>Microsoft.Azure.WebJobs.Rpc.Core</PackageId>
     <AssemblyName>Microsoft.Azure.WebJobs.Rpc.Core</AssemblyName>
@@ -11,7 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.Azure.WebJobs.Host\WebJobs.Host.csproj" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.37" />
+    <!-- <ProjectReference Include="..\Microsoft.Azure.WebJobs.Host\WebJobs.Host.csproj" /> -->
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is a temporary change so we can release these 2 new packages with the existing public WebJobs packages. Once released this change will be reverted.