### PR TITLE
Fix race condition in ShutdownListener constructor

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Listeners/ShutdownListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Listeners/ShutdownListener.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Azure.WebJobs.Host.Listeners
         public ShutdownListener(CancellationToken shutdownToken, IListener innerListener)
         {
             _shutdownToken = shutdownToken;
-            _shutdownRegistration = shutdownToken.Register(Cancel);
             _innerListener = innerListener;
+            _shutdownRegistration = shutdownToken.Register(Cancel);
         }
 
         public async Task StartAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary

Fixes #2927 

This PR fixes a race condition in the `ShutdownListener` constructor that causes a `NullReferenceException` when the shutdown token fires during initialization.

## The Problem

The constructor was registering the cancellation callback before assigning `_innerListener`:

```csharp
_shutdownToken = shutdownToken;
_shutdownRegistration = shutdownToken.Register(Cancel);  // Registers Cancel callback
_innerListener = innerListener;  // Assigned AFTER
```

If the shutdown token fired in the microseconds between registering the callback and assigning `_innerListener`, the `Cancel()` method would be invoked with `_innerListener` still null, resulting in a `NullReferenceException` at line 40.

## The Fix

This PR swaps the order to assign `_innerListener` before registering the callback:

```csharp
_shutdownToken = shutdownToken;
_innerListener = innerListener;  // Now assigned FIRST
_shutdownRegistration = shutdownToken.Register(Cancel);  // Safe to register
```

This ensures `_innerListener` is always initialized when `Cancel()` is invoked, eliminating the race condition.

## Testing

- ✅ Build verified successfully
- This is a defensive fix for a rare production race condition

## Impact

This is a critical fix for production stability. The race condition is rare but when it occurs, it causes the entire WebJob to crash during startup.