### PR TITLE
Update Host.Storage to 5.0.2

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host.Storage/Directory.Version.props
+++ b/src/Microsoft.Azure.WebJobs.Host.Storage/Directory.Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>5.0.1</VersionPrefix>
+    <VersionPrefix>5.0.2</VersionPrefix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Needed to unblock release. 5.0.1 already exists and was deleted from our staging feed. Pipeline fails due to that deletion. Just rev'ing as it won't harm anything to push a new version out with no changes.