### PR TITLE
Add logging to investigate pipeline failures

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Executors/DefaultHostIdProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/DefaultHostIdProvider.cs
@@ -43,6 +43,34 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             return Task.FromResult(_hostId);
         }
 
+        public string GetFirstJobMethod()
+        {
+            // Search through all types for the first job method.
+            // The reason we have to do this rather than attempt to use the entry assembly
+            // (Assembly.GetEntryAssembly) is because that doesn't work for WebApps, and the
+            // SDK supports both WebApp and Console app hosts.
+            MethodInfo firstJobMethod = null;
+            foreach (var type in _typeLocator.GetTypes())
+            {
+                firstJobMethod = FunctionIndexer.GetJobMethods(type).FirstOrDefault();
+                if (firstJobMethod != null)
+                {
+                    _logger.LogDebug("Found first job method: {Method}", firstJobMethod.Name);
+
+                    break;
+                }
+            }
+
+            // Compute hash and map to Guid
+            // If the job host doesn't yet have any job methods (e.g. it's a new project)
+            // then a default ID is generated
+            string hostName = firstJobMethod?.DeclaringType.Assembly.FullName ?? "Unknown";
+
+            _logger.LogDebug("Computing Host ID. Using host name: {HostName}", hostName);
+
+            return hostName;
+        }
+
         private string ComputeHostId()
         {
             // Search through all types for the first job method.

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/DefaultHostIdProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/DefaultHostIdProvider.cs
@@ -54,6 +54,8 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
                 firstJobMethod = FunctionIndexer.GetJobMethods(type).FirstOrDefault();
                 if (firstJobMethod != null)
                 {
+                    _logger.LogDebug("Found first job method: {Method}", firstJobMethod.Name);
+
                     break;
                 }
             }
@@ -62,6 +64,9 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             // If the job host doesn't yet have any job methods (e.g. it's a new project)
             // then a default ID is generated
             string hostName = firstJobMethod?.DeclaringType.Assembly.FullName ?? "Unknown";
+
+            _logger.LogDebug("Computing Host ID. Using host name: {HostName}", hostName);
+
             Guid id;
 
             // CodeQL [SM02196] cannot update the HostId as this would break the customers. MD5 hash is used only for generating unique HostIds and not for encryption or hashing secrets.

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/DefaultHostIdProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/DefaultHostIdProvider.cs
@@ -22,9 +22,10 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
         private readonly ILogger<DefaultHostIdProvider> _logger;
         private string _hostId;
 
-        public DefaultHostIdProvider(ITypeLocator typeLocator)
+        public DefaultHostIdProvider(ITypeLocator typeLocator, ILogger<DefaultHostIdProvider> logger)
         {
             _typeLocator = typeLocator;
+            _logger = logger;
         }
 
         public Task<string> GetHostIdAsync(CancellationToken cancellationToken)

--- a/src/Microsoft.Azure.WebJobs.Host/Executors/DefaultHostIdProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Executors/DefaultHostIdProvider.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Indexers;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Host.Executors
 {
@@ -18,6 +19,7 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
     internal class DefaultHostIdProvider : IHostIdProvider
     {
         private readonly ITypeLocator _typeLocator;
+        private readonly ILogger<DefaultHostIdProvider> _logger;
         private string _hostId;
 
         public DefaultHostIdProvider(ITypeLocator typeLocator)
@@ -30,7 +32,13 @@ namespace Microsoft.Azure.WebJobs.Host.Executors
             if (_hostId == null)
             {
                 _hostId = ComputeHostId();
+                _logger.LogDebug("Host ID not cached. Computed Host ID: {HostId}", _hostId);
             }
+            else
+            {
+                _logger.LogDebug("Returning cached Host ID: {HostId}", _hostId);
+            }
+
             return Task.FromResult(_hostId);
         }
 

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/ILoggerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/ILoggerTests.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
             }
 
             // Five loggers are the startup, singleton, results, function and function.user
-            Assert.Equal(10, loggerProvider.CreatedLoggers.Count);
+            Assert.Equal(11, loggerProvider.CreatedLoggers.Count);
             var functionLogger = loggerProvider.CreatedLoggers.Where(l => l.Category == LogCategories.CreateFunctionUserCategory(functionName)).Single();
             Assert.Equal(2, functionLogger.GetLogMessages().Count);
             var infoMessage = functionLogger.GetLogMessages()[0];

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/ILoggerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/ILoggerTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
 
             // Six loggers are the startup, singleton, results, function and function.user
             // Note: We currently have 3 additional Logger<T> categories that need to be renamed
-            Assert.Equal(10, loggerProvider.CreatedLoggers.Count);
+            Assert.Equal(11, loggerProvider.CreatedLoggers.Count);
 
             var functionLogger = loggerProvider.CreatedLoggers.Where(l => l.Category == LogCategories.CreateFunctionUserCategory(functionName)).Single();
             var resultsLogger = loggerProvider.CreatedLoggers.Where(l => l.Category == LogCategories.Results).Single();

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/ILoggerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/ILoggerTests.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
 
             // Six loggers are the startup, singleton, results, function and function.user
             // Note: We currently have 3 additional Logger<T> categories that need to be renamed
-            Assert.Equal(10, loggerProvider.CreatedLoggers.Count);
+            Assert.Equal(11, loggerProvider.CreatedLoggers.Count);
 
             var functionLogger = loggerProvider.CreatedLoggers.Where(l => l.Category == LogCategories.CreateFunctionUserCategory(functionName)).Single();
             var resultsLogger = loggerProvider.CreatedLoggers.Where(l => l.Category == LogCategories.Results).Single();

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/DefaultHostIdProviderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/DefaultHostIdProviderTests.cs
@@ -41,7 +41,6 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             // ensure the same ID is returned each time
             mockTypeLocator = new Mock<ITypeLocator>(MockBehavior.Strict);
             mockTypeLocator.Setup(p => p.GetTypes()).Returns(new Type[] { type });
-            var logger = CreateLogger();
             idProvider = new DefaultHostIdProvider(mockTypeLocator.Object, logger);
             Assert.Equal(expected, await idProvider.GetHostIdAsync(CancellationToken.None));
 
@@ -76,7 +75,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             // ensure the same ID is returned each time
             mockTypeLocator = new Mock<ITypeLocator>(MockBehavior.Strict);
             mockTypeLocator.Setup(p => p.GetTypes()).Returns(new Type[] { type });
-            idProvider = new DefaultHostIdProvider(mockTypeLocator.Object);
+            idProvider = new DefaultHostIdProvider(mockTypeLocator.Object, logger);
             Assert.Equal(expected, await idProvider.GetHostIdAsync(CancellationToken.None));
         }
 

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/DefaultHostIdProviderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/DefaultHostIdProviderTests.cs
@@ -1,13 +1,14 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Azure.WebJobs.Host.Indexers;
+using Microsoft.Extensions.Logging;
+using Moq;
 using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.WebJobs.Host.Executors;
-using Microsoft.Azure.WebJobs.Host.Indexers;
-using Moq;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
@@ -25,7 +26,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
 
             var mockTypeLocator = new Mock<ITypeLocator>(MockBehavior.Strict);
             mockTypeLocator.Setup(p => p.GetTypes()).Returns(new Type[] { type });
-            var idProvider = new DefaultHostIdProvider(mockTypeLocator.Object);
+            var idProvider = new DefaultHostIdProvider(mockTypeLocator.Object, );
 
             // as long as this test assembly name stays the same, the ID
             // computed should remain static. If this test is failing
@@ -39,7 +40,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             // ensure the same ID is returned each time
             mockTypeLocator = new Mock<ITypeLocator>(MockBehavior.Strict);
             mockTypeLocator.Setup(p => p.GetTypes()).Returns(new Type[] { type });
-            idProvider = new DefaultHostIdProvider(mockTypeLocator.Object);
+            var logger = CreateLogger();
+            idProvider = new DefaultHostIdProvider(mockTypeLocator.Object, logger);
             Assert.Equal(expected, await idProvider.GetHostIdAsync(CancellationToken.None));
 
             // ensure once the ID is computed, a cached result is returned
@@ -58,7 +60,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
 
             var mockTypeLocator = new Mock<ITypeLocator>(MockBehavior.Strict);
             mockTypeLocator.Setup(p => p.GetTypes()).Returns(new Type[] { type });
-            var idProvider = new DefaultHostIdProvider(mockTypeLocator.Object);
+            var logger = CreateLogger();
+            var idProvider = new DefaultHostIdProvider(mockTypeLocator.Object, logger);
 
             // as long as this test assembly name stays the same, the ID
             // computed should remain static. If this test is failing
@@ -79,6 +82,12 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
         // This is a publically discoverable job function used by the test above
         public static void TestQueueFunction([FakeQueueTrigger] string message)
         {
+        }
+
+        private static ILogger<DefaultHostIdProvider> CreateLogger()
+        {
+            // Use a no-op logger for testing
+            return new LoggerFactory().CreateLogger<DefaultHostIdProvider>();
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/DefaultHostIdProviderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/DefaultHostIdProviderTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             var type = GetType();
             var firstJobMethod = FunctionIndexer.GetJobMethods(type).FirstOrDefault();
             Assert.NotNull(firstJobMethod);
-            Assert.Equal(nameof(TestQueueFunction), firstJobMethod?.DeclaringType.Assembly.FullName.Substring(37));
+            Assert.Equal(nameof(TestQueueFunction), firstJobMethod?.DeclaringType.Assembly.FullName.Substring(65));
             Console.WriteLine("Using assembly: " + firstJobMethod?.DeclaringType.Assembly.FullName);
 
             var mockTypeLocator = new Mock<ITypeLocator>(MockBehavior.Strict);

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/DefaultHostIdProviderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/DefaultHostIdProviderTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             var type = GetType();
             var firstJobMethod = FunctionIndexer.GetJobMethods(type).FirstOrDefault();
             Assert.NotNull(firstJobMethod);
-            Assert.Equal(nameof(TestQueueFunction), firstJobMethod?.DeclaringType.Assembly.FullName);
+            Assert.Equal(nameof(TestQueueFunction), firstJobMethod?.DeclaringType.Assembly.FullName.Substring(37));
             Console.WriteLine("Using assembly: " + firstJobMethod?.DeclaringType.Assembly.FullName);
 
             var mockTypeLocator = new Mock<ITypeLocator>(MockBehavior.Strict);

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/DefaultHostIdProviderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/DefaultHostIdProviderTests.cs
@@ -26,7 +26,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
 
             var mockTypeLocator = new Mock<ITypeLocator>(MockBehavior.Strict);
             mockTypeLocator.Setup(p => p.GetTypes()).Returns(new Type[] { type });
-            var idProvider = new DefaultHostIdProvider(mockTypeLocator.Object, );
+            var logger = CreateLogger();
+            var idProvider = new DefaultHostIdProvider(mockTypeLocator.Object, logger);
 
             // as long as this test assembly name stays the same, the ID
             // computed should remain static. If this test is failing

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/DefaultHostIdProviderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/DefaultHostIdProviderTests.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             var firstJobMethod = FunctionIndexer.GetJobMethods(type).FirstOrDefault();
             Assert.NotNull(firstJobMethod);
             Assert.Equal(nameof(TestQueueFunction), firstJobMethod?.DeclaringType.Assembly.FullName);
+            Console.WriteLine("Using assembly: " + firstJobMethod?.DeclaringType.Assembly.FullName);
 
             var mockTypeLocator = new Mock<ITypeLocator>(MockBehavior.Strict);
             mockTypeLocator.Setup(p => p.GetTypes()).Returns(new Type[] { type });

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/DefaultHostIdProviderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/DefaultHostIdProviderTests.cs
@@ -23,8 +23,6 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             var type = GetType();
             var firstJobMethod = FunctionIndexer.GetJobMethods(type).FirstOrDefault();
             Assert.NotNull(firstJobMethod);
-            Assert.Equal(nameof(TestQueueFunction), firstJobMethod?.DeclaringType.Assembly.FullName.Substring(68));
-            Console.WriteLine("Using assembly: " + firstJobMethod?.DeclaringType.Assembly.FullName);
 
             var mockTypeLocator = new Mock<ITypeLocator>(MockBehavior.Strict);
             mockTypeLocator.Setup(p => p.GetTypes()).Returns(new Type[] { type });
@@ -36,6 +34,9 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             // it likely means we've changed the ID computation algorithm
             // which would be a BREAKING CHANGE
             string expected = "6f77803292aa75ec8e56b07b02b633e3";
+
+            var getHostName = idProvider.GetFirstJobMethod();
+            Assert.Equal("someName", getHostName.Substring(65));
 
             var id = await idProvider.GetHostIdAsync(CancellationToken.None);
             Assert.Equal(expected, id);

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/DefaultHostIdProviderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/DefaultHostIdProviderTests.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             var type = GetType();
             var firstJobMethod = FunctionIndexer.GetJobMethods(type).FirstOrDefault();
             Assert.NotNull(firstJobMethod);
+            Assert.Equal(nameof(TestQueueFunction), firstJobMethod?.DeclaringType.Assembly.FullName);
 
             var mockTypeLocator = new Mock<ITypeLocator>(MockBehavior.Strict);
             mockTypeLocator.Setup(p => p.GetTypes()).Returns(new Type[] { type });

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/DefaultHostIdProviderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Executors/DefaultHostIdProviderTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Executors
             var type = GetType();
             var firstJobMethod = FunctionIndexer.GetJobMethods(type).FirstOrDefault();
             Assert.NotNull(firstJobMethod);
-            Assert.Equal(nameof(TestQueueFunction), firstJobMethod?.DeclaringType.Assembly.FullName.Substring(65));
+            Assert.Equal(nameof(TestQueueFunction), firstJobMethod?.DeclaringType.Assembly.FullName.Substring(68));
             Console.WriteLine("Using assembly: " + firstJobMethod?.DeclaringType.Assembly.FullName);
 
             var mockTypeLocator = new Mock<ITypeLocator>(MockBehavior.Strict);


### PR DESCRIPTION
Adding logging to investigate why tests using this value will fail on some pipeline runs but not others.