### PR TITLE
Run code-mirror once a month

### DIFF
--- a/eng/ci/code-mirror.yml
+++ b/eng/ci/code-mirror.yml
@@ -7,6 +7,15 @@ trigger:
     include:
     - '*'
 
+schedules:
+# Run once a month to prevent disablement from inactivity.
+- cron: "0 0 1 * *"
+  displayName: Monthly sync
+  branches:
+    include:
+    - dev
+  always: true
+
 resources:
   repositories:
   - repository: eng


### PR DESCRIPTION
Pipelines are disabled if inactive for 90 days. Since this repo gets infrequent check-ins adding a schedule to avoid code-mirror from going inactive.