### PR TITLE
Delay Adaptive Sampling

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
@@ -258,6 +258,8 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                 { nameof(DiagnosticsEventListenerLogLevel), DiagnosticsEventListenerLogLevel?.ToString() },
                 { nameof(EnableAutocollectedMetricsExtractor), EnableAutocollectedMetricsExtractor },
                 { nameof(EnableMetricsCustomDimensionOptimization), EnableMetricsCustomDimensionOptimization },
+                { nameof(EnableAdaptiveSamplingDelay), EnableAdaptiveSamplingDelay },
+                { nameof(AdaptiveSamplingInitializationDelay), AdaptiveSamplingInitializationDelay },
             };
 
             return options.ToString(Formatting.Indented);

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
@@ -155,6 +155,18 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
         /// </summary>
         public bool EnableMetricsCustomDimensionOptimization { get; set; } = false;
 
+        /// <summary>
+        /// Gets or sets the flag that enables Adaptive Sampling delay.
+        /// Enabled by default.
+        /// </summary>
+        public bool EnableAdaptiveSamplingDelay { get; set; } = true;
+
+        /// <summary>
+        /// Specifies the delay time for initializing Adaptive Sampling, allowing more initialization logs to be sent to Application Insights.
+        /// The default value is 15 seconds.
+        /// </summary>
+        public TimeSpan AdaptiveSamplingInitializationDelay { get; set; } = TimeSpan.FromSeconds(15);
+
         public string Format()
         {
             JObject sampling = null;

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
@@ -394,16 +394,7 @@ namespace Microsoft.Extensions.DependencyInjection
                     }
                     else
                     {
-                        var processor = new AdaptiveSamplingTelemetryProcessor(options.SamplingSettings, null, next);
-                        if (options.SamplingExcludedTypes != null)
-                        {
-                            processor.ExcludedTypes = options.SamplingExcludedTypes;
-                        }
-                        if (options.SamplingIncludedTypes != null)
-                        {
-                            processor.IncludedTypes = options.SamplingIncludedTypes;
-                        }
-                        return processor;
+                        return TelemetryProcessorFactory.CreateAdaptiveSamplingProcessor(options, next);
                     }
                 });
             }

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
@@ -388,16 +388,23 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 configuration.TelemetryProcessorChainBuilder.Use((next) =>
                 {
-                    var processor = new AdaptiveSamplingTelemetryProcessor(options.SamplingSettings, null, next);
-                    if (options.SamplingExcludedTypes != null)
+                    if (options.EnableAdaptiveSamplingDelay)
                     {
-                        processor.ExcludedTypes = options.SamplingExcludedTypes;
+                        return new DelayedSamplingProcessor(next, options);
                     }
-                    if (options.SamplingIncludedTypes != null)
+                    else
                     {
-                        processor.IncludedTypes = options.SamplingIncludedTypes;
+                        var processor = new AdaptiveSamplingTelemetryProcessor(options.SamplingSettings, null, next);
+                        if (options.SamplingExcludedTypes != null)
+                        {
+                            processor.ExcludedTypes = options.SamplingExcludedTypes;
+                        }
+                        if (options.SamplingIncludedTypes != null)
+                        {
+                            processor.IncludedTypes = options.SamplingIncludedTypes;
+                        }
+                        return processor;
                     }
-                    return processor;
                 });
             }
 

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Processors/DelayedSamplingProcessor.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Processors/DelayedSamplingProcessor.cs
@@ -11,14 +11,13 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
     internal class DelayedSamplingProcessor : ITelemetryProcessor
     {
         private readonly AdaptiveSamplingTelemetryProcessor _samplingProcessor;
-        private ITelemetryProcessor next;
-        private bool isSamplingEnabled = false;        
+        private ITelemetryProcessor _next;
+        private bool _isSamplingEnabled = false;        
 
-        public DelayedSamplingProcessor(ITelemetryProcessor next, ApplicationInsightsLoggerOptions options, AdaptiveSamplingTelemetryProcessor samplingProcessor = null)
+        public DelayedSamplingProcessor(ITelemetryProcessor next, ApplicationInsightsLoggerOptions options)
         {
-            this.next = next;
-
-            _samplingProcessor = samplingProcessor ?? new AdaptiveSamplingTelemetryProcessor(options.SamplingSettings, null, next);
+            _next = next;
+            _samplingProcessor = new AdaptiveSamplingTelemetryProcessor(options.SamplingSettings, null, next);
 
             if (options.SamplingExcludedTypes != null)
             {
@@ -35,7 +34,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
 
         public void Process(ITelemetry item)
         {
-            if (isSamplingEnabled)
+            if (_isSamplingEnabled)
             {
                 // Forward to Adaptive Sampling processor
                 _samplingProcessor.Process(item);
@@ -43,13 +42,13 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
             else
             {
                 // Bypass sampling
-                next.Process(item);
+                _next.Process(item);
             }
         }
 
         private void EnableSampling()
         {
-            isSamplingEnabled = true;
+            _isSamplingEnabled = true;
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Processors/DelayedSamplingProcessor.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Processors/DelayedSamplingProcessor.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
+{
+    internal class DelayedSamplingProcessor : ITelemetryProcessor
+    {
+        private readonly AdaptiveSamplingTelemetryProcessor _samplingProcessor;
+        private ITelemetryProcessor next;
+        private bool isSamplingEnabled = false;        
+
+        public DelayedSamplingProcessor(ITelemetryProcessor next, ApplicationInsightsLoggerOptions options, AdaptiveSamplingTelemetryProcessor samplingProcessor = null)
+        {
+            this.next = next;
+
+            _samplingProcessor = samplingProcessor ?? new AdaptiveSamplingTelemetryProcessor(options.SamplingSettings, null, next);
+
+            if (options.SamplingExcludedTypes != null)
+            {
+                _samplingProcessor.ExcludedTypes = options.SamplingExcludedTypes;
+            }
+            if (options.SamplingIncludedTypes != null)
+            {
+                _samplingProcessor.IncludedTypes = options.SamplingIncludedTypes;
+            }
+
+            // Start a timer to enable sampling after a delay        
+            Task.Delay(options.AdaptiveSamplingInitializationDelay).ContinueWith(t => EnableSampling());
+        }
+
+        public void Process(ITelemetry item)
+        {
+            if (isSamplingEnabled)
+            {
+                // Forward to Adaptive Sampling processor
+                _samplingProcessor.Process(item);
+            }
+            else
+            {
+                // Bypass sampling
+                next.Process(item);
+            }
+        }
+
+        private void EnableSampling()
+        {
+            isSamplingEnabled = true;
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Processors/DelayedSamplingProcessor.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Processors/DelayedSamplingProcessor.cs
@@ -16,17 +16,8 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
 
         public DelayedSamplingProcessor(ITelemetryProcessor next, ApplicationInsightsLoggerOptions options)
         {
-            _next = next;
-            _samplingProcessor = new AdaptiveSamplingTelemetryProcessor(options.SamplingSettings, null, next);
-
-            if (options.SamplingExcludedTypes != null)
-            {
-                _samplingProcessor.ExcludedTypes = options.SamplingExcludedTypes;
-            }
-            if (options.SamplingIncludedTypes != null)
-            {
-                _samplingProcessor.IncludedTypes = options.SamplingIncludedTypes;
-            }
+            _next = next;            
+            _samplingProcessor = TelemetryProcessorFactory.CreateAdaptiveSamplingProcessor(options, next);
 
             // Start a timer to enable sampling after a delay        
             Task.Delay(options.AdaptiveSamplingInitializationDelay).ContinueWith(t => EnableSampling());

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Processors/TelemetryProcessorExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Processors/TelemetryProcessorExtensions.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
+
+namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
+{
+    internal static class TelemetryProcessorFactory
+    {
+        internal static AdaptiveSamplingTelemetryProcessor CreateAdaptiveSamplingProcessor(ApplicationInsightsLoggerOptions options, ITelemetryProcessor next = null)
+        {
+            // Create the sampling processor
+            var samplingProcessor = new AdaptiveSamplingTelemetryProcessor(options.SamplingSettings, null, next);
+
+            if (options.SamplingExcludedTypes != null)
+            {
+                samplingProcessor.ExcludedTypes = options.SamplingExcludedTypes;
+            }
+            if (options.SamplingIncludedTypes != null)
+            {
+                samplingProcessor.IncludedTypes = options.SamplingIncludedTypes;
+            }
+            return samplingProcessor;
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <Version>3.0.41$(VersionSuffix)</Version>
+    <Version>3.0.42$(VersionSuffix)</Version>
     <InformationalVersion>$(Version) Commit hash: $(CommitHash)</InformationalVersion>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Microsoft.Azure.WebJobs.Logging.ApplicationInsights</PackageId>


### PR DESCRIPTION
Resolves #3100

The Functions runtime generates important telemetry during startup, but some logs are sampled out due to Adaptive sampling being enabled by default with a `MaxTelemetryItemsPerSecond` of 20. This results in some startup logs being lost when the sampling processor makes its decision.

The proposed change introduces a 15-second delay before Adaptive sampling begins, allowing initial telemetry to be more reliably ingested into AppInsights. The delay duration can be configured, and the feature can be disabled via host.json or appsettings override.