### PR TITLE
Adding package READMEs and updating package metadata

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -20,6 +20,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>webjobs.png</PackageIcon>
     <PackageTags>Microsoft Azure WebJobs AzureFunctions</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <CodeAnalysisRuleSet>..\..\src.ruleset</CodeAnalysisRuleSet>
     <UseSourceLink Condition="$(UseSourceLink) == '' And $(CI) != ''">true</UseSourceLink>
     <SignAssembly>true</SignAssembly>

--- a/sample/SampleHost/Functions.cs
+++ b/sample/SampleHost/Functions.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
-using Microsoft.Azure.EventHubs;
+using Azure.Messaging.EventHubs;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
@@ -71,7 +71,7 @@ namespace SampleHost
         {
             foreach (var evt in events)
             {
-                log.LogInformation($"Event processed (Offset={evt.SystemProperties.Offset}, SequenceNumber={evt.SystemProperties.SequenceNumber})");
+                log.LogInformation($"Event processed (Offset={evt.Offset}, SequenceNumber={evt.SequenceNumber})");
             }
         }
     }

--- a/sample/SampleHost/Program.cs
+++ b/sample/SampleHost/Program.cs
@@ -13,8 +13,8 @@ namespace SampleHost
     {
         public static async Task Main(string[] args)
         {
-            var builder = new HostBuilder()
-                .UseEnvironment("Development")
+            var builder = Host.CreateDefaultBuilder(args)
+                .UseEnvironment(EnvironmentName.Development)
                 .ConfigureWebJobs(b =>
                 {
                     b.AddAzureStorageCoreServices()
@@ -48,11 +48,8 @@ namespace SampleHost
                 })
                 .UseConsoleLifetime();
 
-            var host = builder.Build();
-            using (host)
-            {
-                await host.RunAsync();
-            }
+            using var host = builder.Build();
+            await host.RunAsync();
         }
     }
 }

--- a/sample/SampleHost/SampleHost.csproj
+++ b/sample/SampleHost/SampleHost.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <CodeAnalysisRuleSet>$(SolutionDir)\src.ruleset</CodeAnalysisRuleSet>
-    <LangVersion>7.1</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,13 +13,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="3.0.6" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="6.3.3" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.16.1" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Azure.WebJobs.Extensions.Rpc/README.md
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Rpc/README.md
@@ -1,0 +1,23 @@
+﻿# Microsoft.Azure.WebJobs.Extensions.Rpc
+
+This package provides RPC capabilities to the WebJobs SDK, allowing extensions to communicate between the host and worker via RPC. For more information, please visit https://go.microsoft.com/fwlink/?linkid=2279708.
+
+## Commonly used types
+
+- `WebJobsExtensionBuilderRpcExtensions`
+
+## Example usage
+
+The below example demonstrates how an extension can register a custom gRPC extension.
+
+``` CSharp
+public static IWebJobsBuilder AddMyExtension(this IWebJobsBuilder builder, Action<MyExtensionOptions> configure)
+{
+    builder.AddExtension<MyExtensionConfigProvider>()
+        .MapWorkerGrpcService<MyGrpcService>();
+
+    builder.Services.AddSingleton<MyGrpcService>();
+
+    return builder;
+}
+```

--- a/src/Microsoft.Azure.WebJobs.Extensions.Rpc/WebJobs.Extensions.Rpc.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Rpc/WebJobs.Extensions.Rpc.csproj
@@ -5,9 +5,9 @@
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <PackageId>Microsoft.Azure.WebJobs.Extensions.Rpc</PackageId>
+    <Description>This package provides RPC capabilities to the WebJobs SDK, allowing extensions to communicate between the host and worker via RPC. For more information, please visit https://go.microsoft.com/fwlink/?linkid=2279708.</Description>
     <AssemblyName>Microsoft.Azure.WebJobs.Extensions.Rpc</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.Rpc</RootNamespace>
-    <Description>This package contains the runtime assemblies for Microsoft.Azure.WebJobs.Extensions.Rpc. For more information, please visit http://go.microsoft.com/fwlink/?LinkID=320971</Description>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,5 +17,8 @@
   <ItemGroup>
     <PackageReference Include="Grpc.AspNetCore" Version="2.49.0" />
   </ItemGroup>
-
+  <ItemGroup>
+    <Content Include="README.md" Pack="true" PackagePath="/" />
+  </ItemGroup>
+	
 </Project>

--- a/src/Microsoft.Azure.WebJobs.Host.Storage/README.md
+++ b/src/Microsoft.Azure.WebJobs.Host.Storage/README.md
@@ -1,0 +1,36 @@
+﻿# Microsoft.Azure.WebJobs.Host.Storage
+
+This package contains Azure Storage based implementations of some WebJobs SDK component interfaces. For more information, please visit https://go.microsoft.com/fwlink/?linkid=2279708.
+
+## Commonly used types
+
+The main types exposed by this package are host builder extension methods to `IWebJobsBuilder`, provided by the following Types:
+
+- `RuntimeStorageWebJobsBuilderExtensions`
+- `StorageServiceCollectionExtensions`
+- `StorageServiceCollectionExtensions`
+
+## Example usage
+
+The below example demonstrates the registration of Azure Storage services via the `AddAzureStorageCoreServices` builder method.
+
+``` CSharp
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+
+class Program
+{
+    public static async Task Main(string[] args)
+    {
+        var builder = Host.CreateDefaultBuilder(args)
+            .ConfigureWebJobs(b =>
+            {
+                b.AddAzureStorageCoreServices();
+                b.AddAzureStorageQueues();
+            });
+
+        using var host = builder.Build();
+        await host.RunAsync();
+    }
+}
+```

--- a/src/Microsoft.Azure.WebJobs.Host.Storage/WebJobs.Host.Storage.csproj
+++ b/src/Microsoft.Azure.WebJobs.Host.Storage/WebJobs.Host.Storage.csproj
@@ -7,6 +7,8 @@
     <InformationalVersion>$(Version) Commit hash: $(CommitHash)</InformationalVersion>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
+    <PackageId>Microsoft.Azure.WebJobs.Host.Storage</PackageId>
+    <Description>This package contains Azure Storage based implementations of some WebJobs SDK component interfaces. For more information, please visit https://go.microsoft.com/fwlink/?linkid=2279708.</Description>
     <AssemblyName>Microsoft.Azure.WebJobs.Host.Storage</AssemblyName>
   </PropertyGroup>
 
@@ -21,6 +23,10 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
   </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="README.md" Pack="true" PackagePath="/" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.19.1" />

--- a/src/Microsoft.Azure.WebJobs.Host/README.md
+++ b/src/Microsoft.Azure.WebJobs.Host/README.md
@@ -1,0 +1,34 @@
+﻿# Microsoft.Azure.WebJobs.Host
+
+This package contains the runtime host components of the WebJobs SDK. For more information, please visit https://go.microsoft.com/fwlink/?linkid=2279708.
+
+## Commonly used types
+
+- `WebJobsHostBuilderExtensions`
+- `JobHost`
+- `IExtensionConfigProvider`
+
+## Example usage
+
+The below example demonstrates configuration and startup of a job host running in a console application.
+
+``` CSharp
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+
+class Program
+{
+    public static async Task Main(string[] args)
+    {
+        var builder = Host.CreateDefaultBuilder(args)
+            .ConfigureWebJobs(b =>
+            {
+                b.AddAzureStorageCoreServices();
+                b.AddAzureStorageQueues();
+            });
+
+        using var host = builder.Build();
+        await host.RunAsync();
+    }
+}
+```

--- a/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.Sources.csproj
+++ b/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.Sources.csproj
@@ -5,6 +5,7 @@
 
   <PropertyGroup>
     <PackageId>Microsoft.Azure.WebJobs.Sources</PackageId>
+    <Description>This package contains source for the runtime host components of the WebJobs SDK. For more information, please visit https://go.microsoft.com/fwlink/?linkid=2279708.</Description>
     <IsPackable>true</IsPackable>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <ContentTargetFolders>contentFiles</ContentTargetFolders>
@@ -16,6 +17,10 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Content Include="README.md" Pack="true" PackagePath="/" />
+  </ItemGroup>
+	
   <ItemGroup>
     <Compile Update="Converters\AsyncConverter.cs">
       <Pack>true</Pack>

--- a/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
+++ b/src/Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <PackageId>Microsoft.Azure.WebJobs</PackageId>
-    <Description>This package contains the runtime assemblies for Microsoft.Azure.WebJobs.Host. It also adds rich diagnostics capabilities which makes it easier to monitor the WebJobs in the dashboard. For more information, please visit http://go.microsoft.com/fwlink/?LinkID=320971</Description>
+    <Description>This package contains the runtime host components of the WebJobs SDK. For more information, please visit https://go.microsoft.com/fwlink/?linkid=2279708.</Description>
     <AssemblyName>Microsoft.Azure.WebJobs.Host</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Host</RootNamespace>
   </PropertyGroup>
@@ -114,4 +114,8 @@
     </EmbeddedResource>
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="README.md" Pack="true" PackagePath="/" />
+  </ItemGroup>
+	
 </Project>

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/README.md
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/README.md
@@ -1,0 +1,44 @@
+﻿# Microsoft.Azure.WebJobs.Logging.ApplicationInsights
+
+This package adds Application Insights based logging capabilities to the WebJobs SDK. For more information, please visit https://go.microsoft.com/fwlink/?linkid=2279708.
+
+## Commonly used types
+
+- `ApplicationInsightsLoggingBuilderExtensions`
+- `ApplicationInsightsLoggerProvider`
+- `ApplicationInsightsLoggerOptions`
+
+## Example usage
+
+The below example demonstrates configuration of ApplicationInsights logging on host startup via the `AddApplicationInsightsWebJobs` builder method.
+
+``` CSharp
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+class Program
+{
+    public static async Task Main(string[] args)
+    {
+        var builder = Host.CreateDefaultBuilder(args)
+            .ConfigureWebJobs(b =>
+            {
+                b.AddAzureStorageCoreServices();
+                b.AddAzureStorageQueues();
+            })
+            .ConfigureLogging((context, b) =>
+            {
+                // If this key exists in any config, use it to enable App Insights
+                string appInsightsKey = context.Configuration["APPINSIGHTS_INSTRUMENTATIONKEY"];
+                if (!string.IsNullOrEmpty(appInsightsKey))
+                {
+                    b.AddApplicationInsightsWebJobs(o => o.InstrumentationKey = appInsightsKey);
+                }
+            });
+
+        using var host = builder.Build();
+        await host.RunAsync();
+    }
+}
+```

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
@@ -7,7 +7,7 @@
     <InformationalVersion>$(Version) Commit hash: $(CommitHash)</InformationalVersion>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Microsoft.Azure.WebJobs.Logging.ApplicationInsights</PackageId>
-    <Description>This package contains the runtime assemblies for Microsoft.Azure.WebJobs.Logging.ApplicationInsights. For more information, please visit http://go.microsoft.com/fwlink/?LinkID=320971</Description>
+    <Description>This package adds Application Insights based logging capabilities to the WebJobs SDK. For more information, please visit https://go.microsoft.com/fwlink/?linkid=2279708.</Description>
     <AssemblyName>Microsoft.Azure.WebJobs.Logging.ApplicationInsights</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Logging.ApplicationInsights</RootNamespace>
   </PropertyGroup>
@@ -24,6 +24,10 @@
 
   <ItemGroup>
     <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="README.md" Pack="true" PackagePath="/" />
   </ItemGroup>
 
   <ItemGroup>
@@ -50,7 +54,7 @@
     without all of the others in this solution. If changes to WebJobs.Host are needed here, re-introduce the
     project reference. 
     -->
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.33" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.39" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.Azure.WebJobs.Logging/README.md
+++ b/src/Microsoft.Azure.WebJobs.Logging/README.md
@@ -1,0 +1,9 @@
+﻿# Microsoft.Azure.WebJobs.Host.Logging
+
+This package provides logging related Types and capabilities to the WebJobs SDK. For more information, please visit https://go.microsoft.com/fwlink/?linkid=2279708.
+
+## Commonly used types
+
+- `LogFactory`
+- `ILogReader`
+- `ILogWriter`

--- a/src/Microsoft.Azure.WebJobs.Logging/WebJobs.Logging.csproj
+++ b/src/Microsoft.Azure.WebJobs.Logging/WebJobs.Logging.csproj
@@ -5,7 +5,7 @@
     <InformationalVersion>$(Version) Commit hash: $(CommitHash)</InformationalVersion>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Microsoft.Azure.WebJobs.Logging</PackageId>
-    <Description>This package contains the runtime assemblies for Microsoft.Azure.WebJobs.Logging. For more information, please visit http://go.microsoft.com/fwlink/?LinkID=320971</Description>
+    <Description>This package provides logging related Types and capabilities to the WebJobs SDK. For more information, please visit https://go.microsoft.com/fwlink/?linkid=2279708.</Description>
     <AssemblyName>Microsoft.Azure.WebJobs.Logging</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Logging</RootNamespace>
   </PropertyGroup>
@@ -19,9 +19,13 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
   </PropertyGroup>
-
+	
   <ItemGroup>
     <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="README.md" Pack="true" PackagePath="/" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Microsoft.Azure.WebJobs.Rpc.Core/README.md
+++ b/src/Microsoft.Azure.WebJobs.Rpc.Core/README.md
@@ -1,0 +1,3 @@
+﻿# Microsoft.Azure.WebJobs.Rpc.Core
+
+This package provides core RPC Types and capabilities to the WebJobs SDK. For more information, please visit https://go.microsoft.com/fwlink/?linkid=2279708.

--- a/src/Microsoft.Azure.WebJobs.Rpc.Core/WebJobs.Rpc.Core.csproj
+++ b/src/Microsoft.Azure.WebJobs.Rpc.Core/WebJobs.Rpc.Core.csproj
@@ -1,14 +1,18 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <PackageId>Microsoft.Azure.WebJobs.Rpc.Core</PackageId>
+    <Description>This package provides core RPC Types and capabilities to the WebJobs SDK. For more information, please visit https://go.microsoft.com/fwlink/?linkid=2279708.</Description>
     <AssemblyName>Microsoft.Azure.WebJobs.Rpc.Core</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Rpc.Core</RootNamespace>
-    <Description>This package contains the runtime assemblies for Microsoft.Azure.WebJobs.Host.Rpc. For more information, please visit http://go.microsoft.com/fwlink/?LinkID=320971</Description>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="README.md"  Pack="true" PackagePath="/" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Azure.WebJobs.Host\WebJobs.Host.csproj" />

--- a/src/Microsoft.Azure.WebJobs/README.md
+++ b/src/Microsoft.Azure.WebJobs/README.md
@@ -1,0 +1,24 @@
+﻿# Microsoft.Azure.WebJobs.Core
+
+This package provides the core Types and Attribute definitions for the WebJobs SDK. For more information, please visit https://go.microsoft.com/fwlink/?linkid=2279708.
+
+## Commonly used types
+
+- `TimeoutAttribute`
+- `SingletonAttribute`
+- `FunctionNameAttribute`
+- `ExtensionAttribute`
+
+## Example usage
+
+The below example shows a QueueTrigger function with a timeout defined.
+
+``` CSharp
+using Microsoft.Azure.WebJobs;
+
+[TimeoutAttribute("00:15:00")]
+public void ProcessWorkItem([QueueTrigger("test")] WorkItem workItem, ILogger logger)
+{
+    logger.LogInformation($"Processed work item {workItem.ID}");
+}
+```

--- a/src/Microsoft.Azure.WebJobs/WebJobs.csproj
+++ b/src/Microsoft.Azure.WebJobs/WebJobs.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Microsoft.Azure.WebJobs.Core</PackageId>
-    <Description>This library simplifies the task of adding background processing to your Microsoft Azure Web Sites. The SDK uses Microsoft Azure Storage, triggering a function in your program when items are added to Queues and Blobs. A dashboard provides rich monitoring and diagnostics for the programs that you write by using the SDK. For more information, please visit http://go.microsoft.com/fwlink/?LinkID=320971</Description>
+    <Description>This package provides the core Types and Attribute definitions for the WebJobs SDK. For more information, please visit https://go.microsoft.com/fwlink/?linkid=2279708.</Description>
     <AssemblyName>Microsoft.Azure.WebJobs</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -33,5 +33,8 @@
   </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="README.md" Pack="true" PackagePath="/" />
   </ItemGroup>
 </Project>

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/README.md
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/README.md
@@ -1,0 +1,3 @@
+﻿# Microsoft.Azure.WebJobs.Host.TestCommon
+
+This package contains helpers and Types useful for WebJobs SDK testing. For more information, please visit https://go.microsoft.com/fwlink/?linkid=2279708.

--- a/test/Microsoft.Azure.WebJobs.Host.TestCommon/WebJobs.Host.TestCommon.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.TestCommon/WebJobs.Host.TestCommon.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>true</IsPackable>
+    <PackageId>Microsoft.Azure.WebJobs.Host.TestCommon</PackageId>
+    <Description>This package contains helpers and Types useful for WebJobs SDK testing. For more information, please visit https://go.microsoft.com/fwlink/?linkid=2279708.</Description>
     <AssemblyName>Microsoft.Azure.WebJobs.Host.TestCommon</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Host.TestCommon</RootNamespace>
   </PropertyGroup>
@@ -36,6 +38,10 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Azure.WebJobs.Host.Storage\WebJobs.Host.Storage.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Azure.WebJobs.Host\WebJobs.Host.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="README.md" Pack="true" PackagePath="/" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
All Microsoft developed packages should include readmes - these WebJobs SDK packages currently don't. Open to feedback on readme text/samples, as well as package descriptions.