### PR TITLE
Add structured logging support to custom log states

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/Aggregator/FunctionResultAggregate.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/Aggregator/FunctionResultAggregate.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
 
 namespace Microsoft.Azure.WebJobs.Logging
 {
@@ -18,21 +16,5 @@ namespace Microsoft.Azure.WebJobs.Logging
         public int Failures { get; set; }
         public int Count => Successes + Failures;
         public double SuccessRate => Math.Round((Successes / (double)Count) * 100, 2);
-
-        public IReadOnlyDictionary<string, object> ToReadOnlyDictionary()
-        {
-            return new ReadOnlyDictionary<string, object>(new Dictionary<string, object>
-            {
-                [LogConstants.NameKey] = Name,
-                [LogConstants.CountKey] = Count,
-                [LogConstants.TimestampKey] = Timestamp,
-                [LogConstants.AverageDurationKey] = AverageDuration,
-                [LogConstants.MaxDurationKey] = MaxDuration,
-                [LogConstants.MinDurationKey] = MinDuration,
-                [LogConstants.SuccessesKey] = Successes,
-                [LogConstants.FailuresKey] = Failures,
-                [LogConstants.SuccessRateKey] = SuccessRate
-            });
-        }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/LoggerExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/LoggerExtensions.cs
@@ -200,7 +200,7 @@ namespace Microsoft.Extensions.Logging
                 LogConstants.MetricEventId,
                 new MetricState(name, value, properties),
                 null,
-                static (s, e) => s.ToString());
+                static (s, e) => null);
         }
 
         internal static void LogFunctionResult(this ILogger logger, FunctionInstanceLogEntry logEntry)
@@ -214,7 +214,7 @@ namespace Microsoft.Extensions.Logging
                 0,
                 new FunctionResultState(logEntry, succeeded),
                 logEntry.Exception,
-                static (s, e) => s.ToString());
+                static (s, e) => null);
         }
 
         internal static void LogFunctionResultAggregate(this ILogger logger, FunctionResultAggregate resultAggregate)
@@ -224,7 +224,7 @@ namespace Microsoft.Extensions.Logging
                 0,
                 new FunctionResultAggregateState(resultAggregate),
                 null,
-                static (s, e) => s.ToString());
+                static (s, e) => null);
         }
 
         internal static IDisposable BeginFunctionScope(this ILogger logger, IFunctionInstance functionInstance, Guid hostInstanceId)

--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/LoggerExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/LoggerExtensions.cs
@@ -200,7 +200,7 @@ namespace Microsoft.Extensions.Logging
                 LogConstants.MetricEventId,
                 new MetricState(name, value, properties),
                 null,
-                (s, e) => s.ToString());
+                static (s, e) => s.ToString());
         }
 
         internal static void LogFunctionResult(this ILogger logger, FunctionInstanceLogEntry logEntry)
@@ -224,7 +224,7 @@ namespace Microsoft.Extensions.Logging
                 0,
                 new FunctionResultAggregateState(resultAggregate),
                 null,
-                (s, e) => s.ToString());
+                static (s, e) => s.ToString());
         }
 
         internal static IDisposable BeginFunctionScope(this ILogger logger, IFunctionInstance functionInstance, Guid hostInstanceId)

--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/States/FunctionResultAggregateState.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/States/FunctionResultAggregateState.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.WebJobs.Logging
+{
+    internal readonly struct FunctionResultAggregateState : IReadOnlyList<KeyValuePair<string, object>>
+    {
+        public const string OriginalFormatString = "FunctionResultAggregate {Name} {Count} {Timestamp} {AvgDurationMs}ms {MaxDurationMs}ms {MinDurationMs}ms {Successes} {Failures} {SuccessRate}";
+        private readonly FunctionResultAggregate _resultAggregate;
+
+        public FunctionResultAggregateState(FunctionResultAggregate resultAggregate)
+        {
+            _resultAggregate = resultAggregate;
+        }
+
+        public KeyValuePair<string, object> this[int index]
+        {
+            get
+            {
+                return index switch
+                {
+                    0 => new KeyValuePair<string, object>(LogConstants.NameKey, _resultAggregate.Name),
+                    1 => new KeyValuePair<string, object>(LogConstants.CountKey, _resultAggregate.Count),
+                    2 => new KeyValuePair<string, object>(LogConstants.TimestampKey, _resultAggregate.Timestamp),
+                    3 => new KeyValuePair<string, object>(LogConstants.AverageDurationKey, _resultAggregate.AverageDuration),
+                    4 => new KeyValuePair<string, object>(LogConstants.MaxDurationKey, _resultAggregate.MaxDuration),
+                    5 => new KeyValuePair<string, object>(LogConstants.MinDurationKey, _resultAggregate.MinDuration),
+                    6 => new KeyValuePair<string, object>(LogConstants.SuccessesKey, _resultAggregate.Successes),
+                    7 => new KeyValuePair<string, object>(LogConstants.FailuresKey, _resultAggregate.Failures),
+                    8 => new KeyValuePair<string, object>(LogConstants.SuccessRateKey, _resultAggregate.SuccessRate),
+                    9 => new KeyValuePair<string, object>(LogConstants.OriginalFormatKey, OriginalFormatString),
+                    _ => throw new ArgumentOutOfRangeException(nameof(index)),
+                };
+            }
+        }
+
+        public int Count => 10;
+
+        public Enumerator GetEnumerator() => new Enumerator(this);
+
+        IEnumerator<KeyValuePair<string, object>> IEnumerable<KeyValuePair<string, object>>.GetEnumerator()
+            => GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator()
+            => GetEnumerator();
+
+        public override string ToString()
+        {
+            return $"FunctionResultAggregate {_resultAggregate.Name} {_resultAggregate.Count} {_resultAggregate.Timestamp} {_resultAggregate.AverageDuration}ms {_resultAggregate.MaxDuration}ms {_resultAggregate.MinDuration}ms {_resultAggregate.Successes} {_resultAggregate.Failures} {_resultAggregate.SuccessRate}";
+        }
+
+        public struct Enumerator : IEnumerator<KeyValuePair<string, object>>
+        {
+            private readonly FunctionResultAggregateState _state;
+            private int _index = -1;
+
+            public Enumerator(FunctionResultAggregateState state)
+            {
+                _state = state;
+            }
+
+            public readonly KeyValuePair<string, object> Current
+                => _state[_index];
+
+            readonly object IEnumerator.Current => Current;
+
+            public readonly void Dispose()
+            {
+            }
+
+            public bool MoveNext()
+            {
+                return ++_index < _state.Count;
+            }
+
+            public readonly void Reset()
+            {
+                throw new NotSupportedException();
+            }
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/States/FunctionResultAggregateState.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/States/FunctionResultAggregateState.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.WebJobs.Logging
 {
     internal readonly struct FunctionResultAggregateState : IReadOnlyList<KeyValuePair<string, object>>
     {
-        public const string OriginalFormatString = "FunctionResultAggregate {Name} {Count} {Timestamp} {AvgDurationMs}ms {MaxDurationMs}ms {MinDurationMs}ms {Successes} {Failures} {SuccessRate}";
+        public const string OriginalFormatString = "Aggregate result (function={Name}, count={Count}, time={Timestamp}, duration={AverageDuration}ms, maxDuration={MaxDuration}ms, minDuration={MinDuration}ms, success={Successes}, failure={Failures}, rate={SuccessRate})";
         private readonly FunctionResultAggregate _resultAggregate;
 
         public FunctionResultAggregateState(FunctionResultAggregate resultAggregate)
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.WebJobs.Logging
 
         public override string ToString()
         {
-            return $"FunctionResultAggregate {_resultAggregate.Name} {_resultAggregate.Count} {_resultAggregate.Timestamp} {_resultAggregate.AverageDuration}ms {_resultAggregate.MaxDuration}ms {_resultAggregate.MinDuration}ms {_resultAggregate.Successes} {_resultAggregate.Failures} {_resultAggregate.SuccessRate}";
+            return $"Aggregate result (function={_resultAggregate.Name}, count={_resultAggregate.Count}, time={_resultAggregate.Timestamp}, duration={_resultAggregate.AverageDuration}ms, maxDuration={_resultAggregate.MaxDuration}ms, minDuration={_resultAggregate.MinDuration}ms, success={_resultAggregate.Successes}, failure={_resultAggregate.Failures}, rate={_resultAggregate.SuccessRate})";
         }
 
         public struct Enumerator : IEnumerator<KeyValuePair<string, object>>

--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/States/FunctionResultState.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/States/FunctionResultState.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.WebJobs.Host.Loggers;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.WebJobs.Logging
+{
+    internal readonly struct FunctionResultState : IReadOnlyList<KeyValuePair<string, object>>
+    {
+        public const string OriginalFormatString = "FunctionResult {FullName} {InvocationId} {Name} {TriggerReason} {StartTime} {EndTime} {Duration} {Succeeded}";
+        private readonly FunctionInstanceLogEntry _logEntry;
+        private readonly bool _succeeded;
+
+        public FunctionResultState(FunctionInstanceLogEntry logEntry, bool succeeded)
+        {
+            _logEntry = logEntry;
+            _succeeded = succeeded;
+        }
+
+        public KeyValuePair<string, object> this[int index]
+        {
+            get
+            {
+                return index switch
+                {
+                    0 => new KeyValuePair<string, object>(LogConstants.FullNameKey, _logEntry.FunctionName),
+                    1 => new KeyValuePair<string, object>(LogConstants.InvocationIdKey, _logEntry.FunctionInstanceId),
+                    2 => new KeyValuePair<string, object>(LogConstants.NameKey, _logEntry.LogName),
+                    3 => new KeyValuePair<string, object>(LogConstants.TriggerReasonKey, _logEntry.TriggerReason),
+                    4 => new KeyValuePair<string, object>(LogConstants.StartTimeKey, _logEntry.StartTime),
+                    5 => new KeyValuePair<string, object>(LogConstants.EndTimeKey, _logEntry.EndTime),
+                    6 => new KeyValuePair<string, object>(LogConstants.DurationKey, _logEntry.Duration),
+                    7 => new KeyValuePair<string, object>(LogConstants.SucceededKey, _succeeded),
+                    8 => new KeyValuePair<string, object>(LogConstants.OriginalFormatKey, OriginalFormatString),
+                    _ => throw new ArgumentOutOfRangeException(nameof(index)),
+                };
+            }
+        }
+
+        public int Count => 9;
+
+        public Enumerator GetEnumerator() => new Enumerator(this);
+
+        IEnumerator<KeyValuePair<string, object>> IEnumerable<KeyValuePair<string, object>>.GetEnumerator()
+            => GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator()
+            => GetEnumerator();
+
+        public override string ToString()
+        {
+            return $"FunctionResult {_logEntry.FunctionName} {_logEntry.FunctionInstanceId} {_logEntry.LogName} {_logEntry.TriggerReason} {_logEntry.StartTime} {_logEntry.EndTime} {_logEntry.Duration} {_succeeded}";
+        }
+
+        public struct Enumerator : IEnumerator<KeyValuePair<string, object>>
+        {
+            private readonly FunctionResultState _state;
+            private int _index = -1;
+
+            public Enumerator(FunctionResultState state)
+            {
+                _state = state;
+            }
+
+            public readonly KeyValuePair<string, object> Current
+                => _state[_index];
+
+            readonly object IEnumerator.Current => Current;
+
+            public readonly void Dispose()
+            {
+            }
+
+            public bool MoveNext()
+            {
+                return ++_index < _state.Count;
+            }
+
+            public readonly void Reset()
+            {
+                throw new NotSupportedException();
+            }
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/States/FunctionResultState.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/States/FunctionResultState.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.WebJobs.Logging
 {
     internal readonly struct FunctionResultState : IReadOnlyList<KeyValuePair<string, object>>
     {
-        public const string OriginalFormatString = "FunctionResult {FullName} {InvocationId} {Name} {TriggerReason} {StartTime} {EndTime} {Duration} {Succeeded}";
+        public const string OriginalFormatString = "Result '{FunctionName}' (started at={StartTime}, duration={Duration}, succeeded={Succeeded})";
         private readonly FunctionInstanceLogEntry _logEntry;
         private readonly bool _succeeded;
 
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.WebJobs.Logging
 
         public override string ToString()
         {
-            return $"FunctionResult {_logEntry.FunctionName} {_logEntry.FunctionInstanceId} {_logEntry.LogName} {_logEntry.TriggerReason} {_logEntry.StartTime} {_logEntry.EndTime} {_logEntry.Duration} {_succeeded}";
+            return $"Result '{_logEntry.FunctionName}' (started at={_logEntry.StartTime}, duration={_logEntry.Duration}, succeeded={_succeeded})";
         }
 
         public struct Enumerator : IEnumerator<KeyValuePair<string, object>>

--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/States/MetricState.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/States/MetricState.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Azure.WebJobs.Logging
+{
+    internal readonly struct MetricState : IReadOnlyList<KeyValuePair<string, object>>
+    {
+        public const string OriginalFormatString = "Metric {Name} {Value}";
+        private readonly string _name;
+        private readonly double _value;
+        private readonly IReadOnlyList<KeyValuePair<string, object>> _properties;
+
+        public MetricState(string name, double value, IDictionary<string, object> properties)
+        {
+            _name = name;
+            _value = value;
+            _properties = properties?.ToList();
+        }
+
+        public KeyValuePair<string, object> this[int index]
+        {
+            get
+            {
+                if (index == 0)
+                {
+                    return new KeyValuePair<string, object>(LogConstants.NameKey, _name);
+                }
+
+                if (index == 1)
+                {
+                    return new KeyValuePair<string, object>(LogConstants.MetricValueKey, _value);
+                }
+
+                index -= 2;
+
+                if (_properties != null)
+                {
+                    if (index < _properties.Count)
+                    {
+                        return _properties[index];
+                    }
+
+                    index -= _properties.Count;
+                }
+
+                if (index == 0)
+                {
+                    return new KeyValuePair<string, object>(LogConstants.OriginalFormatKey, OriginalFormatString);
+                }
+
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+        }
+
+        public int Count => 3 + (_properties?.Count ?? 0);
+
+        public Enumerator GetEnumerator() => new Enumerator(this);
+
+        IEnumerator<KeyValuePair<string, object>> IEnumerable<KeyValuePair<string, object>>.GetEnumerator()
+            => GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator()
+            => GetEnumerator();
+
+        public override string ToString()
+        {
+            return $"Metric {_name} {_value}";
+        }
+
+        public struct Enumerator : IEnumerator<KeyValuePair<string, object>>
+        {
+            private readonly MetricState _state;
+            private int _index = -1;
+
+            public Enumerator(MetricState state)
+            {
+                _state = state;
+            }
+
+            public readonly KeyValuePair<string, object> Current
+                => _state[_index];
+
+            readonly object IEnumerator.Current => Current;
+
+            public readonly void Dispose()
+            {
+            }
+
+            public bool MoveNext()
+            {
+                return ++_index < _state.Count;
+            }
+
+            public readonly void Reset()
+            {
+                throw new NotSupportedException();
+            }
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/LoggerExtensionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/LoggerExtensionsTests.cs
@@ -37,13 +37,13 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
         public void LogFunctionResult_Succeeded_CreatesCorrectState()
         {
             int logCount = 0;
-            ILogger logger = CreateMockLogger<IDictionary<string, object>>((l, e, o, ex, f) =>
+            ILogger logger = CreateMockLogger<FunctionResultState>((l, e, o, ex, f) =>
              {
                  logCount++;
                  Assert.Equal(LogLevel.Information, l);
                  Assert.Equal(0, e);
                  Assert.Null(ex);
-                 Assert.Null(f(o, ex));
+                 Assert.NotNull(f(o, ex));
 
                  var payload = VerifyResultDefaultsAndConvert(o);
                  Assert.True((bool)payload[LogConstants.SucceededKey]);
@@ -60,14 +60,14 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
         public void LogFunctionResult_Failed_CreatesCorrectState()
         {
             int logCount = 0;
-            ILogger logger = CreateMockLogger<IDictionary<string, object>>((l, e, o, ex, f) =>
+            ILogger logger = CreateMockLogger<FunctionResultState>((l, e, o, ex, f) =>
              {
                  logCount++;
                  Assert.Equal(LogLevel.Error, l);
                  Assert.Equal(0, e);
                  Assert.NotNull(ex);
                  Assert.IsType<FunctionInvocationException>(ex);
-                 Assert.Null(f(o, ex));
+                 Assert.NotNull(f(o, ex));
 
                  var payload = VerifyResultDefaultsAndConvert(o);
                  Assert.False((bool)payload[LogConstants.SucceededKey]);
@@ -86,17 +86,20 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
         {
             DateTimeOffset now = DateTimeOffset.Now;
             int logCount = 0;
-            ILogger logger = CreateMockLogger<IReadOnlyDictionary<string, object>>((l, e, payload, ex, f) =>
+            ILogger logger = CreateMockLogger<FunctionResultAggregateState>((l, e, s, ex, f) =>
             {
+                var enumerable = s as IEnumerable<KeyValuePair<string, object>>;
+                Assert.NotNull(enumerable);
+
+                var payload = enumerable.ToDictionary(k => k.Key, v => v.Value);
+
                 logCount++;
                 Assert.Equal(LogLevel.Information, l);
                 Assert.Equal(0, e);
                 Assert.Null(ex);
+                Assert.NotNull(f(s, ex));
 
-                // nothing logged
-                Assert.Null(f(payload, ex));
-
-                Assert.Equal(9, payload.Count);
+                Assert.Equal(10, payload.Count);
                 Assert.Equal(_functionShortName, payload[LogConstants.NameKey]);
                 Assert.Equal(4, payload[LogConstants.FailuresKey]);
                 Assert.Equal(116, payload[LogConstants.SuccessesKey]);
@@ -106,6 +109,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                 Assert.Equal(now, payload[LogConstants.TimestampKey]);
                 Assert.Equal(120, payload[LogConstants.CountKey]);
                 Assert.Equal(96.67, payload[LogConstants.SuccessRateKey]);
+                Assert.Equal(FunctionResultAggregateState.OriginalFormatString, payload[LogConstants.OriginalFormatKey]);
             });
 
             var resultAggregate = new FunctionResultAggregate
@@ -143,14 +147,14 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             };
         }
 
-        private IDictionary<string, object> VerifyResultDefaultsAndConvert<TState>(TState state)
+        private IDictionary<string, object> VerifyResultDefaultsAndConvert(FunctionResultState state)
         {
             var enumerable = state as IEnumerable<KeyValuePair<string, object>>;
             Assert.NotNull(enumerable);
 
             var payload = enumerable.ToDictionary(k => k.Key, v => v.Value);
 
-            Assert.Equal(8, payload.Count);
+            Assert.Equal(9, payload.Count);
             Assert.Equal(_functionFullName, payload[LogConstants.FullNameKey]);
             Assert.Equal(_functionShortName, payload[LogConstants.NameKey]);
             Assert.Equal(_invocationId, payload[LogConstants.InvocationIdKey]);
@@ -158,6 +162,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             Assert.Equal(_endTime, payload[LogConstants.EndTimeKey]);
             Assert.Equal(_duration, payload[LogConstants.DurationKey]);
             Assert.Equal(_triggerReason, payload[LogConstants.TriggerReasonKey]);
+            Assert.Equal(FunctionResultState.OriginalFormatString, payload[LogConstants.OriginalFormatKey]);
 
             // verify that we no longer log parameters
             var args = payload.Where(kvp => kvp.Key.ToString().StartsWith(LogConstants.ParameterPrefix));

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/LoggerExtensionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/LoggerExtensionsTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                  Assert.Equal(LogLevel.Information, l);
                  Assert.Equal(0, e);
                  Assert.Null(ex);
-                 Assert.NotNull(f(o, ex));
+                 Assert.Null(f(o, ex));
 
                  var payload = VerifyResultDefaultsAndConvert(o);
                  Assert.True((bool)payload[LogConstants.SucceededKey]);
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                  Assert.Equal(0, e);
                  Assert.NotNull(ex);
                  Assert.IsType<FunctionInvocationException>(ex);
-                 Assert.NotNull(f(o, ex));
+                 Assert.Null(f(o, ex));
 
                  var payload = VerifyResultDefaultsAndConvert(o);
                  Assert.False((bool)payload[LogConstants.SucceededKey]);
@@ -97,7 +97,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                 Assert.Equal(LogLevel.Information, l);
                 Assert.Equal(0, e);
                 Assert.Null(ex);
-                Assert.NotNull(f(s, ex));
+                Assert.Null(f(s, ex));
 
                 Assert.Equal(10, payload.Count);
                 Assert.Equal(_functionShortName, payload[LogConstants.NameKey]);


### PR DESCRIPTION
This PR updates the LogMetric, LogFunctionResult, LogFunctionResultAggregate ILogger extensions to use TStates which support structured logging:

* `{OriginalFormat}` attribute is added as the last KVP which contains a template for these logs.
* A formatter is provided which will generate formatted messages based on the template if called.

The reason for this is OpenTelemetry is implemented as an ILoggerProvider and it kind of barfs on the existing states which do not implement the typical structured logging state contract. Implementing this structure will make these logs work better with OpenTelemetry and likely many other ILoggerProvider implementations. See: https://github.com/Azure/azure-sdk-for-net/issues/37832

This is similar to: https://github.com/dotnet/aspnetcore/pull/45253