### PR TITLE
Adding IListenerDecorator support

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostContextFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/JobHostContextFactory.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
         private readonly IDrainModeManager _drainModeManager;
         private readonly IApplicationLifetime _applicationLifetime;
         private readonly ITargetScalerManager _targetScalerManager;
+        private readonly IEnumerable<IListenerDecorator> _listenerDecorators;
 
         public JobHostContextFactory(
             IDashboardLoggingSetup dashboardLoggingSetup,
@@ -75,7 +76,8 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             IScaleMonitorManager monitorManager,
             IDrainModeManager drainModeManager,
             IApplicationLifetime applicationLifetime,
-            ITargetScalerManager targetScalerManager)
+            ITargetScalerManager targetScalerManager,
+            IEnumerable<IListenerDecorator> listenerDecorators)
         {
             _dashboardLoggingSetup = dashboardLoggingSetup;
             _functionExecutor = functionExecutor;
@@ -99,6 +101,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             _drainModeManager = drainModeManager;
             _applicationLifetime = applicationLifetime;
             _targetScalerManager = targetScalerManager;
+            _listenerDecorators = listenerDecorators;
         }
 
         public async Task<JobHostContext> Create(JobHost host, CancellationToken shutdownToken, CancellationToken cancellationToken)
@@ -127,8 +130,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
                     // they are started).
                     host.OnHostInitialized();
                 };
-                IListenerFactory functionsListenerFactory = new HostListenerFactory(functions.ReadAll(), _singletonManager, _activator, _nameResolver, _loggerFactory,
-                    _monitorManager, _targetScalerManager, listenersCreatedCallback, _jobHostOptions.Value.AllowPartialHostStartup, _drainModeManager);
+                IListenerFactory functionsListenerFactory = new HostListenerFactory(functions.ReadAll(), _loggerFactory, _monitorManager, _targetScalerManager, _listenerDecorators, listenersCreatedCallback, _drainModeManager);
 
                 string hostId = await _hostIdProvider.GetHostIdAsync(cancellationToken);
                 bool dashboardLoggingEnabled = _dashboardLoggingSetup.Setup(functions, functionsListenerFactory, out IFunctionExecutor hostCallExecutor,

--- a/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsServiceCollectionExtensions.cs
@@ -128,6 +128,8 @@ namespace Microsoft.Azure.WebJobs
             services.TryAddSingleton<ConcurrencyManager>();
             services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, ConcurrencyManagerService>());
 
+            AddListenerDecorators(services);
+
             services.ConfigureOptions<ConcurrencyOptionsSetup>();
             services.ConfigureOptions<PrimaryHostCoordinatorOptionsSetup>();
             services.AddOptions<ConcurrencyOptions>()
@@ -209,6 +211,14 @@ namespace Microsoft.Azure.WebJobs
             services.AddSingleton<IOptionsLoggingSource, OptionsLoggingSource>();
             services.AddSingleton<IHostedService, OptionsLoggingService>();
             services.AddSingleton<IOptionsFormatter<LoggerFilterOptions>, LoggerFilterOptionsFormatter>();
+        }
+
+        private static void AddListenerDecorators(IServiceCollection services)
+        {
+            // Order is important for these platform decorator registrations!
+            // They will be applied in this order after any user registered decorators.
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IListenerDecorator, SingletonListenerDecorator>());
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IListenerDecorator, FunctionListenerDecorator>());
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Listeners/FunctionListenerDecorator.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Listeners/FunctionListenerDecorator.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.WebJobs.Host.Listeners
+{
+    internal class FunctionListenerDecorator : IListenerDecorator
+    {
+        private readonly ILoggerFactory _loggerFactory;
+        private readonly IOptions<JobHostOptions> _jobHostOptions;
+
+        public FunctionListenerDecorator(ILoggerFactory loggerFactory, IOptions<JobHostOptions> jobHostOptions)
+        {
+            _loggerFactory = loggerFactory;
+            _jobHostOptions = jobHostOptions;
+        }
+
+        public IListener Decorate(ListenerDecoratorContext context)
+        {
+            // wrap the listener with a function listener to handle exceptions
+            bool allowPartialHostStartup = _jobHostOptions.Value.AllowPartialHostStartup;
+            return new FunctionListener(context.Listener, context.FunctionDefinition.Descriptor, _loggerFactory, allowPartialHostStartup);
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Listeners/IListenerDecorator.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Listeners/IListenerDecorator.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Host.Listeners
+{
+    /// <summary>
+    /// Custom decorator interface called during <see cref="JobHost"/> listener creation to
+    /// allow function listeners to be customized.
+    /// </summary>
+    public interface IListenerDecorator
+    {
+        /// <summary>
+        /// Creates a listener.
+        /// </summary>
+        /// <param name="context">The listener context.</param>
+        /// <returns>The listener to use. This may be a new wrapped listener, or the original
+        /// listener.</returns>
+        IListener Decorate(ListenerDecoratorContext context);
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Listeners/ListenerDecoratorContext.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Listeners/ListenerDecoratorContext.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.WebJobs.Host.Indexers;
+using System;
+
+namespace Microsoft.Azure.WebJobs.Host.Listeners
+{
+    /// <summary>
+    /// Context class for <see cref="IListenerDecorator.Decorate(ListenerDecoratorContext)"/>.
+    /// </summary>
+    public class ListenerDecoratorContext
+    {
+        /// <summary>
+        /// Constructs an instance.
+        /// </summary>
+        /// <param name="functionDefinition">The function the specified listener is for.</param>
+        /// <param name="rootListenerType">Gets the type of the root listener.</param>
+        /// <param name="listener">The listener to decorate.</param>
+        public ListenerDecoratorContext(IFunctionDefinition functionDefinition, Type rootListenerType, IListener listener)
+        {
+            FunctionDefinition = functionDefinition;
+            ListenerType = rootListenerType;
+            Listener = listener;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="IFunctionDefinition"/> the specified listener is for.
+        /// </summary>
+        public IFunctionDefinition FunctionDefinition { get; }
+
+        /// <summary>
+        /// Gets the listener to decorate.
+        /// </summary>
+        public IListener Listener { get; }
+
+        /// <summary>
+        /// Gets the type of the root listener.
+        /// </summary>
+        public Type ListenerType { get; }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Listeners/SingletonListenerDecorator.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Listeners/SingletonListenerDecorator.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Host.Listeners
+{
+    internal class SingletonListenerDecorator : IListenerDecorator
+    {
+        private readonly SingletonManager _singletonManager;
+        private readonly ILoggerFactory _loggerFactory;
+
+        public SingletonListenerDecorator(SingletonManager singletonManager, ILoggerFactory loggerFactory) 
+        {
+            _singletonManager = singletonManager;
+            _loggerFactory = loggerFactory;
+        }
+
+        public IListener Decorate(ListenerDecoratorContext context)
+        {
+            var functionDescriptor = context.FunctionDefinition.Descriptor;
+
+            // if the listener is a Singleton, wrap it with our SingletonListener
+            IListener listener = context.Listener;
+            SingletonAttribute singletonAttribute = SingletonManager.GetListenerSingletonOrNull(context.ListenerType, functionDescriptor);
+            if (singletonAttribute != null)
+            {
+                listener = new SingletonListener(functionDescriptor, singletonAttribute, _singletonManager, listener, _loggerFactory);
+            }
+
+            return listener;
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
@@ -310,7 +310,9 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 "IScaleStatusProvider",
                 "ScaleOptions",
                 "TriggerMetadata",
-                "AggregateScaleStatus"
+                "AggregateScaleStatus",
+                "IListenerDecorator",
+                "ListenerDecoratorContext"
             };
 
             TestHelpers.AssertPublicTypes(expected, assembly);


### PR DESCRIPTION
Exposing a new decorator feature for layering of listener behaviors. I've refactored a couple of our existing platform listener behaviors (singleton and function listener error handling) on top of this new feature to prove it out.

The Logic Apps team will be using this feature to implement some new advanced features in their extension, requiring dynamic listener behaviors. The decorators feature will allow them to add that.