### PR TITLE
Exposing the ability to override the job instance service provider

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Executors/DefaultInstanceServicesProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/DefaultInstanceServicesProvider.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.Azure.WebJobs.Host.Executors
+{
+    internal class DefaultInstanceServicesProvider : IInstanceServicesProvider, IDisposable
+    {
+        private readonly IServiceScopeFactory _serviceScopeFactory;
+        private IServiceScope _instanceServicesScope;
+        private IServiceProvider _instanceServices;
+
+        public DefaultInstanceServicesProvider(IServiceScopeFactory serviceScopeFactory)
+        {
+            _serviceScopeFactory = serviceScopeFactory;
+        }
+
+        public IServiceProvider InstanceServices
+        {
+            get
+            {
+                if (_instanceServices == null && _serviceScopeFactory != null)
+                {
+                    _instanceServicesScope = _serviceScopeFactory.CreateScope();
+                    _instanceServices = _instanceServicesScope.ServiceProvider;
+                }
+
+                return _instanceServices;
+            }
+            set
+            {
+                _instanceServices = value;
+            }
+        }
+
+        public void Dispose()
+        {
+            _instanceServicesScope?.Dispose();
+
+            _instanceServicesScope = null;
+            _instanceServices = null;
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/DefaultInstanceServicesProviderFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/DefaultInstanceServicesProviderFactory.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.Azure.WebJobs.Host.Executors
+{
+    internal class DefaultInstanceServicesProviderFactory : IInstanceServicesProviderFactory
+    {
+        private readonly IServiceScopeFactory _serviceScopeFactory;
+
+        public DefaultInstanceServicesProviderFactory(IServiceScopeFactory serviceScopeFactory)
+        {
+            _serviceScopeFactory = serviceScopeFactory;
+        }
+
+        public IInstanceServicesProvider CreateInstanceServicesProvider(FunctionInstanceFactoryContext functionInstanceFactoryContext)
+        {
+            return new DefaultInstanceServicesProvider(_serviceScopeFactory);
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionInstance.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionInstance.cs
@@ -3,37 +3,38 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Protocols;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Azure.WebJobs.Host.Executors
 {
     internal class FunctionInstance : IFunctionInstanceEx, IDisposable
     {
-        private IServiceScope _instanceServicesScope;
-        private readonly IServiceScopeFactory _serviceScopeFactory;
-        private IServiceProvider _instanceServices;
+        private IInstanceServicesProviderFactory _instanceServicesProviderFactory;
+        private IInstanceServicesProvider _instanceServicesProvider;
+        private readonly FunctionInstanceFactoryContext _instanceContext;
 
-        public FunctionInstance(Guid id, IDictionary<string, string> triggerDetails, Guid? parentId, ExecutionReason reason, IBindingSource bindingSource,
-            IFunctionInvoker invoker, FunctionDescriptor functionDescriptor, IServiceScopeFactory serviceScopeFactory)
+        public FunctionInstance(FunctionInstanceFactoryContext context, IBindingSource bindingSource,
+                                IFunctionInvoker invoker, FunctionDescriptor functionDescriptor,
+                                IInstanceServicesProviderFactory instanceServicesProviderFactory)
         {
-            Id = id;
-            TriggerDetails = triggerDetails;
-            ParentId = parentId;
-            Reason = reason;
+            
+            _instanceContext = context ?? throw new ArgumentNullException(nameof(context));
+            _instanceServicesProviderFactory = instanceServicesProviderFactory;
+
             BindingSource = bindingSource;
             Invoker = invoker;
             FunctionDescriptor = functionDescriptor;
-            _serviceScopeFactory = serviceScopeFactory;
         }
 
-        public Guid Id { get; }
 
-        public IDictionary<string, string> TriggerDetails { get; }
+        public Guid Id => _instanceContext.Id;
 
-        public Guid? ParentId { get; }
+        public IDictionary<string, string> TriggerDetails => _instanceContext.TriggerDetails;
 
-        public ExecutionReason Reason { get; }
+        public Guid? ParentId => _instanceContext.ParentId;
+
+        public ExecutionReason Reason => _instanceContext.ExecutionReason;
 
         public IBindingSource BindingSource { get; }
 
@@ -47,25 +48,20 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
         {
             get
             {
-                if (_instanceServicesScope == null && _serviceScopeFactory != null)
+                if (_instanceServicesProvider == null && _instanceServicesProviderFactory != null)
                 {
-                    _instanceServicesScope = _serviceScopeFactory.CreateScope();
-                    _instanceServices = _instanceServicesScope.ServiceProvider;
+                    _instanceServicesProvider = _instanceServicesProviderFactory.CreateInstanceServicesProvider(_instanceContext);
                 }
 
-                return _instanceServices;
+                return _instanceServicesProvider?.InstanceServices;
             }
         }
 
         public void Dispose()
         {
-            if (_instanceServicesScope != null)
-            {
-                _instanceServicesScope.Dispose();
-            }
+            (_instanceServicesProvider as IDisposable)?.Dispose();
 
-            _instanceServicesScope = null;
-            _instanceServices = null;
+            _instanceServicesProvider = null;
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionInstanceFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/FunctionInstanceFactory.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Protocols;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Azure.WebJobs.Host.Executors
 {
@@ -12,20 +11,21 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
         private readonly IFunctionBinding _binding;
         private readonly IFunctionInvoker _invoker;
         private readonly FunctionDescriptor _descriptor;
-        private readonly IServiceScopeFactory _serviceScopeFactory;
+        private readonly IInstanceServicesProviderFactory _instanceServicesProviderFactory;
 
-        public FunctionInstanceFactory(IFunctionBinding binding, IFunctionInvoker invoker, FunctionDescriptor descriptor, IServiceScopeFactory serviceScopeFactory)
+        public FunctionInstanceFactory(IFunctionBinding binding, IFunctionInvoker invoker, FunctionDescriptor descriptor, IInstanceServicesProviderFactory instanceServicesFactory)
         {
             _binding = binding;
             _invoker = invoker;
             _descriptor = descriptor;
-            _serviceScopeFactory = serviceScopeFactory;
+            _instanceServicesProviderFactory = instanceServicesFactory;
         }
 
         public IFunctionInstance Create(FunctionInstanceFactoryContext context)
         {
             IBindingSource bindingSource = new BindingSource(_binding, context.Parameters);
-            return new FunctionInstance(context.Id, context.TriggerDetails, context.ParentId, context.ExecutionReason, bindingSource, _invoker, _descriptor, _serviceScopeFactory);
+            // The internal implementation of the FunctionInstance class will dispose of the created instance services provider when the function instance is disposed.
+            return new FunctionInstance(context, bindingSource, _invoker, _descriptor, _instanceServicesProviderFactory);
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/IInstanceServicesProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/IInstanceServicesProvider.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Azure.WebJobs.Host.Executors
+{
+    /// <summary>
+    /// Provides access to an instance-scoped <see cref="IServiceProvider"/>.
+    /// </summary>
+    public interface IInstanceServicesProvider
+    {
+        IServiceProvider InstanceServices { get; set; }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/IInstanceServicesProviderFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/IInstanceServicesProviderFactory.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Host.Executors
+{
+    /// <summary>
+    /// Factory for creating <see cref="IInstanceServicesProvider"/> instances.
+    /// </summary>
+    public interface IInstanceServicesProviderFactory
+    {
+        IInstanceServicesProvider CreateInstanceServicesProvider(FunctionInstanceFactoryContext functionInstance);
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/TriggeredFunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/TriggeredFunctionExecutor.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
         {
             var context = new FunctionInstanceFactoryContext<TTriggerValue>()
             {
+                Id = Guid.NewGuid(),
                 TriggerValue = (TTriggerValue)input.TriggerValue,
                 ParentId = input.ParentId,
                 TriggerDetails = input.TriggerDetails

--- a/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsServiceCollectionExtensions.cs
@@ -88,6 +88,7 @@ namespace Microsoft.Azure.WebJobs
             services.TryAddSingleton<IFunctionInstanceLogger, FunctionInstanceLogger>();
             services.TryAddSingleton<IHostInstanceLogger, NullHostInstanceLogger>();
             services.TryAddSingleton<IDistributedLockManager, InMemoryDistributedLockManager>();
+            services.TryAddSingleton<IInstanceServicesProviderFactory, DefaultInstanceServicesProviderFactory>();
 
             services.AddCommonScaleServices();
             services.TryAddSingleton<IScaleMetricsRepository, NullScaleMetricsRepository>();

--- a/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexProvider.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
         private readonly IRetryStrategy _defaultRetryStrategy;
         private readonly bool _allowPartialHostStartup;
         private readonly IConfiguration _configuration;
-        private readonly IServiceScopeFactory _serviceScopeFactory;
+        private readonly IInstanceServicesProviderFactory _instanceServicesFactory;
         private IFunctionIndex _index;
 
         public FunctionIndexProvider(ITypeLocator typeLocator,
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
             IOptions<JobHostFunctionTimeoutOptions> timeoutOptions,
             IOptions<JobHostOptions> hostOptions,
             IConfiguration configuration,
-            IServiceScopeFactory serviceScopeFactory,
+            IInstanceServicesProviderFactory instanceServicesFactory,
             IRetryStrategy defaultRetryStrategy = null)
         {
             _typeLocator = typeLocator ?? throw new ArgumentNullException(nameof(typeLocator));
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
             _executor = executor ?? throw new ArgumentNullException(nameof(executor));
             _singletonManager = singletonManager ?? throw new ArgumentNullException(nameof(singletonManager));
             _sharedQueue = sharedQueue ?? throw new ArgumentNullException(nameof(sharedQueue));
-            _serviceScopeFactory = serviceScopeFactory ?? throw new ArgumentNullException(nameof(serviceScopeFactory));
+            _instanceServicesFactory = instanceServicesFactory ?? throw new ArgumentNullException(nameof(instanceServicesFactory));
             _loggerFactory = loggerFactory;
             _defaultTimeout = timeoutOptions.Value.ToAttribute();
             _allowPartialHostStartup = hostOptions.Value.AllowPartialHostStartup;
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
                 _singletonManager, 
                 _loggerFactory, 
                 _configuration, 
-                _serviceScopeFactory, 
+                _instanceServicesFactory, 
                 null, 
                 _sharedQueue, 
                 _defaultTimeout, 

--- a/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexer.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexer.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
         private readonly IRetryStrategy _defaultRetryStrategy;
         private readonly bool _allowPartialHostStartup;
         private readonly IConfiguration _configuration;
-        private readonly IServiceScopeFactory _serviceScopeFactory;
+        private readonly IInstanceServicesProviderFactory _instanceServicesFactory;
         private readonly ILoggerFactory _loggerFactory;
 
         public FunctionIndexer(
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
             SingletonManager singletonManager,
             ILoggerFactory loggerFactory,
             IConfiguration configuration,
-            IServiceScopeFactory serviceScopeFactory,
+            IInstanceServicesProviderFactory instanceServicesFactory,
             INameResolver nameResolver = null,
             SharedQueueHandler sharedQueue = null,
             TimeoutAttribute defaultTimeout = null,
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
             _allowPartialHostStartup = allowPartialHostStartup;
             _defaultRetryStrategy = defaultRetryStrategy;
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
-            _serviceScopeFactory = serviceScopeFactory;
+            _instanceServicesFactory = instanceServicesFactory;
         }
 
         public async Task IndexTypeAsync(Type type, IFunctionIndexCollector index, CancellationToken cancellationToken)
@@ -342,7 +342,7 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
             }
             else
             {
-                IFunctionInstanceFactory instanceFactory = new FunctionInstanceFactory(new FunctionBinding(functionDescriptor, nonTriggerBindings, _singletonManager), invoker, functionDescriptor, _serviceScopeFactory);
+                IFunctionInstanceFactory instanceFactory = new FunctionInstanceFactory(new FunctionBinding(functionDescriptor, nonTriggerBindings, _singletonManager), invoker, functionDescriptor, _instanceServicesFactory);
                 functionDefinition = new FunctionDefinition(functionDescriptor, instanceFactory, listenerFactory: null);
             }
 
@@ -374,7 +374,7 @@ namespace Microsoft.Azure.WebJobs.Host.Indexers
             IReadOnlyDictionary<string, IBinding> nonTriggerBindings, IFunctionInvokerEx invoker)
         {
             ITriggeredFunctionBinding<TTriggerValue> functionBinding = new TriggeredFunctionBinding<TTriggerValue>(descriptor, parameterName, triggerBinding, nonTriggerBindings, _singletonManager);
-            ITriggeredFunctionInstanceFactory<TTriggerValue> instanceFactory = new TriggeredFunctionInstanceFactory<TTriggerValue>(functionBinding, invoker, descriptor, _serviceScopeFactory);
+            ITriggeredFunctionInstanceFactory<TTriggerValue> instanceFactory = new TriggeredFunctionInstanceFactory<TTriggerValue>(functionBinding, invoker, descriptor, _instanceServicesFactory);
             ITriggeredFunctionExecutor triggerExecutor = new TriggeredFunctionExecutor<TTriggerValue>(descriptor, _executor, instanceFactory, _loggerFactory);
             IListenerFactory listenerFactory = new ListenerFactory(descriptor, triggerExecutor, triggerBinding, _sharedQueue, _singletonManager, _loggerFactory);
 

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/Indexers/FunctionIndexerFactory.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/Indexers/FunctionIndexerFactory.cs
@@ -48,13 +48,13 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
             IJobActivator activator = host.Services.GetService<IJobActivator>();
             extensionRegistry = host.Services.GetService<IExtensionRegistry>();
             SingletonManager singletonManager = host.Services.GetService<SingletonManager>();
-            var serviceScopeFactory = host.Services.GetService<IServiceScopeFactory>();
+            var instanceServicesFactory = host.Services.GetService<IInstanceServicesProviderFactory>();
 
             IFunctionExecutor executor = host.Services.GetService<IFunctionExecutor>();
             IConfiguration configuration = host.Services.GetService<IConfiguration>();
 
             // TODO: This should be using DI internally and not be so complicated to construct
-            return new FunctionIndexer(triggerBindingProvider, bindingProvider, activator, executor, singletonManager, loggerFactory, configuration, serviceScopeFactory);
+            return new FunctionIndexer(triggerBindingProvider, bindingProvider, activator, executor, singletonManager, loggerFactory, configuration, instanceServicesFactory);
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/Indexers/FunctionIndexerIntegrationErrorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/Indexers/FunctionIndexerIntegrationErrorTests.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Indexers
                 Mock<IServiceScopeFactory> scopeFactoryMock = new Mock<IServiceScopeFactory>(MockBehavior.Strict);
                 IFunctionIndexCollector stubIndex = new Mock<IFunctionIndexCollector>().Object;
                 IConfiguration configuration = new ConfigurationBuilder().Build();
+                var instanceServicesFactory = new DefaultInstanceServicesProviderFactory(scopeFactoryMock.Object);
 
                 FunctionIndexer indexer = new FunctionIndexer(
                     new Mock<ITriggerBindingProvider>(MockBehavior.Strict).Object,
@@ -37,7 +38,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Indexers
                     new SingletonManager(),
                     null,
                     configuration,
-                    scopeFactoryMock.Object);
+                    instanceServicesFactory);
 
                 Assert.Throws<FunctionIndexingException>(() => indexer.IndexMethodAsync(method, stubIndex, CancellationToken.None).GetAwaiter().GetResult());
             }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/FunctionExecutorTestHelper.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/FunctionExecutorTestHelper.cs
@@ -51,7 +51,16 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
                 return red;
             });
             mockBindingSource.Setup(p => p.BindAsync(It.IsAny<ValueBindingContext>())).Returns(valueProviders);
-            return new FunctionInstance(id, triggerDetails, null, new ExecutionReason(), mockBindingSource.Object, mockInvoker.Object, descriptor, serviceScopeFactoryMock.Object);
+
+            var instanceServicesProviderFactory = new DefaultInstanceServicesProviderFactory(serviceScopeFactoryMock.Object);
+
+            var context = new FunctionInstanceFactoryContext
+            {
+                Id = id,
+                TriggerDetails = triggerDetails
+            };
+
+            return new FunctionInstance(context, mockBindingSource.Object, mockInvoker.Object, descriptor, instanceServicesProviderFactory);
         }
 
         [FixedDelayRetry(5, "00:00:01")]

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/TriggeredFunctionExecutorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/TriggeredFunctionExecutorTests.cs
@@ -60,7 +60,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             var mockTriggerBinding = new Mock<ITriggeredFunctionBinding<int>>();
             var functionDescriptor = new FunctionDescriptor();
             var serviceScopeFactoryMock = new Mock<IServiceScopeFactory>(MockBehavior.Strict);
-            var instanceFactory = new TriggeredFunctionInstanceFactory<int>(mockTriggerBinding.Object, mockInvoker.Object, functionDescriptor, serviceScopeFactoryMock.Object);
+            var instanceServicesFactory = new DefaultInstanceServicesProviderFactory(serviceScopeFactoryMock.Object);
+            var instanceFactory = new TriggeredFunctionInstanceFactory<int>(mockTriggerBinding.Object, mockInvoker.Object, functionDescriptor, instanceServicesFactory);
             var triggerExecutor = new TriggeredFunctionExecutor<int>(functionDescriptor, mockExecutor.Object, instanceFactory, NullLoggerFactory.Instance);
 
             // specify a custom handler on the trigger data and

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsLoggerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsLoggerTests.cs
@@ -1044,8 +1044,15 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             var method = GetType().GetMethod(nameof(TestFunction), BindingFlags.NonPublic | BindingFlags.Static);
             var descriptor = FunctionIndexer.FromMethod(method, new ConfigurationBuilder().Build());
             var serviceScopeFactoryMock = new Mock<IServiceScopeFactory>(MockBehavior.Strict);
+            var instanceServicesProviderFactory = new DefaultInstanceServicesProviderFactory(serviceScopeFactoryMock.Object);
 
-            return new FunctionInstance(id, triggerDetails ?? new Dictionary<string, string>(), null, new ExecutionReason(), null, null, descriptor, serviceScopeFactoryMock.Object);
+            var context = new FunctionInstanceFactoryContext
+            {
+                Id = id,
+                TriggerDetails = triggerDetails ?? new Dictionary<string, string>(),
+            };
+
+            return new FunctionInstance(context, null, null, descriptor, instanceServicesProviderFactory);
         }
 
         private static void TestFunction()

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using Microsoft.Azure.WebJobs.Description;
+using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Azure.WebJobs.Logging.ApplicationInsights;
@@ -187,6 +188,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 "IFunctionInvoker",
                 "IHostIdProvider",
                 "IHostSingletonManager",
+                "IInstanceServicesProvider",
+                "IInstanceServicesProviderFactory",
                 "IJobActivator",
                 "IJobActivatorEx",
                 "IJobHost",


### PR DESCRIPTION
The changes in this PR enable consumers to override the service provider used by job instances, enabling scenarios like externally provided scopes.