### PR TITLE
Trigger build on tags

### DIFF
--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -3,6 +3,9 @@ trigger:
   branches:
     include:
     - dev
+  tags:
+    include:
+    - 'v*'
 
 schedules:
 # Ensure we build nightly to catch any new CVEs and report SDL often.

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -5,6 +5,9 @@ trigger:
   branches:
     include:
     - dev
+  tags:
+    include:
+    - 'v*'
 
 schedules:
 # Ensure we build nightly to catch any new CVEs and report SDL often.


### PR DESCRIPTION
Adds trigger for CI build on tags. I have adjusted the pattern slightly to be `v*` instead of `*`. This is because I also intend to lock down creation of those tags to specific members.