### PR TITLE
Use common artifacts

### DIFF
--- a/WebJobs.sln
+++ b/WebJobs.sln
@@ -41,6 +41,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebJobs.Extensions.Rpc.Unit
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebJobs.Shared", "src\Microsoft.Azure.WebJobs.Shared\WebJobs.Shared.csproj", "{404D3F0E-B531-4470-97DB-A0101444AB12}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebJobs.Host.Sources", "src\Microsoft.Azure.WebJobs.Host\WebJobs.Host.Sources.csproj", "{5386A876-23BC-4D3B-98BB-2A6409B1427D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -243,6 +245,18 @@ Global
 		{404D3F0E-B531-4470-97DB-A0101444AB12}.Release|x64.Build.0 = Release|Any CPU
 		{404D3F0E-B531-4470-97DB-A0101444AB12}.Release|x86.ActiveCfg = Release|Any CPU
 		{404D3F0E-B531-4470-97DB-A0101444AB12}.Release|x86.Build.0 = Release|Any CPU
+		{5386A876-23BC-4D3B-98BB-2A6409B1427D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5386A876-23BC-4D3B-98BB-2A6409B1427D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5386A876-23BC-4D3B-98BB-2A6409B1427D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5386A876-23BC-4D3B-98BB-2A6409B1427D}.Debug|x64.Build.0 = Debug|Any CPU
+		{5386A876-23BC-4D3B-98BB-2A6409B1427D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5386A876-23BC-4D3B-98BB-2A6409B1427D}.Debug|x86.Build.0 = Debug|Any CPU
+		{5386A876-23BC-4D3B-98BB-2A6409B1427D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5386A876-23BC-4D3B-98BB-2A6409B1427D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5386A876-23BC-4D3B-98BB-2A6409B1427D}.Release|x64.ActiveCfg = Release|Any CPU
+		{5386A876-23BC-4D3B-98BB-2A6409B1427D}.Release|x64.Build.0 = Release|Any CPU
+		{5386A876-23BC-4D3B-98BB-2A6409B1427D}.Release|x86.ActiveCfg = Release|Any CPU
+		{5386A876-23BC-4D3B-98BB-2A6409B1427D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/eng/build/Engineering.props
+++ b/eng/build/Engineering.props
@@ -1,5 +1,12 @@
 <Project>
 
+  <!-- artifacts -->
+  <PropertyGroup>
+    <ArtifactsPath>$(RepoRoot)out</ArtifactsPath>
+    <ArtifactsPublishOutputName>pub</ArtifactsPublishOutputName>
+    <ArtifactsPackageOutputName>pkg</ArtifactsPackageOutputName>
+  </PropertyGroup>
+
   <PropertyGroup>
     <!-- Nuget audit as warnings only, even in TreatWarningsAsErrors. -->
     <!-- Except for in CI, critical will fail the build. -->

--- a/eng/ci/templates/variables/build.yml
+++ b/eng/ci/templates/variables/build.yml
@@ -8,6 +8,6 @@ variables:
 - name: configuration
   value: release
 - name: project
-  value: Webjobs.sln
+  value: WebJobs.sln
 - name: Build.Counter
   value: $[counter(format('{0:yyyyMMdd}', pipeline.startTime), 0)]


### PR DESCRIPTION
Adopt common artifacts feature of dotnet SDK. CI yaml files are not updated as they provide explicit nuget package output paths via `-o`, meaning this change does not affect them.