### PR TITLE
Fix flaky unit test relying on timing

### DIFF
--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Timers/TaskSeriesTimerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Timers/TaskSeriesTimerTests.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
-using DotNext.Threading;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.Azure.WebJobs.Host.Timers;
 using Moq;
@@ -97,19 +96,27 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Timers
         {
             // Arrange
             int executionCount = 0;
-            static Task SecondRunAsync(AsyncManualResetEvent reset)
+
+            static async Task FirstRunAsync(Task gate)
             {
-                reset.Set();
-                return Task.CompletedTask;
+                await gate;
+                await Task.Delay(5);
             }
 
-            using var reset = new AsyncManualResetEvent(false);
+            static async Task SecondRunAsync(TaskCompletionSource tcs)
+            {
+                tcs.SetResult();
+                await Task.Delay(5);
+            }
+
+            var tcs1 = new TaskCompletionSource();
+            var tcs2 = new TaskCompletionSource();
             ITaskSeriesCommand command = CreateCommand(() =>
             {
                 return executionCount++ switch
                 {
-                    0 => new TaskSeriesCommandResult(reset.WaitAsync().AsTask()),
-                    1 => new TaskSeriesCommandResult(SecondRunAsync(reset)),
+                    0 => new TaskSeriesCommandResult(FirstRunAsync(tcs1.Task)),
+                    1 => new TaskSeriesCommandResult(SecondRunAsync(tcs2)),
                     _ => throw new InvalidOperationException("No more iterations needed."),
                 };
             });
@@ -123,10 +130,9 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Timers
             // If the TaskSeriesTimer ever proceeds to the next iteration without awaiting the first, we will
             // see tcs2.Task be completed early and this test will fail.
             await Task.Delay(10);
-            Assert.Equal(1, executionCount);
-            reset.Set();
-            await reset.WaitAsync(TimeSpan.FromMilliseconds(100));
-            Assert.Equal(2, executionCount);
+            Assert.False(tcs2.Task.IsCompleted);
+            tcs1.SetResult();
+            await tcs2.Task.WaitAsync(TimeSpan.FromMilliseconds(100));
         }
 
         [Fact]
@@ -447,25 +453,26 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Timers
         {
             // Arrange
             int executionCount = 0;
-            using var reset = new AsyncManualResetEvent(false);
-            TimeSpan timeout = TimeSpan.FromMicroseconds(100);
+            var tcs1 = new TaskCompletionSource();
+            var tcs2 = new TaskCompletionSource();
+            TimeSpan timeout = TimeSpan.FromMilliseconds(100);
             ITaskSeriesCommand command = CreateCommand(async () =>
             {
                 executionCount++;
-                reset.Set();
-                await reset.WaitAsync(timeout);
+                tcs1.TrySetResult();
+                await tcs2.Task.WaitAsync(timeout);
                 return new TaskSeriesCommandResult(Task.CompletedTask);
             });
 
             // Act
-            using ITaskSeriesTimer product = CreateProductUnderTest(command);
+            using TaskSeriesTimer product = CreateProductUnderTest(command);
             product.Start();
 
             // Assert
-            await reset.WaitAsync(timeout);
+            await tcs1.Task.WaitAsync(timeout);
             Assert.Equal(1, executionCount);
             Task stop = product.StopAsync(default);
-            reset.Set();
+            tcs2.TrySetResult();
             await stop.WaitAsync(timeout);
 
             Assert.Equal(1, executionCount);

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Timers/TaskSeriesTimerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Timers/TaskSeriesTimerTests.cs
@@ -92,50 +92,48 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Timers
         }
 
         [Fact]
-        public void Start_AfterExecute_WaitsForReturnedWait()
+        public async Task Start_AfterExecute_WaitsForReturnedWait()
         {
             // Arrange
-            bool executedOnce = false;
-            bool executedTwice = false;
-            TimeSpan initialInterval = TimeSpan.Zero;
-            // Detect the difference between waiting and not waiting, but keep the test execution time fast.
-            TimeSpan subsequentInterval = TimeSpan.FromMilliseconds(5);
-            Stopwatch stopwatch = new Stopwatch();
+            int executionCount = 0;
 
-            using (EventWaitHandle waitForSecondExecution = new ManualResetEvent(initialState: false))
+            static async Task FirstRunAsync(Task gate)
             {
-                ITaskSeriesCommand command = CreateCommand(() =>
-                {
-                    if (executedTwice)
-                    {
-                        return new TaskSeriesCommandResult(wait: Task.Delay(TimeSpan.FromDays(1)));
-                    }
-
-                    if (!executedOnce)
-                    {
-                        stopwatch.Start();
-                        executedOnce = true;
-                        return new TaskSeriesCommandResult(wait: Task.Delay(subsequentInterval));
-                    }
-                    else
-                    {
-                        stopwatch.Stop();
-                        executedTwice = true;
-                        Assert.True(waitForSecondExecution.Set()); // Guard
-                        return new TaskSeriesCommandResult(wait: Task.Delay(initialInterval));
-                    }
-                });
-
-                using (ITaskSeriesTimer product = CreateProductUnderTest(command))
-                {
-                    // Act
-                    product.Start();
-
-                    // Assert
-                    Assert.True(waitForSecondExecution.WaitOne(1000)); // Guard
-                    AssertGreaterThan(subsequentInterval, stopwatch.Elapsed);
-                }
+                await gate;
+                await Task.Delay(5);
             }
+
+            static async Task SecondRunAsync(TaskCompletionSource tcs)
+            {
+                tcs.SetResult();
+                await Task.Delay(5);
+            }
+
+            // Detect the difference between waiting and not waiting, but keep the test execution time fast.
+            var tcs1 = new TaskCompletionSource();
+            var tcs2 = new TaskCompletionSource();
+            ITaskSeriesCommand command = CreateCommand(() =>
+            {
+                return executionCount++ switch
+                {
+                    0 => new TaskSeriesCommandResult(FirstRunAsync(tcs1.Task)),
+                    1 => new TaskSeriesCommandResult(SecondRunAsync(tcs2)),
+                    _ => throw new InvalidOperationException("No more iterations needed."),
+                };
+            });
+
+            // Act
+            using TaskSeriesTimer product = CreateProductUnderTest(command);
+            product.Start();
+
+            // Assert
+            // tcs2.Task is completed by the 2nd run. But the 2nd run should not occur until we unblock the 1st run.
+            // If the TaskSeriesTimer ever proceeds to the next iteration without awaiting the first, we will
+            // see tcs2.Task be completed early and this test will fail.
+            await Task.Delay(10);
+            Assert.False(tcs2.Task.IsCompleted);
+            tcs1.SetResult();
+            await tcs2.Task.WaitAsync(TimeSpan.FromMilliseconds(100));
         }
 
         [Fact]
@@ -836,8 +834,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Timers
 
         private static void AssertGreaterThan(TimeSpan expected, TimeSpan actual)
         {
-            string message = String.Format("{0} > {1}", actual, expected);
-            Assert.True(actual > expected, message);
+            Assert.True(actual > expected, $"{actual} > {expected}");
         }
 
         private static ITaskSeriesCommand CreateCommand(Func<TaskSeriesCommandResult> execute)

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Timers/TaskSeriesTimerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Timers/TaskSeriesTimerTests.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
+using DotNext.Threading;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.Azure.WebJobs.Host.Timers;
 using Moq;
@@ -96,28 +97,19 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Timers
         {
             // Arrange
             int executionCount = 0;
-
-            static async Task FirstRunAsync(Task gate)
+            static Task SecondRunAsync(AsyncManualResetEvent reset)
             {
-                await gate;
-                await Task.Delay(5);
+                reset.Set();
+                return Task.CompletedTask;
             }
 
-            static async Task SecondRunAsync(TaskCompletionSource tcs)
-            {
-                tcs.SetResult();
-                await Task.Delay(5);
-            }
-
-            // Detect the difference between waiting and not waiting, but keep the test execution time fast.
-            var tcs1 = new TaskCompletionSource();
-            var tcs2 = new TaskCompletionSource();
+            using var reset = new AsyncManualResetEvent(false);
             ITaskSeriesCommand command = CreateCommand(() =>
             {
                 return executionCount++ switch
                 {
-                    0 => new TaskSeriesCommandResult(FirstRunAsync(tcs1.Task)),
-                    1 => new TaskSeriesCommandResult(SecondRunAsync(tcs2)),
+                    0 => new TaskSeriesCommandResult(reset.WaitAsync().AsTask()),
+                    1 => new TaskSeriesCommandResult(SecondRunAsync(reset)),
                     _ => throw new InvalidOperationException("No more iterations needed."),
                 };
             });
@@ -131,9 +123,10 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Timers
             // If the TaskSeriesTimer ever proceeds to the next iteration without awaiting the first, we will
             // see tcs2.Task be completed early and this test will fail.
             await Task.Delay(10);
-            Assert.False(tcs2.Task.IsCompleted);
-            tcs1.SetResult();
-            await tcs2.Task.WaitAsync(TimeSpan.FromMilliseconds(100));
+            Assert.Equal(1, executionCount);
+            reset.Set();
+            await reset.WaitAsync(TimeSpan.FromMilliseconds(100));
+            Assert.Equal(2, executionCount);
         }
 
         [Fact]
@@ -450,46 +443,32 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Timers
         }
 
         [Fact]
-        public void StopAsync_TriggersNotExecutingAgain()
+        public async Task StopAsync_TriggersNotExecutingAgain()
         {
             // Arrange
-            using (EventWaitHandle executedOnceWaitHandle = new ManualResetEvent(initialState: false))
+            int executionCount = 0;
+            using var reset = new AsyncManualResetEvent(false);
+            TimeSpan timeout = TimeSpan.FromMicroseconds(100);
+            ITaskSeriesCommand command = CreateCommand(async () =>
             {
-                ITaskSeriesTimer product = null;
-                Task stop = null;
-                bool executedOnce = false;
-                bool executedTwice = false;
+                executionCount++;
+                reset.Set();
+                await reset.WaitAsync(timeout);
+                return new TaskSeriesCommandResult(Task.CompletedTask);
+            });
 
-                ITaskSeriesCommand command = CreateCommand(() =>
-                {
-                    if (!executedOnce)
-                    {
-                        stop = product.StopAsync(CancellationToken.None);
-                        Assert.True(executedOnceWaitHandle.Set()); // Guard
-                        executedOnce = true;
-                        return new TaskSeriesCommandResult(wait: Task.Delay(0));
-                    }
-                    else
-                    {
-                        executedTwice = true;
-                        return new TaskSeriesCommandResult(wait: Task.Delay(0));
-                    }
-                });
+            // Act
+            using ITaskSeriesTimer product = CreateProductUnderTest(command);
+            product.Start();
 
-                using (product = CreateProductUnderTest(command))
-                {
-                    product.Start();
+            // Assert
+            await reset.WaitAsync(timeout);
+            Assert.Equal(1, executionCount);
+            Task stop = product.StopAsync(default);
+            reset.Set();
+            await stop.WaitAsync(timeout);
 
-                    // Act
-                    bool executed = executedOnceWaitHandle.WaitOne(3000);
-
-                    // Assert
-                    Assert.True(executed); // Guard
-                    Assert.NotNull(stop);
-                    stop.GetAwaiter().GetResult();
-                    Assert.False(executedTwice);
-                }
-            }
+            Assert.Equal(1, executionCount);
         }
 
         [Fact]

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
@@ -16,7 +16,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNext.Threading" Version="5.21.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.22" />

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/WebJobs.Host.UnitTests.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="DotNext.Threading" Version="5.21.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.22" />


### PR DESCRIPTION
This test was relying on timing control by comparing two durations. This was not always accurate. This PR refactors to use a gate system to ensure the calls are sequential. The test controls the 1st gate, and the system under test controls the 2nd. The test asserts the 2nd gate does not open until _after_ it has opened the 1st gate.