### PR TITLE
Adding support for pre-aggregated (standard) metrics.

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
@@ -142,7 +142,13 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
         /// Disabled by default.
         /// </summary>
         public EventLevel? DiagnosticsEventListenerLogLevel { get; set; }
-        
+
+        /// <summary>
+        /// Gets or sets the flag that enables standard metrics collection in ApplicationInsights.
+        /// Disabled by default.
+        /// </summary>
+        public bool EnableAutocollectedMetricsExtractor { get; set; } = false;        
+
         public string Format()
         {
             JObject sampling = null;
@@ -232,6 +238,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                 { nameof(DependencyTrackingOptions), dependencyTrackingOptions },
                 { nameof(TokenCredentialOptions), tokenCredentialOptions },
                 { nameof(DiagnosticsEventListenerLogLevel), DiagnosticsEventListenerLogLevel?.ToString() },
+                { nameof(EnableAutocollectedMetricsExtractor), EnableAutocollectedMetricsExtractor },
             };
 
             return options.ToString(Formatting.Indented);

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
@@ -358,6 +358,13 @@ namespace Microsoft.Extensions.DependencyInjection
                 }
             }
 
+            // metrics extractor must be added before filtering and adaptive sampling telemetry processor to account for all the data.
+            if (options.EnableAutocollectedMetricsExtractor)
+            {
+                configuration.TelemetryProcessorChainBuilder
+                    .Use((next) => new AutocollectedMetricsExtractor(next));
+            }
+
             QuickPulseTelemetryProcessor quickPulseProcessor = null;
             configuration.TelemetryProcessorChainBuilder
                 .Use((next) => new OperationFilteringTelemetryProcessor(next));

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
@@ -358,7 +358,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 }
             }
 
-            // metrics extractor must be added before filtering and adaptive sampling telemetry processor to account for all the data.
+            // Metrics extractor must be added before filtering and adaptive sampling telemetry processor to account for all the data.
             if (options.EnableAutocollectedMetricsExtractor)
             {
                 configuration.TelemetryProcessorChainBuilder

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.10.4" />
+    <PackageReference Include="Azure.Identity" Version="1.10.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.21.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.SnapshotCollector" Version="1.4.3" />

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.10.2" />
+    <PackageReference Include="Azure.Identity" Version="1.10.4" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.21.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.SnapshotCollector" Version="1.4.3" />

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                 Assert.Single(modules.OfType<PerformanceCollectorModule>());
                 Assert.Single(modules.OfType<AppServicesHeartbeatTelemetryModule>());
                 Assert.Single(modules.OfType<RequestTrackingTelemetryModule>());
-                // SelfDiagnosticsTelemetryModule is dabled by default and instead NullTelemetryModule is added
+                // SelfDiagnosticsTelemetryModule is disabled by default and instead NullTelemetryModule is added
                 Assert.Single(modules.OfType<NullTelemetryModule>());
 
                 var dependencyModule = modules.OfType<DependencyTrackingTelemetryModule>().Single();
@@ -135,6 +135,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                     {
                         o.ConnectionString = "InstrumentationKey=somekey;EndpointSuffix=applicationinsights.us";
                         o.DiagnosticsEventListenerLogLevel = EventLevel.Verbose;
+                        o.EnableAutocollectedMetricsExtractor = true;
                     }); 
                 });
 
@@ -195,10 +196,11 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                 Assert.NotNull(providers[0]);
 
                 // Verify Processors
-                Assert.Equal(4, config.TelemetryProcessors.Count);
-                Assert.IsType<OperationFilteringTelemetryProcessor>(config.TelemetryProcessors[0]);
-                Assert.IsType<QuickPulseTelemetryProcessor>(config.TelemetryProcessors[1]);
-                Assert.IsType<FilteringTelemetryProcessor>(config.TelemetryProcessors[2]);
+                Assert.Equal(5, config.TelemetryProcessors.Count);
+                Assert.IsType<AutocollectedMetricsExtractor>(config.TelemetryProcessors[0]);
+                Assert.IsType<OperationFilteringTelemetryProcessor>(config.TelemetryProcessors[1]);
+                Assert.IsType<QuickPulseTelemetryProcessor>(config.TelemetryProcessors[2]);
+                Assert.IsType<FilteringTelemetryProcessor>(config.TelemetryProcessors[3]);
                 Assert.Empty(config.TelemetryProcessors.OfType<AdaptiveSamplingTelemetryProcessor>());
 
                 // Verify ApplicationIdProvider


### PR DESCRIPTION
Enabling support for AutocollectedMetricsExtractor.


> Extracts auto-collected, pre-aggregated (aka. "standard") metrics from telemetry. Metric Extractors participate in the telemetry pipeline as telemetry processors. They examine telemetry items going through the pipeline and create pre-aggregated metrics based on the encountered items.
https://learn.microsoft.com/en-us/dotnet/api/microsoft.applicationinsights.extensibility.autocollectedmetricsextractor?view=azure-dotnet


Without AutocollectedMetricsExtractor . Log based and standard metrics shows the exact number. 
<img width="1062" alt="image" src="https://github.com/Azure/azure-webjobs-sdk/assets/90008725/e9e4446e-5021-4ade-a616-0507122e484e">


With AutocollectedMetricsExtractor enabled. Standard metrics are _almost_ accurate while log based metrics are off. This will be more evident if the dropped %tage is very high due to sampling.
<img width="1086" alt="image" src="https://github.com/Azure/azure-webjobs-sdk/assets/90008725/c58bebc3-a31a-4f3f-a355-a457d577ee7a">
