### PR TITLE
Add option to log the URL query string for HTTP functions to LoggerOptions

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
@@ -124,9 +124,9 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
         public HttpAutoCollectionOptions HttpAutoCollectionOptions { get; set; } = new HttpAutoCollectionOptions();
 
         /// <summary>
-        /// Gets or sets a value that removes the query parameters from functions URLs. True by default.
-        /// When true, the query parameters are stripped off of the functions URL for logging HTTP trigger calls.
-        /// When false, query parameters are logged.
+        /// Gets or sets a value that removes the query parameters from functions URLs. False by default.
+        /// When false (default), the query parameters are stripped off of the functions URL for logging HTTP trigger calls.
+        /// When true, query parameters are logged.
         /// </summary>
         public bool EnableQueryStringTracing { get; set; } = false;
 

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
         /// When true, the query parameters are stripped off of the functions URL for logging HTTP trigger calls.
         /// When false, query parameters are logged.
         /// </summary>
-        public bool SanitizeRequestURL { get; set; } = true;
+        public bool EnableQueryStringTracing { get; set; } = false;
 
         public string Format()
         {
@@ -207,7 +207,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                 { nameof(LiveMetricsInitializationDelay), LiveMetricsInitializationDelay },
                 { nameof(EnableLiveMetrics), EnableLiveMetrics },
                 { nameof(EnableLiveMetricsFilters), EnableLiveMetricsFilters },
-                { nameof(SanitizeRequestURL), SanitizeRequestURL },
+                { nameof(EnableQueryStringTracing), EnableQueryStringTracing },
                 { nameof(EnableDependencyTracking), EnableDependencyTracking },
                 { nameof(DependencyTrackingOptions), dependencyTrackingOptions }
             };

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
@@ -123,6 +123,13 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
         /// </summary>
         public HttpAutoCollectionOptions HttpAutoCollectionOptions { get; set; } = new HttpAutoCollectionOptions();
 
+        /// <summary>
+        /// Gets or sets a value that removes the query parameters from functions URLs. True by default.
+        /// When true, the query parameters are stripped off of the functions URL for logging HTTP trigger calls.
+        /// When false, query parameters are logged.
+        /// </summary>
+        public bool SanitizeRequestURL { get; set; } = true;
+
         public string Format()
         {
             JObject sampling = null;
@@ -200,6 +207,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                 { nameof(LiveMetricsInitializationDelay), LiveMetricsInitializationDelay },
                 { nameof(EnableLiveMetrics), EnableLiveMetrics },
                 { nameof(EnableLiveMetricsFilters), EnableLiveMetricsFilters },
+                { nameof(SanitizeRequestURL), SanitizeRequestURL },
                 { nameof(EnableDependencyTracking), EnableDependencyTracking },
                 { nameof(DependencyTrackingOptions), dependencyTrackingOptions }
             };

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
@@ -76,11 +76,7 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
             services.AddSingleton<ITelemetryInitializer, WebJobsRoleEnvironmentTelemetryInitializer>();
-            services.AddSingleton<ITelemetryInitializer, WebJobsTelemetryInitializer>(provider =>
-            {
-                var options = provider.GetService<IOptions<ApplicationInsightsLoggerOptions>>().Value;
-                return new WebJobsTelemetryInitializer(provider.GetService<ISdkVersionProvider>(), provider.GetService<IRoleInstanceProvider>(), options);
-            });
+            services.AddSingleton<ITelemetryInitializer, WebJobsTelemetryInitializer>();
             services.AddSingleton<ITelemetryInitializer, MetricSdkVersionTelemetryInitializer>();
             services.AddSingleton<QuickPulseInitializationScheduler>();
             services.AddSingleton<QuickPulseTelemetryModule>();
@@ -221,7 +217,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 if (!activeConfig.TelemetryInitializers.OfType<WebJobsRoleEnvironmentTelemetryInitializer>().Any())
                 {
                     activeConfig.TelemetryInitializers.Add(new WebJobsRoleEnvironmentTelemetryInitializer());
-                    activeConfig.TelemetryInitializers.Add(new WebJobsTelemetryInitializer(sdkVersionProvider, roleInstanceProvider, options));
+                    activeConfig.TelemetryInitializers.Add(new WebJobsTelemetryInitializer(sdkVersionProvider, roleInstanceProvider, provider.GetService<IOptions<ApplicationInsightsLoggerOptions>>()));
                 }
 
                 SetupTelemetryConfiguration(

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
@@ -76,7 +76,11 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
             services.AddSingleton<ITelemetryInitializer, WebJobsRoleEnvironmentTelemetryInitializer>();
-            services.AddSingleton<ITelemetryInitializer, WebJobsTelemetryInitializer>();
+            services.AddSingleton<ITelemetryInitializer, WebJobsTelemetryInitializer>(provider =>
+            {
+                var options = provider.GetService<IOptions<ApplicationInsightsLoggerOptions>>().Value;
+                return new WebJobsTelemetryInitializer(provider.GetService<ISdkVersionProvider>(), provider.GetService<IRoleInstanceProvider>(), options);
+            });
             services.AddSingleton<ITelemetryInitializer, MetricSdkVersionTelemetryInitializer>();
             services.AddSingleton<QuickPulseInitializationScheduler>();
             services.AddSingleton<QuickPulseTelemetryModule>();
@@ -217,7 +221,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 if (!activeConfig.TelemetryInitializers.OfType<WebJobsRoleEnvironmentTelemetryInitializer>().Any())
                 {
                     activeConfig.TelemetryInitializers.Add(new WebJobsRoleEnvironmentTelemetryInitializer());
-                    activeConfig.TelemetryInitializers.Add(new WebJobsTelemetryInitializer(sdkVersionProvider, roleInstanceProvider));
+                    activeConfig.TelemetryInitializers.Add(new WebJobsTelemetryInitializer(sdkVersionProvider, roleInstanceProvider, options));
                 }
 
                 SetupTelemetryConfiguration(

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/WebJobsTelemetryInitializer.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/WebJobsTelemetryInitializer.cs
@@ -11,6 +11,7 @@ using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.Extensibility.Implementation;
 using Microsoft.Azure.WebJobs.Logging.ApplicationInsights.Extensions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
 {
@@ -21,7 +22,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
         private readonly string _roleInstanceName;
         private readonly ApplicationInsightsLoggerOptions _options;
 
-        public WebJobsTelemetryInitializer(ISdkVersionProvider versionProvider, IRoleInstanceProvider roleInstanceProvider, ApplicationInsightsLoggerOptions options)
+        public WebJobsTelemetryInitializer(ISdkVersionProvider versionProvider, IRoleInstanceProvider roleInstanceProvider, IOptions<ApplicationInsightsLoggerOptions> options)
         {
             if (versionProvider == null)
             {
@@ -35,7 +36,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
 
             _sdkVersion = versionProvider.GetSdkVersion();
             _roleInstanceName = roleInstanceProvider.GetRoleInstanceName();
-            _options = options;
+            _options = options.Value;
         }
 
         public void Initialize(ITelemetry telemetry)
@@ -161,7 +162,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                 }
 
                 // sanitize request Url - remove query string
-                if (_options.SanitizeRequestURL)
+                if (!_options.EnableQueryStringTracing)
                 {
                     request.Url = new Uri(request.Url.GetLeftPart(UriPartial.Path));
                 }

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/WebJobsTelemetryInitializer.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/WebJobsTelemetryInitializer.cs
@@ -19,8 +19,9 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
         private static readonly string _currentProcessId = Process.GetCurrentProcess().Id.ToString();
         private readonly string _sdkVersion;
         private readonly string _roleInstanceName;
+        private readonly ApplicationInsightsLoggerOptions _options;
 
-        public WebJobsTelemetryInitializer(ISdkVersionProvider versionProvider, IRoleInstanceProvider roleInstanceProvider)
+        public WebJobsTelemetryInitializer(ISdkVersionProvider versionProvider, IRoleInstanceProvider roleInstanceProvider, ApplicationInsightsLoggerOptions options)
         {
             if (versionProvider == null)
             {
@@ -34,6 +35,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
 
             _sdkVersion = versionProvider.GetSdkVersion();
             _roleInstanceName = roleInstanceProvider.GetRoleInstanceName();
+            _options = options;
         }
 
         public void Initialize(ITelemetry telemetry)
@@ -159,7 +161,10 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                 }
 
                 // sanitize request Url - remove query string
-                request.Url = new Uri(request.Url.GetLeftPart(UriPartial.Path));
+                if (_options.SanitizeRequestURL)
+                {
+                    request.Url = new Uri(request.Url.GetLeftPart(UriPartial.Path));
+                }
             }
         }
 

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/ApplicationInsightsEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/ApplicationInsightsEndToEndTests.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                         o.LiveMetricsInitializationDelay = TimeSpan.FromSeconds(1);
                         if (applicationInsightsOptions != null)
                         {
-                            o.SanitizeRequestURL = applicationInsightsOptions.SanitizeRequestURL;
+                            o.EnableQueryStringTracing = applicationInsightsOptions.EnableQueryStringTracing;
                             o.EnableLiveMetricsFilters = applicationInsightsOptions.EnableLiveMetricsFilters;
                             o.EnableLiveMetrics = applicationInsightsOptions.EnableLiveMetrics;
                         }
@@ -610,7 +610,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             Uri requestUrl = new Uri("http://my-func/api/func-name?name=123");
             using (IHost host = ConfigureHost(applicationInsightsOptions: new ApplicationInsightsLoggerOptions()
             {
-                SanitizeRequestURL = false
+                EnableQueryStringTracing = true
             }))
             {
                 TelemetryClient telemetryClient = host.Services.GetService<TelemetryClient>();

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/WebJobsTelemetryInitializerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/WebJobsTelemetryInitializerTests.cs
@@ -71,7 +71,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             {
                 ResponseCode = string.Empty,
                 Name = "",
-            };
+                Url = new Uri("http://localhost/api/somemethod?secret=secret")
+        };
 
             Activity requestActivity = new Activity("dummy");
             requestActivity.Start();
@@ -79,7 +80,6 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             requestActivity.AddTag(LogConstants.SucceededKey, "true");
 
             var options = new ApplicationInsightsLoggerOptions();
-
             var initializer = new WebJobsTelemetryInitializer(new WebJobsSdkVersionProvider(), new WebJobsRoleInstanceProvider(), Options.Create(options));
 
             initializer.Initialize(request);
@@ -88,7 +88,41 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             Assert.Equal(functionName, request.Name);
             Assert.Equal("0", request.ResponseCode);
             Assert.Equal(true, request.Success);
-            Assert.Null(request.Url);
+            Assert.Equal(request.Url, new Uri("http://localhost/api/somemethod")); 
+            Assert.DoesNotContain(request.Properties, p => p.Key == LogConstants.SucceededKey);
+        }
+
+
+        [Fact]
+        public void Initializer_IsIdempotent_ServiceBusRequest_EnableQueryStringTracing()
+        {
+            string functionName = "MyFunction";
+
+            // Simulate an HttpRequest
+            var request = new RequestTelemetry
+            {
+                ResponseCode = string.Empty,
+                Name = "",
+                Url = new Uri("http://localhost/api/somemethod?secret=secret")
+            };
+
+            Activity requestActivity = new Activity("dummy");
+            requestActivity.Start();
+            requestActivity.AddTag(LogConstants.NameKey, functionName);
+            requestActivity.AddTag(LogConstants.SucceededKey, "true");
+
+            var options = new ApplicationInsightsLoggerOptions();
+            IOptions<ApplicationInsightsLoggerOptions> aiOptions = Options.Create(options);
+            aiOptions.Value.EnableQueryStringTracing = true;
+            var initializer = new WebJobsTelemetryInitializer(new WebJobsSdkVersionProvider(), new WebJobsRoleInstanceProvider(), aiOptions);
+
+            initializer.Initialize(request);
+            initializer.Initialize(request);
+
+            Assert.Equal(functionName, request.Name);
+            Assert.Equal("0", request.ResponseCode);
+            Assert.Equal(true, request.Success);
+            Assert.Equal(request.Url, new Uri("http://localhost/api/somemethod?secret=secret"));
             Assert.DoesNotContain(request.Properties, p => p.Key == LogConstants.SucceededKey);
         }
 

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/WebJobsTelemetryInitializerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/WebJobsTelemetryInitializerTests.cs
@@ -33,13 +33,15 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                 ResponseCode = status,
                 Name = "POST /api/somemethod",
             };
+            
+            var options = new ApplicationInsightsLoggerOptions();
 
             Activity requestActivity = new Activity("dummy");
             requestActivity.Start();
             requestActivity.AddTag(LogConstants.NameKey, functionName);
             requestActivity.AddTag(LogConstants.SucceededKey, "true");
 
-            var initializer = new WebJobsTelemetryInitializer(new WebJobsSdkVersionProvider(), new WebJobsRoleInstanceProvider());
+            var initializer = new WebJobsTelemetryInitializer(new WebJobsSdkVersionProvider(), new WebJobsRoleInstanceProvider(), options);
 
             initializer.Initialize(request);
             initializer.Initialize(request);
@@ -75,7 +77,9 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             requestActivity.AddTag(LogConstants.NameKey, functionName);
             requestActivity.AddTag(LogConstants.SucceededKey, "true");
 
-            var initializer = new WebJobsTelemetryInitializer(new WebJobsSdkVersionProvider(), new WebJobsRoleInstanceProvider());
+            var options = new ApplicationInsightsLoggerOptions();
+
+            var initializer = new WebJobsTelemetryInitializer(new WebJobsSdkVersionProvider(), new WebJobsRoleInstanceProvider(), options);
 
             initializer.Initialize(request);
             initializer.Initialize(request);
@@ -91,7 +95,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
         public void Initializer_SetsRoleInstance()
         {
             var request = new RequestTelemetry { Name = "custom" };
-            var initializer = new WebJobsTelemetryInitializer(new WebJobsSdkVersionProvider(), new TestRoleInstanceProvider("my custom role instance"));
+            var options = new ApplicationInsightsLoggerOptions();
+            var initializer = new WebJobsTelemetryInitializer(new WebJobsSdkVersionProvider(), new TestRoleInstanceProvider("my custom role instance"), options);
 
             initializer.Initialize(request);
 

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/WebJobsTelemetryInitializerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/WebJobsTelemetryInitializerTests.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Azure.WebJobs.Logging.ApplicationInsights;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
@@ -41,7 +42,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             requestActivity.AddTag(LogConstants.NameKey, functionName);
             requestActivity.AddTag(LogConstants.SucceededKey, "true");
 
-            var initializer = new WebJobsTelemetryInitializer(new WebJobsSdkVersionProvider(), new WebJobsRoleInstanceProvider(), options);
+            var initializer = new WebJobsTelemetryInitializer(new WebJobsSdkVersionProvider(), new WebJobsRoleInstanceProvider(), Options.Create(options));
 
             initializer.Initialize(request);
             initializer.Initialize(request);
@@ -79,7 +80,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
 
             var options = new ApplicationInsightsLoggerOptions();
 
-            var initializer = new WebJobsTelemetryInitializer(new WebJobsSdkVersionProvider(), new WebJobsRoleInstanceProvider(), options);
+            var initializer = new WebJobsTelemetryInitializer(new WebJobsSdkVersionProvider(), new WebJobsRoleInstanceProvider(), Options.Create(options));
 
             initializer.Initialize(request);
             initializer.Initialize(request);
@@ -96,7 +97,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
         {
             var request = new RequestTelemetry { Name = "custom" };
             var options = new ApplicationInsightsLoggerOptions();
-            var initializer = new WebJobsTelemetryInitializer(new WebJobsSdkVersionProvider(), new TestRoleInstanceProvider("my custom role instance"), options);
+            var initializer = new WebJobsTelemetryInitializer(new WebJobsSdkVersionProvider(), new TestRoleInstanceProvider("my custom role instance"), Options.Create(options));
 
             initializer.Initialize(request);
 


### PR DESCRIPTION
Currently, parameters on queries to HTTP triggered functions are stripped from the request URL before the URL is logged in the Request Telemetry. This PR adds an option to host.json logging settings which may be set to true to disable this behavior, logging the entire request URL along with the parameters. 