### PR TITLE
Enum TryParse speedup

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/LogLevelExtension.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/LogLevelExtension.cs
@@ -34,5 +34,41 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights.Extensions
                     return logLevel.ToString(CultureInfo.InvariantCulture);
             }
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool TryParseOptimized(this string logLevel, out LogLevel level)
+        {
+            switch (logLevel)
+            {
+                case "Trace":
+                    level = LogLevel.Trace;
+                    break;
+                case "Debug":
+                    level = LogLevel.Debug;
+                    break;
+                case "Information":
+                    level = LogLevel.Information;
+                    break;
+                case "Warning":
+                    level = LogLevel.Warning;
+                    break;
+                case "Error":
+                    level = LogLevel.Error;
+                    break;
+                case "Critical":
+                    level = LogLevel.Critical;
+                    break;
+                case "None":
+                    level = LogLevel.None;
+                    break;
+                default:
+                    if (!Enum.TryParse(logLevel, out level))
+                    {
+                        return false;
+                    }
+                    break;
+            }
+            return true;
+        }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Processors/FilteringTelemetryProcessor.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Processors/FilteringTelemetryProcessor.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.Azure.WebJobs.Logging.ApplicationInsights.Extensions;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
@@ -47,7 +48,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
 
                 // Extract the log level and apply the filter
                 if (telemetry.Properties.TryGetValue(LogConstants.LogLevelKey, out string logLevelString) &&
-                    Enum.TryParse(logLevelString, out LogLevel logLevel))
+                    LogLevelExtension.TryParseOptimized(logLevelString, out LogLevel logLevel))
                 {
                     LoggerFilterRule filterRule = _ruleMap.GetOrAdd(categoryName, c => SelectRule(c));
 


### PR DESCRIPTION
Small improvement to a call to Enum.TryParse for LogLevel in a telemetry filter. Should make this call ~20x more performant and reduce memory use to 0b