### PR TITLE
Update ServiceBus SDK in test projects

### DIFF
--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/TelemetryValidationHelpers.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/ApplicationInsights/TelemetryValidationHelpers.cs
@@ -73,7 +73,12 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests.ApplicationInsights
             Assert.Equal(requestName, request.Name);
 
             Assert.True(request.Properties.ContainsKey(LogConstants.InvocationIdKey));
-            Assert.True(request.Properties.ContainsKey(LogConstants.TriggerReasonKey));
+
+            if (request.Name != "ServiceBusTrigger") // SB 5.x does not have a trigger
+            {
+                Assert.True(request.Properties.ContainsKey(LogConstants.TriggerReasonKey));
+            }
+
             Assert.StartsWith("webjobs:", request.Context.GetInternalContext().SdkVersion);
 
             Assert.Equal(success, request.Success);

--- a/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/WebJobs.Host.EndToEndTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.EndToEndTests/WebJobs.Host.EndToEndTests.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="appinsights.testlogger" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
 	  <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.16.4" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/Indexers/FunctionIndexerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/Indexers/FunctionIndexerTests.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Indexers
             });
             innerException = exception.InnerException as InvalidOperationException;
             Assert.NotNull(innerException);
-            Assert.Equal("Cannot bind parameter 'receiver' to type ServiceBusReceiver. Make sure the parameter Type is supported by the binding. The binding supports the following parameter names for type ServiceBusReceiver: (ServiceBusReceiver). If you're trying to bind to one of those values, rename your parameter to match the contract name (case insensitive). If you're using binding extensions (e.g. Azure Storage, ServiceBus, Timers, etc.) make sure you've called the registration method for the extension(s) in your startup code (e.g. builder.AddAzureStorage(), builder.AddServiceBus(), builder.AddTimers(), etc.).", innerException.Message);
+            Assert.Equal("Cannot bind parameter 'receiver' to type ServiceBusReceiver. Make sure the parameter Type is supported by the binding. If you're using binding extensions (e.g. Azure Storage, ServiceBus, Timers, etc.) make sure you've called the registration method for the extension(s) in your startup code (e.g. builder.AddAzureStorage(), builder.AddServiceBus(), builder.AddTimers(), etc.).", innerException.Message);
         }
 
         [Theory]

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/Indexers/FunctionIndexerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/Indexers/FunctionIndexerTests.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.ServiceBus.Core;
+using Azure.Messaging.ServiceBus;
 using Microsoft.Azure.WebJobs.Description;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Indexers;
@@ -450,7 +450,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Indexers
 
         // Attempt to bind to a QueueTrigger binding contract member with the wrong name
         // In this case, we're trying to bind to MessageReceiver
-        public static void ServiceBusTrigger_ContractParameterBindingFailsIndexing([ServiceBusTrigger("queue")] string input, MessageReceiver receiver)
+        public static void ServiceBusTrigger_ContractParameterBindingFailsIndexing([ServiceBusTrigger("queue")] string input, ServiceBusReceiver receiver)
         {
             throw new NotImplementedException();
         }

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/Indexers/FunctionIndexerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/Indexers/FunctionIndexerTests.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Indexers
             });
             innerException = exception.InnerException as InvalidOperationException;
             Assert.NotNull(innerException);
-            Assert.Equal("Cannot bind parameter 'receiver' to type MessageReceiver. Make sure the parameter Type is supported by the binding. The binding supports the following parameter names for type MessageReceiver: (MessageReceiver). If you're trying to bind to one of those values, rename your parameter to match the contract name (case insensitive). If you're using binding extensions (e.g. Azure Storage, ServiceBus, Timers, etc.) make sure you've called the registration method for the extension(s) in your startup code (e.g. builder.AddAzureStorage(), builder.AddServiceBus(), builder.AddTimers(), etc.).", innerException.Message);
+            Assert.Equal("Cannot bind parameter 'receiver' to type ServiceBusReceiver. Make sure the parameter Type is supported by the binding. The binding supports the following parameter names for type ServiceBusReceiver: (ServiceBusReceiver). If you're trying to bind to one of those values, rename your parameter to match the contract name (case insensitive). If you're using binding extensions (e.g. Azure Storage, ServiceBus, Timers, etc.) make sure you've called the registration method for the extension(s) in your startup code (e.g. builder.AddAzureStorage(), builder.AddServiceBus(), builder.AddTimers(), etc.).", innerException.Message);
         }
 
         [Theory]
@@ -449,7 +449,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Indexers
         }
 
         // Attempt to bind to a QueueTrigger binding contract member with the wrong name
-        // In this case, we're trying to bind to MessageReceiver
+        // In this case, we're trying to bind to ServiceBusReceiver
         public static void ServiceBusTrigger_ContractParameterBindingFailsIndexing([ServiceBusTrigger("queue")] string input, ServiceBusReceiver receiver)
         {
             throw new NotImplementedException();

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/WebJobs.Host.FunctionalTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/WebJobs.Host.FunctionalTests.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.16.4" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Upgrades service bus webjobs package to v5.x in the e2e and functional test projects. Also moves ServiceBus SDK to track 2.