### PR TITLE
Use SetTag instead of AddTag in ApplyFunctionResultActivityTags

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLogger.cs
@@ -445,7 +445,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                         case LogConstants.DurationKey:
                             if (prop.Value is TimeSpan duration)
                             {
-                                currentActivity.AddTag(LogConstants.FunctionExecutionTimeKey, duration.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
+                                currentActivity.SetTag(LogConstants.FunctionExecutionTimeKey, duration.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
                             }
                             break;
                         default:
@@ -453,15 +453,15 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                             // the passed-in values without any 'prop__' prefix.
                             if (prop.Value != null)
                             {
-                                currentActivity.AddTag(prop.Key, prop.Value.ToString());
+                                currentActivity.SetTag(prop.Key, prop.Value.ToString());
                             }
 
                             break;
                     }
                 }
 
-                currentActivity.AddTag(LogConstants.CategoryNameKey, _categoryName);
-                currentActivity.AddTag(LogConstants.LogLevelKey, logLevel.ToStringOptimized());
+                currentActivity.SetTag(LogConstants.CategoryNameKey, _categoryName);
+                currentActivity.SetTag(LogConstants.LogLevelKey, logLevel.ToStringOptimized());
 
                 if (scope != null)
                 {
@@ -469,7 +469,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                         scope.TryGetValue(ApplicationInsightsScopeKeys.HttpRequest, out var request) &&
                         request is HttpRequest httpRequest)
                     {
-                        currentActivity.AddTag(LoggingConstants.ClientIpKey, GetIpAddress(httpRequest));
+                        currentActivity.SetTag(LoggingConstants.ClientIpKey, GetIpAddress(httpRequest));
                     }
                 }
             }

--- a/src/release_notes.md
+++ b/src/release_notes.md
@@ -1,10 +1,5 @@
 ### What's Changed
 
-### Microsoft.Azure.WebJobs 3.0.43
+### Microsoft.Azure.WebJobs 3.0.44
 
-- fixing race in Binder that can cause NullReferenceExceptions (#3167)
-- Improve FunctionExecutor error handling (#3166)
-- Make LogFunctionScaleError public to use in the extensions (#3164)
-- Fix race condition in ShutdownListener constructor (#3158)
-- Create a function-level request telemetry when none exists (#3146)
-
+- Use `SetTag` instead of `AddTag` in `ApplyFunctionResultActivityTags` (#3171)


### PR DESCRIPTION
This PR switches `Activity.AddTag` to `Activity.SetTag`. This is to mitigate https://github.com/Azure/azure-functions-host/issues/9651. By using `SetTag` we will avoid appending redundant tags to the activity.