### PR TITLE
Downgrading Azure.Identity to 1.10.2

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <Version>3.0.39$(VersionSuffix)</Version>
+    <Version>3.0.40$(VersionSuffix)</Version>
     <InformationalVersion>$(Version) Commit hash: $(CommitHash)</InformationalVersion>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Microsoft.Azure.WebJobs.Logging.ApplicationInsights</PackageId>
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.10.4" />
+    <PackageReference Include="Azure.Identity" Version="1.10.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.22.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.SnapshotCollector" Version="1.4.4" />


### PR DESCRIPTION
Azure.Identity was upgraded from 1.10.2 to 1.10.4 ([PR](https://github.com/Azure/azure-webjobs-sdk/pull/3046)) but there are major version bump in most of the of the dependencies.

```
Microsoft.Identity.Client.Extensions.Msal.dll: 2.31.0.0/2.31.0.0 -> 4.56.0.0/4.56.0.0
Microsoft.Win32.SystemEvents.dll: 4.0.2.0/4.700.19.56404 -> 6.0.0.0/6.0.21.52210
System.Configuration.ConfigurationManager.dll: 4.0.3.0/4.700.19.56404 -> 6.0.0.0/6.0.21.52210
System.Security.Cryptography.ProtectedData.dll: 4.0.5.0/4.700.19.56404 -> 6.0.0.0/6.0.21.52210
System.Security.Permissions.dll: 4.0.3.0/4.700.19.56404 -> 6.0.0.0/6.0.21.52210
System.Windows.Extensions.dll: 4.0.1.0/4.700.19.56404 -> 6.0.0.0/6.0.21.52210
```
Reverting the change as we don't upgrade major dependencies in minor release.