### PR TITLE
Revert "Change RPC packages to 3.0.37"

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Rpc/WebJobs.Extensions.Rpc.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Rpc/WebJobs.Extensions.Rpc.csproj
@@ -3,7 +3,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>3.0.37$(VersionSuffix)</Version>
     <LangVersion>latest</LangVersion>
     <PackageId>Microsoft.Azure.WebJobs.Extensions.Rpc</PackageId>
     <AssemblyName>Microsoft.Azure.WebJobs.Extensions.Rpc</AssemblyName>

--- a/src/Microsoft.Azure.WebJobs.Rpc.Core/WebJobs.Rpc.Core.csproj
+++ b/src/Microsoft.Azure.WebJobs.Rpc.Core/WebJobs.Rpc.Core.csproj
@@ -3,7 +3,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>3.0.37$(VersionSuffix)</Version>
     <LangVersion>latest</LangVersion>
     <PackageId>Microsoft.Azure.WebJobs.Rpc.Core</PackageId>
     <AssemblyName>Microsoft.Azure.WebJobs.Rpc.Core</AssemblyName>
@@ -12,8 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.37" />
-    <!-- <ProjectReference Include="..\Microsoft.Azure.WebJobs.Host\WebJobs.Host.csproj" /> -->
+    <ProjectReference Include="..\Microsoft.Azure.WebJobs.Host\WebJobs.Host.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Reverts Azure/azure-webjobs-sdk#2998

The 3.0.37 package has been published to our internal feed. This change is no longer needed, reverting.