### PR TITLE
Further refine bin path and sign pattern

### DIFF
--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -50,11 +50,10 @@ jobs:
       - template: ci/sign-files.yml@eng
         parameters:
           displayName: Sign assemblies
-          folderPath: out/bin
+          folderPath: out/bin/src
           minimatch: true
           pattern: |
             **/Microsoft.Azure.WebJobs*.dll
-            !**/*Test*.dll
           signType: dll-strong-name
 
     - task: DotNetCoreCLI@2

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>
+    <ArtifactsBinOutputName>bin/src</ArtifactsBinOutputName>
   </PropertyGroup>
 
 </Project>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,10 +1,9 @@
 <Project>
-
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"
           Condition="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../')) != ''" />
-          
+
   <PropertyGroup>
-    <ArtifactsBinOutputName>bin/sample</ArtifactsBinOutputName>
+    <ArtifactsBinOutputName>bin/test</ArtifactsBinOutputName>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This PR separates the bin path of sample, src, and test to their own sub directory. Allowing for easier scoping of sign step.