### PR TITLE
No longer build Logging projects in CI

### DIFF
--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -66,8 +66,6 @@ jobs:
           src\Microsoft.Azure.WebJobs\WebJobs.csproj
           src\Microsoft.Azure.WebJobs.Host\WebJobs.Host.csproj
           src\Microsoft.Azure.WebJobs.Host\WebJobs.Host.Sources.csproj
-          src\Microsoft.Azure.WebJobs.Logging\WebJobs.Logging.csproj
-          src\Microsoft.Azure.WebJobs.Logging.ApplicationInsights\WebJobs.Logging.ApplicationInsights.csproj
           src\Microsoft.Azure.WebJobs.Host.Storage\WebJobs.Host.Storage.csproj
           src\Microsoft.Azure.WebJobs.Rpc.Core\WebJobs.Rpc.Core.csproj
           src\Microsoft.Azure.WebJobs.Extensions.Rpc\WebJobs.Extensions.Rpc.csproj

--- a/eng/ci/templates/jobs/run-integration-tests.yml
+++ b/eng/ci/templates/jobs/run-integration-tests.yml
@@ -30,7 +30,6 @@ jobs:
       arguments: -c $(configuration) --no-build
       projects: |
         test\Microsoft.Azure.WebJobs.Host.FunctionalTests\*.csproj
-        test\Microsoft.Azure.WebJobs.Logging.FunctionalTests\*.csproj
         test\Microsoft.Azure.WebJobs.Host.EndToEndTests\*.csproj
     env:
       AzureWebJobsDashboard: $(Storage)

--- a/sample/SampleHost/Program.cs
+++ b/sample/SampleHost/Program.cs
@@ -32,19 +32,13 @@ namespace SampleHost
                 {
                     b.SetMinimumLevel(LogLevel.Debug);
                     b.AddConsole();
-
-                    // If this key exists in any config, use it to enable App Insights
-                    string appInsightsKey = context.Configuration["APPINSIGHTS_INSTRUMENTATIONKEY"];
-                    if (!string.IsNullOrEmpty(appInsightsKey))
-                    {
-                        b.AddApplicationInsightsWebJobs(o => o.InstrumentationKey = appInsightsKey);
-                    }
                 })
                 .ConfigureServices(services =>
                 {
                     // add some sample services to demonstrate job class DI
                     services.AddSingleton<ISampleServiceA, SampleServiceA>();
                     services.AddSingleton<ISampleServiceB, SampleServiceB>();
+                    services.AddApplicationInsightsTelemetryWorkerService();
                 })
                 .UseConsoleLifetime();
 

--- a/sample/SampleHost/SampleHost.csproj
+++ b/sample/SampleHost/SampleHost.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="6.3.5" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.16.4" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.3.3" />
@@ -25,7 +26,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Azure.WebJobs.Host.Storage\WebJobs.Host.Storage.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Azure.WebJobs.Host\WebJobs.Host.csproj" />
-    <ProjectReference Include="..\..\src\Microsoft.Azure.WebJobs.Logging.ApplicationInsights\WebJobs.Logging.ApplicationInsights.csproj" />
   </ItemGroup>
   
 


### PR DESCRIPTION
We intend to deprecate/remove these projects as they have long been replaced by using the official app insights SDK or other logging frameworks. This PR drops them from CI to skip releasing them.