### PR TITLE
Added EnableLiveMetricsFilters in logger options

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
@@ -199,6 +199,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                 { nameof(HttpAutoCollectionOptions), httpOptions },
                 { nameof(LiveMetricsInitializationDelay), LiveMetricsInitializationDelay },
                 { nameof(EnableLiveMetrics), EnableLiveMetrics },
+                { nameof(EnableLiveMetricsFilters), EnableLiveMetricsFilters },
                 { nameof(EnableDependencyTracking), EnableDependencyTracking },
                 { nameof(DependencyTrackingOptions), dependencyTrackingOptions }
             };

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsLoggerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsLoggerTests.cs
@@ -683,6 +683,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
         {
             var options = new ApplicationInsightsLoggerOptions
             {
+                EnableLiveMetrics = true,
+                EnableLiveMetricsFilters = true,
                 SamplingSettings = new SamplingPercentageEstimatorSettings()
                 {
                     EvaluationInterval = TimeSpan.FromHours(1),
@@ -773,6 +775,9 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             Assert.Equal(options.DependencyTrackingOptions.EnableLegacyCorrelationHeadersInjection, deserializedOptions.DependencyTrackingOptions.EnableLegacyCorrelationHeadersInjection);
             Assert.Equal(options.DependencyTrackingOptions.EnableRequestIdHeaderInjectionInW3CMode, deserializedOptions.DependencyTrackingOptions.EnableRequestIdHeaderInjectionInW3CMode);
             Assert.Equal(options.DependencyTrackingOptions.EnableSqlCommandTextInstrumentation, deserializedOptions.DependencyTrackingOptions.EnableSqlCommandTextInstrumentation);
+
+            Assert.Equal(options.EnableLiveMetrics, deserializedOptions.EnableLiveMetrics);
+            Assert.Equal(options.EnableLiveMetricsFilters, deserializedOptions.EnableLiveMetricsFilters);
         }
 
         [Fact]


### PR DESCRIPTION
Adding EnableLiveMetricsFilters in logger options for supportability

Issue - https://github.com/Azure/azure-functions-host/issues/9408