### PR TITLE
Adding ability to enable filters for live metrics in ApplicationInsights logging options

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
@@ -112,6 +112,13 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
         public DependencyTrackingOptions DependencyTrackingOptions { get; set; }
 
         /// <summary>
+        /// Gets or sets a value that filters logs before they are sent to Live Metrics. False by default.
+        /// When false, all logs are sent to Live Metrics, regardless of any log filter configuration. When true,
+        /// the logs are filtered before they are sent. Setting to true may yield better performance.
+        /// </summary>
+        public bool EnableLiveMetricsFilters { get; set; } = false;
+
+        /// <summary>
         /// Gets or sets HTTP request collection options. 
         /// </summary>
         public HttpAutoCollectionOptions HttpAutoCollectionOptions { get; set; } = new HttpAutoCollectionOptions();

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
         /// <summary>
         /// Gets or sets a value that filters logs before they are sent to Live Metrics. False by default.
         /// When false, all logs are sent to Live Metrics, regardless of any log filter configuration. When true,
-        /// the logs are filtered before they are sent. Setting to true may yield better performance.
+        /// the logs are filtered before they are sent.
         /// </summary>
         public bool EnableLiveMetricsFilters { get; set; } = false;
 

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsLoggingBuilderExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsLoggingBuilderExtensions.cs
@@ -8,6 +8,7 @@ using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Azure.WebJobs.Logging.ApplicationInsights;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Configuration;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.Logging
 {
@@ -62,14 +63,17 @@ namespace Microsoft.Extensions.Logging
             builder.Services.AddApplicationInsights(loggerOptionsConfiguration, additionalTelemetryConfiguration);
 
             builder.Services.AddOptions<LoggerFilterOptions>()
-                .PostConfigure<ApplicationInsightsLoggerOptions>((o, appInsightsOptions) =>
-            {
+                .PostConfigure<IOptions<ApplicationInsightsLoggerOptions>>((o, appInsightsOptions) =>
+                {
                 // The custom filtering below is only needed if we are sending all logs to Live Metrics.
                 // If we are filtering (or not using Live Metrics) we don't need to do this.
-                if (!appInsightsOptions.EnableLiveMetrics ||
-                    appInsightsOptions.EnableLiveMetricsFilters)
+                if (appInsightsOptions != null)
                 {
-                    return;
+                    if (!appInsightsOptions.Value.EnableLiveMetrics ||
+                        appInsightsOptions.Value.EnableLiveMetricsFilters)
+                    {
+                        return;
+                    }
                 }
 
                 // We want all logs to flow through the logger so they show up in QuickPulse.

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
@@ -341,15 +341,16 @@ namespace Microsoft.Extensions.DependencyInjection
 
             QuickPulseTelemetryProcessor quickPulseProcessor = null;
             configuration.TelemetryProcessorChainBuilder
-                .Use((next) => new OperationFilteringTelemetryProcessor(next))
-                .Use((next) =>
+                .Use((next) => new OperationFilteringTelemetryProcessor(next));
+
+            if (options.EnableLiveMetrics)
+            {
+                configuration.TelemetryProcessorChainBuilder.Use((next) =>
                 {
-                    if (options.EnableLiveMetrics)
-                    {
-                        quickPulseProcessor = new QuickPulseTelemetryProcessor(next);
-                    }
+                    quickPulseProcessor = new QuickPulseTelemetryProcessor(next);
                     return quickPulseProcessor;
                 });
+            }
 
             // No need to "late filter" as the logs will already be filtered before they are sent to the Logger.
             if (filterOptions != null)

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
@@ -344,7 +344,10 @@ namespace Microsoft.Extensions.DependencyInjection
                 .Use((next) => new OperationFilteringTelemetryProcessor(next))
                 .Use((next) =>
                 {
-                    quickPulseProcessor = new QuickPulseTelemetryProcessor(next);
+                    if (options.EnableLiveMetrics)
+                    {
+                        quickPulseProcessor = new QuickPulseTelemetryProcessor(next);
+                    }
                     return quickPulseProcessor;
                 });
 

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
@@ -230,6 +230,27 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             }
         }
 
+        
+        [Fact]
+        public void DependencyInjectionConfiguration_EnableLiveMetricsFilters()
+        {
+            using (var host = new HostBuilder()
+                .ConfigureLogging(b =>
+                {
+                    b.AddApplicationInsightsWebJobs(o =>
+                    {
+                        o.InstrumentationKey = "some key";
+                        o.EnableLiveMetricsFilters = true;
+                    });
+                })
+                .Build())
+            {
+                var config = host.Services.GetService<TelemetryConfiguration>();
+                Assert.Equal(3, config.TelemetryProcessors.Count);
+                Assert.IsType<OperationFilteringTelemetryProcessor>(config.TelemetryProcessors[0]);
+                Assert.IsType<QuickPulseTelemetryProcessor>(config.TelemetryProcessors[1]);
+              }
+        }
 
         [Fact]
         public void DependencyInjectionConfiguration_ConfiguresRequestCollectionOptions()
@@ -676,6 +697,46 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
 
                 // ikey should still be set
                 Assert.Equal("some key", TelemetryConfiguration.Active.InstrumentationKey);
+            }
+        }
+
+        [Fact]
+        public void CreateFilterOptions_EnableLiveMetricsFilters()
+        {
+            using (var host = new HostBuilder()
+                .ConfigureLogging(b =>
+                {
+                    b.AddApplicationInsightsWebJobs(o =>
+                    {
+                        o.InstrumentationKey = "some key";
+                        o.EnableLiveMetricsFilters = true;
+                    });
+                })
+                .Build())
+            {
+                var filterOptions = host.Services.GetService<IOptions<LoggerFilterOptions>>().Value;
+                var rule = SelectAppInsightsRule(filterOptions, "Category");
+                Assert.Equal(null, rule.Filter);
+            }
+        }
+
+        [Fact]
+        public void CreateFilterOptions_DisableLiveMetrics()
+        {
+            using (var host = new HostBuilder()
+                .ConfigureLogging(b =>
+                {
+                    b.AddApplicationInsightsWebJobs(o =>
+                    {
+                        o.InstrumentationKey = "some key";
+                        o.EnableLiveMetrics = false;
+                    });
+                })
+                .Build())
+            {
+                var filterOptions = host.Services.GetService<IOptions<LoggerFilterOptions>>().Value;
+                var rule = SelectAppInsightsRule(filterOptions, "Category");
+                Assert.Equal(null, rule.Filter);
             }
         }
 


### PR DESCRIPTION
Issue related to PR - https://github.com/Azure/azure-functions-host/issues/8973

Writeup for the changes - https://github.com/Azure/azure-functions-host/issues/8973#issuecomment-1636192111

Adding a setting `EnableLiveMetricsFilters` that filters logs before they are sent to Live Metrics.
- When false, all logs are sent to Live Metrics, regardless of any log filter configuration. 
- When true, the logs are filtered before they are sent. Setting to true may yield better performance.
