### PR TITLE
Update to 3.0.44, add ability to skip Storage on release

### DIFF
--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -3,6 +3,9 @@ parameters:
   displayName: Sign Files (release/* always signed)
   type: boolean
   default: true
+- name: skipStorage
+  type: boolean
+  default: false
 
 trigger:
   batch: true
@@ -67,6 +70,7 @@ extends:
       - template: /eng/ci/templates/jobs/build.yml@self
         parameters:
           official: ${{ variables.sign }}
+          skipStorage: ${{ parameters.skipStorage }}
 
     - stage: Test
       dependsOn: '' # Run in parallel

--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -20,6 +20,7 @@ jobs:
         src\Microsoft.Azure.WebJobs\WebJobs.csproj
         src\Microsoft.Azure.WebJobs.Host\WebJobs.Host.csproj
         src\Microsoft.Azure.WebJobs.Host\WebJobs.Host.Sources.csproj
+        src\Microsoft.Azure.WebJobs.Logging.ApplicationInsights\WebJobs.Logging.ApplicationInsights.csproj
         src\Microsoft.Azure.WebJobs.Rpc.Core\WebJobs.Rpc.Core.csproj
         src\Microsoft.Azure.WebJobs.Extensions.Rpc\WebJobs.Extensions.Rpc.csproj
         test\Microsoft.Azure.WebJobs.Host.TestCommon\WebJobs.Host.TestCommon.csproj
@@ -28,6 +29,7 @@ jobs:
         src\Microsoft.Azure.WebJobs\WebJobs.csproj
         src\Microsoft.Azure.WebJobs.Host\WebJobs.Host.csproj
         src\Microsoft.Azure.WebJobs.Host\WebJobs.Host.Sources.csproj
+        src\Microsoft.Azure.WebJobs.Logging.ApplicationInsights\WebJobs.Logging.ApplicationInsights.csproj
         src\Microsoft.Azure.WebJobs.Rpc.Core\WebJobs.Rpc.Core.csproj
         src\Microsoft.Azure.WebJobs.Extensions.Rpc\WebJobs.Extensions.Rpc.csproj
         src\Microsoft.Azure.WebJobs.Extensions.Storage\WebJobs.Extensions.Storage.csproj

--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -13,6 +13,25 @@ jobs:
   variables:
   - name: pack_dir
     value: $(Build.ArtifactStagingDirectory)/pkg
+  - name: pack_projects
+    readonly: true
+    ${{ if parameters.skipStorage }}:
+      value: |
+        src\Microsoft.Azure.WebJobs\WebJobs.csproj
+        src\Microsoft.Azure.WebJobs.Host\WebJobs.Host.csproj
+        src\Microsoft.Azure.WebJobs.Host\WebJobs.Host.Sources.csproj
+        src\Microsoft.Azure.WebJobs.Rpc.Core\WebJobs.Rpc.Core.csproj
+        src\Microsoft.Azure.WebJobs.Extensions.Rpc\WebJobs.Extensions.Rpc.csproj
+        test\Microsoft.Azure.WebJobs.Host.TestCommon\WebJobs.Host.TestCommon.csproj
+    ${{ else }}:
+      value: |
+        src\Microsoft.Azure.WebJobs\WebJobs.csproj
+        src\Microsoft.Azure.WebJobs.Host\WebJobs.Host.csproj
+        src\Microsoft.Azure.WebJobs.Host\WebJobs.Host.Sources.csproj
+        src\Microsoft.Azure.WebJobs.Rpc.Core\WebJobs.Rpc.Core.csproj
+        src\Microsoft.Azure.WebJobs.Extensions.Rpc\WebJobs.Extensions.Rpc.csproj
+        src\Microsoft.Azure.WebJobs.Extensions.Storage\WebJobs.Extensions.Storage.csproj
+        test\Microsoft.Azure.WebJobs.Host.TestCommon\WebJobs.Host.TestCommon.csproj
 
   templateContext:
     outputParentDirectory: $(Build.ArtifactStagingDirectory)
@@ -65,15 +84,7 @@ jobs:
         command: custom
         custom: pack
         arguments: -c $(configuration) -v m -o $(pack_dir) --no-build
-        projects: |
-          src\Microsoft.Azure.WebJobs\WebJobs.csproj
-          src\Microsoft.Azure.WebJobs.Host\WebJobs.Host.csproj
-          src\Microsoft.Azure.WebJobs.Host\WebJobs.Host.Sources.csproj
-          src\Microsoft.Azure.WebJobs.Rpc.Core\WebJobs.Rpc.Core.csproj
-          src\Microsoft.Azure.WebJobs.Extensions.Rpc\WebJobs.Extensions.Rpc.csproj
-          test\Microsoft.Azure.WebJobs.Host.TestCommon\WebJobs.Host.TestCommon.csproj
-          ${{ if not(parameters.skipStorage) }}:
-            src\Microsoft.Azure.WebJobs.Extensions.Storage\WebJobs.Extensions.Storage.csproj
+        projects: $(pack_projects)
 
     - ${{ if eq(parameters.official, true) }}:
       - template: ci/sign-files.yml@eng

--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -2,6 +2,9 @@ parameters:
 - name: official
   type: boolean
   default: false
+- name: skipStorage
+  type: boolean
+  default: false
 
 jobs:
 - job: build
@@ -66,10 +69,11 @@ jobs:
           src\Microsoft.Azure.WebJobs\WebJobs.csproj
           src\Microsoft.Azure.WebJobs.Host\WebJobs.Host.csproj
           src\Microsoft.Azure.WebJobs.Host\WebJobs.Host.Sources.csproj
-          src\Microsoft.Azure.WebJobs.Host.Storage\WebJobs.Host.Storage.csproj
           src\Microsoft.Azure.WebJobs.Rpc.Core\WebJobs.Rpc.Core.csproj
           src\Microsoft.Azure.WebJobs.Extensions.Rpc\WebJobs.Extensions.Rpc.csproj
           test\Microsoft.Azure.WebJobs.Host.TestCommon\WebJobs.Host.TestCommon.csproj
+          ${{ if not(parameters.skipStorage) }}:
+            src\Microsoft.Azure.WebJobs.Extensions.Storage\WebJobs.Extensions.Storage.csproj
 
     - ${{ if eq(parameters.official, true) }}:
       - template: ci/sign-files.yml@eng

--- a/src/Directory.Version.props
+++ b/src/Directory.Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.0.43</VersionPrefix>
+    <VersionPrefix>3.0.44</VersionPrefix>
     <UpdateBuildNumber>true</UpdateBuildNumber>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Directory.Version.props
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Directory.Version.props
@@ -1,5 +1,0 @@
-<Project>
-  <PropertyGroup>
-    <VersionPrefix>3.0.42</VersionPrefix>
-  </PropertyGroup>
-</Project>

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/WebJobs.Logging.ApplicationInsights.csproj
@@ -9,12 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!--
-    Explicitly referencing a package rather than using a project reference to allow us to release this package 
-    without all of the others in this solution. If changes to WebJobs.Host are needed here, re-introduce the
-    project reference.
-    -->
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.39" />
+    <ProjectReference Include="../Microsoft.Azure.WebJobs.Host/WebJobs.Host.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Bumps version to 3.0.44 to prep release. Also adds a tweak to the build pipeline to allow skipping packing of storage. This is helpful as storage has infrequent version revs.