### PR TITLE
Adding support for multi-dimensional metrics

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
@@ -112,8 +112,12 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
             // Always apply scope first to allow state to override.
             ApplyScopeProperties(telemetry);
 
-            // Add known properties like category, logLevel and event
-            ApplyKnownProperties(telemetry.Properties, logLevel, eventId);
+            // Do not apply state properties if optimization is enabled
+            if (!_loggerOptions.EnableMetricsCustomDimensionOptimization)
+            {
+                // Add known properties like category, logLevel and event
+                ApplyKnownProperties(telemetry.Properties, logLevel, eventId);
+            }
 
             foreach (var entry in values)
             {
@@ -357,8 +361,14 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                 }
             }
 
-            IDictionary<string, string> properties = new Dictionary<string, string>(2);
-            ApplyKnownProperties(properties, logLevel, eventId);
+            IDictionary<string, string> properties = null;
+
+            // Do not apply state properties if optimization is enabled
+            if (!_loggerOptions.EnableMetricsCustomDimensionOptimization)
+            {
+                properties = new Dictionary<string, string>(2);
+                ApplyKnownProperties(properties, logLevel, eventId);
+            }
 
             foreach (KeyValuePair<string, double> metric in metrics)
             {

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
@@ -149,7 +149,6 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
         /// </summary>
         public bool EnableAutocollectedMetricsExtractor { get; set; } = false;
 
-
         /// <summary>
         /// Gets or sets the flag that bypass custom dimensions in Metrics telemetry.
         /// Disabled by default.

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
@@ -147,7 +147,14 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
         /// Gets or sets the flag that enables standard metrics collection in ApplicationInsights.
         /// Disabled by default.
         /// </summary>
-        public bool EnableAutocollectedMetricsExtractor { get; set; } = false;        
+        public bool EnableAutocollectedMetricsExtractor { get; set; } = false;
+
+
+        /// <summary>
+        /// Gets or sets the flag that bypass custom dimensions in Metrics telemetry.
+        /// Disabled by default.
+        /// </summary>
+        public bool EnableMetricsCustomDimensionOptimization { get; set; } = false;
 
         public string Format()
         {
@@ -239,6 +246,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                 { nameof(TokenCredentialOptions), tokenCredentialOptions },
                 { nameof(DiagnosticsEventListenerLogLevel), DiagnosticsEventListenerLogLevel?.ToString() },
                 { nameof(EnableAutocollectedMetricsExtractor), EnableAutocollectedMetricsExtractor },
+                { nameof(EnableMetricsCustomDimensionOptimization), EnableMetricsCustomDimensionOptimization },
             };
 
             return options.ToString(Formatting.Indented);

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Constants/LoggingConstants.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Constants/LoggingConstants.cs
@@ -8,5 +8,6 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
         public const string ZeroIpAddress = "0.0.0.0";
         public const string Unknown = "[Unknown]";
         public const string ClientIpKey = "ClientIp";
+        public const string HostInstanceIdKey = "HostInstanceId";
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/WebJobsTelemetryInitializer.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/WebJobsTelemetryInitializer.cs
@@ -52,59 +52,69 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
             {
                 telemetryContext.Location.Ip = LoggingConstants.ZeroIpAddress;
             }
-            telemetryContext.Properties[LogConstants.ProcessIdKey] = _currentProcessId;
-            
-            // Apply our special scope properties
-            IReadOnlyDictionary<string, object> scopeProps = DictionaryLoggerScope.GetMergedStateDictionaryOrNull();
 
-            // this could be telemetry tracked in scope of function call - then we should apply the logger scope
-            // or RequestTelemetry tracked by the WebJobs SDK or AppInsight SDK - then we should apply Activity.Tags
-            if (scopeProps?.Count > 0)
+            // Do not apply state properties if optimization is enabled.
+            if (_options.EnableMetricsCustomDimensionOptimization && telemetry is MetricTelemetry)
             {
-                if (!telemetryContext.Properties.ContainsKey(LogConstants.InvocationIdKey))
+                // Remove the Host instance ID property, since it's not needed.
+                telemetryContext.Properties.Remove(LoggingConstants.HostInstanceIdKey);
+                return;
+            }
+            else
+            { 
+                telemetryContext.Properties[LogConstants.ProcessIdKey] = _currentProcessId;
+
+                // Apply our special scope properties
+                IReadOnlyDictionary<string, object> scopeProps = DictionaryLoggerScope.GetMergedStateDictionaryOrNull();
+
+                // this could be telemetry tracked in scope of function call - then we should apply the logger scope
+                // or RequestTelemetry tracked by the WebJobs SDK or AppInsight SDK - then we should apply Activity.Tags
+                if (scopeProps?.Count > 0)
                 {
-                    if (scopeProps?.GetValueOrDefault<string>(ScopeKeys.FunctionInvocationId) is string invocationId)
+                    if (!telemetryContext.Properties.ContainsKey(LogConstants.InvocationIdKey))
                     {
-                        telemetryContext.Properties[LogConstants.InvocationIdKey] = invocationId;
+                        if (scopeProps?.GetValueOrDefault<string>(ScopeKeys.FunctionInvocationId) is string invocationId)
+                        {
+                            telemetryContext.Properties[LogConstants.InvocationIdKey] = invocationId;
+                        }
                     }
-                }
 
-                telemetryContext.Operation.Name = scopeProps.GetValueOrDefault<string>(ScopeKeys.FunctionName);
+                    telemetryContext.Operation.Name = scopeProps.GetValueOrDefault<string>(ScopeKeys.FunctionName);
 
-                // Apply Category, LogLevel event details to all telemetry
-                if (!telemetryContext.Properties.ContainsKey(LogConstants.CategoryNameKey))
-                {
-                    if (scopeProps.GetValueOrDefault<string>(LogConstants.CategoryNameKey) is string category)
+                    // Apply Category, LogLevel event details to all telemetry
+                    if (!telemetryContext.Properties.ContainsKey(LogConstants.CategoryNameKey))
                     {
-                        telemetryContext.Properties[LogConstants.CategoryNameKey] = category;
+                        if (scopeProps.GetValueOrDefault<string>(LogConstants.CategoryNameKey) is string category)
+                        {
+                            telemetryContext.Properties[LogConstants.CategoryNameKey] = category;
+                        }
                     }
-                }
 
-                if (!telemetryContext.Properties.ContainsKey(LogConstants.LogLevelKey))
-                {
-                    if (scopeProps.GetValueOrDefault<LogLevel?>(LogConstants.LogLevelKey) is LogLevel logLevel)
+                    if (!telemetryContext.Properties.ContainsKey(LogConstants.LogLevelKey))
                     {
-                        telemetryContext.Properties[LogConstants.LogLevelKey] = logLevel.ToStringOptimized();
+                        if (scopeProps.GetValueOrDefault<LogLevel?>(LogConstants.LogLevelKey) is LogLevel logLevel)
+                        {
+                            telemetryContext.Properties[LogConstants.LogLevelKey] = logLevel.ToStringOptimized();
+                        }
                     }
-                }
 
-                if (!telemetryContext.Properties.ContainsKey(LogConstants.EventIdKey))
-                {
-                    if (scopeProps.GetValueOrDefault<int>(LogConstants.EventIdKey) is int eventId && eventId != 0)
+                    if (!telemetryContext.Properties.ContainsKey(LogConstants.EventIdKey))
                     {
-                        telemetryContext.Properties[LogConstants.EventIdKey] = eventId.ToString(CultureInfo.InvariantCulture);
+                        if (scopeProps.GetValueOrDefault<int>(LogConstants.EventIdKey) is int eventId && eventId != 0)
+                        {
+                            telemetryContext.Properties[LogConstants.EventIdKey] = eventId.ToString(CultureInfo.InvariantCulture);
+                        }
                     }
-                }
 
-                if (!telemetryContext.Properties.ContainsKey(LogConstants.EventNameKey))
-                {
-                    if (scopeProps.GetValueOrDefault<string>(LogConstants.EventNameKey) is string eventName)
+                    if (!telemetryContext.Properties.ContainsKey(LogConstants.EventNameKey))
                     {
-                        telemetryContext.Properties[LogConstants.EventNameKey] = eventName;
+                        if (scopeProps.GetValueOrDefault<string>(LogConstants.EventNameKey) is string eventName)
+                        {
+                            telemetryContext.Properties[LogConstants.EventNameKey] = eventName;
+                        }
                     }
                 }
             }
-
             // we may track traces/dependencies after function scope ends - we don't want to update those
             if (telemetry is RequestTelemetry request)
             {

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/WebJobsTelemetryInitializer.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/WebJobsTelemetryInitializer.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                             telemetryContext.Properties[LogConstants.InvocationIdKey] = invocationId;
                         }
                     }
-
+                    
                     telemetryContext.Operation.Name = scopeProps.GetValueOrDefault<string>(ScopeKeys.FunctionName);
 
                     // Apply Category, LogLevel event details to all telemetry

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/WebJobsTelemetryInitializer.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/WebJobsTelemetryInitializer.cs
@@ -52,75 +52,86 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
             {
                 telemetryContext.Location.Ip = LoggingConstants.ZeroIpAddress;
             }
-            telemetryContext.Properties[LogConstants.ProcessIdKey] = _currentProcessId;
 
-            // Apply our special scope properties
-            IReadOnlyDictionary<string, object> scopeProps = DictionaryLoggerScope.GetMergedStateDictionaryOrNull();
-
-            // this could be telemetry tracked in scope of function call - then we should apply the logger scope
-            // or RequestTelemetry tracked by the WebJobs SDK or AppInsight SDK - then we should apply Activity.Tags
-            if (scopeProps?.Count > 0)
+            // Do not apply state properties if optimization is enabled.
+            if (_options.EnableMetricsCustomDimensionOptimization && telemetry is MetricTelemetry)
             {
-                if (!telemetryContext.Properties.ContainsKey(LogConstants.InvocationIdKey))
-                {
-                    if (scopeProps?.GetValueOrDefault<string>(ScopeKeys.FunctionInvocationId) is string invocationId)
-                    {
-                        telemetryContext.Properties[LogConstants.InvocationIdKey] = invocationId;
-                    }
-                }
-
-                telemetryContext.Operation.Name = scopeProps.GetValueOrDefault<string>(ScopeKeys.FunctionName);
-
-                // Apply Category, LogLevel event details to all telemetry
-                if (!telemetryContext.Properties.ContainsKey(LogConstants.CategoryNameKey))
-                {
-                    if (scopeProps.GetValueOrDefault<string>(LogConstants.CategoryNameKey) is string category)
-                    {
-                        telemetryContext.Properties[LogConstants.CategoryNameKey] = category;
-                    }
-                }
-
-                if (!telemetryContext.Properties.ContainsKey(LogConstants.LogLevelKey))
-                {
-                    if (scopeProps.GetValueOrDefault<LogLevel?>(LogConstants.LogLevelKey) is LogLevel logLevel)
-                    {
-                        telemetryContext.Properties[LogConstants.LogLevelKey] = logLevel.ToStringOptimized();
-                    }
-                }
-
-                if (!telemetryContext.Properties.ContainsKey(LogConstants.EventIdKey))
-                {
-                    if (scopeProps.GetValueOrDefault<int>(LogConstants.EventIdKey) is int eventId && eventId != 0)
-                    {
-                        telemetryContext.Properties[LogConstants.EventIdKey] = eventId.ToString(CultureInfo.InvariantCulture);
-                    }
-                }
-
-                if (!telemetryContext.Properties.ContainsKey(LogConstants.EventNameKey))
-                {
-                    if (scopeProps.GetValueOrDefault<string>(LogConstants.EventNameKey) is string eventName)
-                    {
-                        telemetryContext.Properties[LogConstants.EventNameKey] = eventName;
-                    }
-                }
+                // Remove the Host instance ID property, since it's not needed.
+                telemetryContext.Properties.Remove(LoggingConstants.HostInstanceIdKey);
+                return;
             }
-
-            // we may track traces/dependencies after function scope ends - we don't want to update those
-            if (telemetry is RequestTelemetry request)
+            else
             {
-                UpdateRequestProperties(request);
+                telemetryContext.Properties[LogConstants.ProcessIdKey] = _currentProcessId;
 
-                Activity currentActivity = Activity.Current;
-                if (currentActivity != null)
+                // Apply our special scope properties
+                IReadOnlyDictionary<string, object> scopeProps = DictionaryLoggerScope.GetMergedStateDictionaryOrNull();
+
+                // this could be telemetry tracked in scope of function call - then we should apply the logger scope
+                // or RequestTelemetry tracked by the WebJobs SDK or AppInsight SDK - then we should apply Activity.Tags
+                if (scopeProps?.Count > 0)
                 {
-                    foreach (var tag in currentActivity.Tags)
+                    if (!telemetryContext.Properties.ContainsKey(LogConstants.InvocationIdKey))
                     {
-                        // Apply well-known tags and custom properties, 
-                        // but ignore internal ai tags
-                        if (!TryApplyProperty(request, tag) &&
-                            !tag.Key.StartsWith("ai_"))
+                        if (scopeProps?.GetValueOrDefault<string>(ScopeKeys.FunctionInvocationId) is string invocationId)
                         {
-                            request.Properties[tag.Key] = tag.Value;
+                            telemetryContext.Properties[LogConstants.InvocationIdKey] = invocationId;
+                        }
+                    }
+
+                    telemetryContext.Operation.Name = scopeProps.GetValueOrDefault<string>(ScopeKeys.FunctionName);
+
+                    // Apply Category, LogLevel event details to all telemetry
+                    if (!telemetryContext.Properties.ContainsKey(LogConstants.CategoryNameKey))
+                    {
+                        if (scopeProps.GetValueOrDefault<string>(LogConstants.CategoryNameKey) is string category)
+                        {
+                            telemetryContext.Properties[LogConstants.CategoryNameKey] = category;
+                        }
+                    }
+
+                    if (!telemetryContext.Properties.ContainsKey(LogConstants.LogLevelKey))
+                    {
+                        if (scopeProps.GetValueOrDefault<LogLevel?>(LogConstants.LogLevelKey) is LogLevel logLevel)
+                        {
+                            telemetryContext.Properties[LogConstants.LogLevelKey] = logLevel.ToStringOptimized();
+                        }
+                    }
+
+                    if (!telemetryContext.Properties.ContainsKey(LogConstants.EventIdKey))
+                    {
+                        if (scopeProps.GetValueOrDefault<int>(LogConstants.EventIdKey) is int eventId && eventId != 0)
+                        {
+                            telemetryContext.Properties[LogConstants.EventIdKey] = eventId.ToString(CultureInfo.InvariantCulture);
+                        }
+                    }
+
+                    if (!telemetryContext.Properties.ContainsKey(LogConstants.EventNameKey))
+                    {
+                        if (scopeProps.GetValueOrDefault<string>(LogConstants.EventNameKey) is string eventName)
+                        {
+                            telemetryContext.Properties[LogConstants.EventNameKey] = eventName;
+                        }
+                    }
+                }
+
+                // we may track traces/dependencies after function scope ends - we don't want to update those
+                if (telemetry is RequestTelemetry request)
+                {
+                    UpdateRequestProperties(request);
+
+                    Activity currentActivity = Activity.Current;
+                    if (currentActivity != null)
+                    {
+                        foreach (var tag in currentActivity.Tags)
+                        {
+                            // Apply well-known tags and custom properties, 
+                            // but ignore internal ai tags
+                            if (!TryApplyProperty(request, tag) &&
+                                !tag.Key.StartsWith("ai_"))
+                            {
+                                request.Properties[tag.Key] = tag.Value;
+                            }
                         }
                     }
                 }

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
@@ -28,16 +28,16 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.10.4" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.21.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.SnapshotCollector" Version="1.4.3" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.21.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.21.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.22.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.SnapshotCollector" Version="1.4.4" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.22.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.22.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.21.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.22.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/ApplicationInsightsEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/ApplicationInsightsEndToEndTests.cs
@@ -856,7 +856,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     traceId,
                     parentSpanId);
 
-                Assert.Equal(sampledIn ? SamplingDecision.SampledIn : SamplingDecision.None, functionRequest.ProactiveSamplingDecision);                    
+                Assert.Equal(SamplingDecision.None, functionRequest.ProactiveSamplingDecision);                    
 
                 // Make sure operation ids match
                 var traces = _channel.Telemetries.OfType<TraceTelemetry>().Where(t => t.Context.Operation.Id == functionRequest.Context.Operation.Id);
@@ -962,7 +962,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
                 foreach (var trace in traces)
                 {
-                    Assert.Equal(anySampledIn ? SamplingDecision.SampledIn : SamplingDecision.None, trace.ProactiveSamplingDecision);
+                    Assert.Equal(SamplingDecision.None, trace.ProactiveSamplingDecision);
                 }
 
                 Assert.Equal(anySampledIn ? SamplingDecision.SampledIn : SamplingDecision.None,

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/ApplicationInsightsEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/ApplicationInsightsEndToEndTests.cs
@@ -1313,7 +1313,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             }
         }
 
-
         [Theory]
         [InlineData(true, false)]
         [InlineData(false, true)]

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsLoggerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsLoggerTests.cs
@@ -777,6 +777,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             Assert.Equal("*******", deserializedOptions.TokenCredentialOptions.ClientId);
             Assert.Equal(options.EnableLiveMetrics, deserializedOptions.EnableLiveMetrics);
             Assert.Equal(options.EnableLiveMetricsFilters, deserializedOptions.EnableLiveMetricsFilters);
+            Assert.Equal(false, deserializedOptions.EnableMetricsCustomDimensionOptimization);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #3040 
EnableMetricsCustomDimensionOptimization flag to skip adding custom dimensions.

The Functions runtime publishes custom metrics to App Insights. These custom metrics have custom dimensions that can assume a high number of unique values (high cardinality). 
When the [multi-dimensional] (https://learn.microsoft.com/en-us/azure/azure-monitor/app/get-metric#enable-multidimensional-metrics) metrics feature is enabled in App Insights, these high-cardinality dimensions consume a lot of the 50k time series quota offered for the feature, which makes Azure Monitor visualizations of custom metrics unreliable.

This optimization will remove all the state properties but retain the scope properties.

<img width="1523" alt="image" src="https://github.com/Azure/azure-webjobs-sdk/assets/90008725/c9611833-66b9-4ab6-a570-b95a5caca391">

