### PR TITLE
Update Extensions.Rpc to use Grpc.AspNetCore.Server

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Rpc/WebJobs.Extensions.Rpc.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Rpc/WebJobs.Extensions.Rpc.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore" Version="2.49.0" />
+    <PackageReference Include="Grpc.AspNetCore.Server" Version="2.61.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Replace `Grpc.AspNetCore/2.49.0` with `Grpc.AspNetCore.Server/2.61.0`. 