### PR TITLE
fixing race in Binder that can cause NullReferenceExceptions

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/Runtime/Binder.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/Runtime/Binder.cs
@@ -153,18 +153,8 @@ namespace Microsoft.Azure.WebJobs
         /// <returns></returns>
         internal async Task Complete(CancellationToken cancellationToken)
         {
-            if (_binders == null)
-            {
-                return;
-            }
-
             foreach (IValueBinder binder in _binders)
             {
-                if (binder == null)
-                {
-                    continue;
-                }
-
                 // Binding can only be uses for non-Out parameters, and their binders ignore this argument.
                 await binder.SetValueAsync(value: null, cancellationToken: cancellationToken);
             }

--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/Runtime/Binder.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/Runtime/Binder.cs
@@ -153,8 +153,18 @@ namespace Microsoft.Azure.WebJobs
         /// <returns></returns>
         internal async Task Complete(CancellationToken cancellationToken)
         {
+            if (_binders == null)
+            {
+                return;
+            }
+
             foreach (IValueBinder binder in _binders)
             {
+                if (binder == null)
+                {
+                    continue;
+                }
+
                 // Binding can only be uses for non-Out parameters, and their binders ignore this argument.
                 await binder.SetValueAsync(value: null, cancellationToken: cancellationToken);
             }

--- a/src/Microsoft.Azure.WebJobs.Host/Bindings/Runtime/Binder.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Bindings/Runtime/Binder.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Azure.WebJobs
     /// </summary>
     public class Binder : IBinder, IWatchable, IDisposable
     {
+        private readonly object _bindersLock = new object();
         private readonly IAttributeBindingSource _bindingSource;
         private readonly IList<IValueBinder> _binders = new List<IValueBinder>();
         private readonly RuntimeBindingWatcher _watcher = new RuntimeBindingWatcher();
@@ -53,6 +54,11 @@ namespace Microsoft.Azure.WebJobs
                 }
             }
         }
+
+        /// <summary>
+        /// For testing only.
+        /// </summary>
+        internal IList<IValueBinder> Binders => _binders;
 
         /// <summary>
         /// Gets the binding data.
@@ -133,7 +139,10 @@ namespace Microsoft.Azure.WebJobs
             IValueBinder binder = provider as IValueBinder;
             if (binder != null)
             {
-                _binders.Add(binder);
+                lock (_bindersLock)
+                {
+                    _binders.Add(binder);
+                }
             }
 
             IDisposable disposableProvider = provider as IDisposable;
@@ -153,7 +162,13 @@ namespace Microsoft.Azure.WebJobs
         /// <returns></returns>
         internal async Task Complete(CancellationToken cancellationToken)
         {
-            foreach (IValueBinder binder in _binders)
+            IValueBinder[] binders;
+            lock (_bindersLock)
+            {
+                binders = _binders.ToArray();
+            }
+
+            foreach (IValueBinder binder in binders)
             {
                 // Binding can only be uses for non-Out parameters, and their binders ignore this argument.
                 await binder.SetValueAsync(value: null, cancellationToken: cancellationToken);

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Bindings/Runtime/BinderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Bindings/Runtime/BinderTests.cs
@@ -72,11 +72,7 @@ public class BinderTests
 
         // Because List resizing is not deterministic, another side effect is having a
         // different count of binders than expected.
-        var binders = typeof(Binder)
-            .GetField("_binders", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
-            .GetValue(binder) as IList<IValueBinder>;
-
-        Assert.Equal(numConcurrentThreads * numTasksPerThread, binders.Count);
+        Assert.Equal(numConcurrentThreads * numTasksPerThread, binder.Binders.Count);
     }
 
     private class TestAttribute : Attribute { }

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Bindings/Runtime/BinderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Bindings/Runtime/BinderTests.cs
@@ -37,7 +37,7 @@ public class BinderTests
         var threads = new List<Thread>();
 
         const int numConcurrentThreads = 100;
-        const int numTasksPerThread = 10;
+        const int numTasksPerThread = 100;
 
         // Call BindAsync simultaneously from many threads. There was a race where this would corrupt
         // the internal _binders list.

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Bindings/Runtime/BinderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Bindings/Runtime/BinderTests.cs
@@ -1,0 +1,62 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Azure.WebJobs.Host.Bindings.Runtime;
+using Microsoft.Azure.WebJobs.Host.Protocols;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Host.UnitTests.Bindings.Runtime;
+
+public class BinderTests
+{
+    [Fact]
+    public async Task Complete_AfterConcurrentBinds_ThrowsNullReferenceException()
+    {
+        // Arrange
+        var mockValueBinder = new Mock<IValueBinder>();
+        mockValueBinder.Setup(m => m.Type).Returns(typeof(object));
+
+        var mockBinding = new Mock<IBinding>();
+        mockBinding.Setup(b => b.BindAsync(It.IsAny<BindingContext>())).ReturnsAsync(mockValueBinder.Object);
+        mockBinding.Setup(b => b.ToParameterDescriptor()).Returns(new ParameterDescriptor());
+
+        var mockBindingSource = new Mock<IAttributeBindingSource>();
+        mockBindingSource.Setup(s => s.BindAsync<object>(It.IsAny<Attribute>(), It.IsAny<Attribute[]>(), It.IsAny<CancellationToken>()))
+                         .ReturnsAsync(mockBinding.Object);
+
+        var functionContext = new FunctionBindingContext(Guid.NewGuid(), CancellationToken.None, null);
+        mockBindingSource.Setup(s => s.AmbientBindingContext).Returns(new AmbientBindingContext(functionContext, new Dictionary<string, object>().AsReadOnly()));
+
+        var binder = new Binder(mockBindingSource.Object);
+        var tasks = new List<Task>();
+
+        // Act
+        // Start many concurrent tasks that call _binders.Add(). This is not thread-safe
+        // and can corrupt the internal state of the List<T>, leading to null entries.
+        for (int t = 0; t < 100_000; t++)
+        {
+            tasks.Add(Task.Run(async () =>
+            {
+                for (int i = 0; i < 10; i++)
+                {
+                    await binder.BindAsync<object>(new TestAttribute());
+                }
+            }));
+        }
+
+        await Task.WhenAll(tasks);
+
+        // Now that all concurrent binds are done, call Complete.
+        // If the list's internal state was corrupted by the concurrent Add calls,
+        // this iteration will likely hit a null element.
+        await binder.Complete(CancellationToken.None);
+    }
+
+    private class TestAttribute : Attribute { }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Bindings/Runtime/BinderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Bindings/Runtime/BinderTests.cs
@@ -34,28 +34,49 @@ public class BinderTests
         mockBindingSource.Setup(s => s.AmbientBindingContext).Returns(new AmbientBindingContext(functionContext, new Dictionary<string, object>().AsReadOnly()));
 
         var binder = new Binder(mockBindingSource.Object);
-        var tasks = new List<Task>();
+        var threads = new List<Thread>();
 
-        // Act
-        // Start many concurrent tasks that call _binders.Add(). This is not thread-safe
-        // and can corrupt the internal state of the List<T>, leading to null entries.
-        for (int t = 0; t < 100_000; t++)
+        const int numConcurrentThreads = 100;
+        const int numTasksPerThread = 10;
+
+        // Call BindAsync simultaneously from many threads. There was a race where this would corrupt
+        // the internal _binders list.
+        for (int i = 0; i < numConcurrentThreads; i++)
         {
-            tasks.Add(Task.Run(async () =>
+            threads.Add(new Thread(() =>
             {
-                for (int i = 0; i < 10; i++)
+                var tasks = new List<Task>();
+                for (int t = 0; t < numTasksPerThread; t++)
                 {
-                    await binder.BindAsync<object>(new TestAttribute());
+                    tasks.Add(binder.BindAsync<object>(new TestAttribute()));
                 }
+
+                Task.WaitAll(tasks.ToArray());
             }));
         }
 
-        await Task.WhenAll(tasks);
+        foreach (var thread in threads)
+        {
+            thread.Start();
+        }
+
+        foreach (var thread in threads)
+        {
+            thread.Join();
+        }
 
         // Now that all concurrent binds are done, call Complete.
         // If the list's internal state was corrupted by the concurrent Add calls,
         // this iteration will likely hit a null element.
         await binder.Complete(CancellationToken.None);
+
+        // Because List resizing is not deterministic, another side effect is having a
+        // different count of binders than expected.
+        var binders = typeof(Binder)
+            .GetField("_binders", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+            .GetValue(binder) as IList<IValueBinder>;
+
+        Assert.Equal(numConcurrentThreads * numTasksPerThread, binders.Count);
     }
 
     private class TestAttribute : Attribute { }


### PR DESCRIPTION
For a long time, we've seen a decent number of errors coming from this code with the stack:

```
System.InvalidOperationException : Error while handling parameter _binder after function returned: ---> System.NullReferenceException : Object reference not set to an instance of an object.
   at async Microsoft.Azure.WebJobs.Binder.Complete(CancellationToken cancellationToken) at D:\a\_work\1\s\src\Microsoft.Azure.WebJobs.Host\Bindings\Runtime\Binder.cs : 156
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at async Microsoft.Azure.WebJobs.Host.Bindings.Runtime.RuntimeValueProvider.SetValueAsync(Object value,CancellationToken cancellationToken) at D:\a\_work\1\s\src\Microsoft.Azure.WebJobs.Host\Bindings\Runtime\RuntimeValueProvider.cs : 34
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at async Microsoft.Azure.WebJobs.Host.Executors.FunctionExecutor.ParameterHelper.ProcessOutputParameters(CancellationToken cancellationToken) at D:\a\_work\1\s\src\Microsoft.Azure.WebJobs.Host\Executors\FunctionExecutor.cs : 959
```

~~It's unclear how this is even possible given that the code here can seemingly never be null. But we're going to do some null-checks here to see if we can prevent these exceptions while we continue to investigate.~~

Edit:
We figured out the underlying issue. In Functions if you have multiple input bindings [we call BindAsync() all in parallel](https://github.com/Azure/azure-functions-host/blob/d8ffdbc293d8a424de7f0b89dce2a7a4e56c8c12/src/WebJobs.Script/Description/Workers/WorkerFunctionInvoker.cs?plain=1#L144C13-L158C20). This adds them to the underlying `_binders` list.
 
But `list.Add(item)` isn't thread-safe -- it can cause internal resizing, etc, which means that internally things can be in a bad state. Then later enumerating it can see null items when there should be none. If you use one of these null items, you get a NullRef.

I was confused why the typical "add while enumerating" exceptions weren't being thrown, and it seemed like we would never even be in this state. But now it all makes sense with how Functions calls `BindAsync()` in parallel.

So the issue isn't "adding in one thread while enumerating in another" but it's "adding from multiple threads and then later enumerating". That explains why it never throws "collection was modified".