### PR TITLE
Expose AddFormattableOptionsLogging as public

### DIFF
--- a/src/Directory.Version.props
+++ b/src/Directory.Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.0.44</VersionPrefix>
+    <VersionPrefix>3.1.0</VersionPrefix>
     <UpdateBuildNumber>true</UpdateBuildNumber>
   </PropertyGroup>
 </Project>

--- a/src/Directory.Version.props
+++ b/src/Directory.Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.1.0</VersionPrefix>
+    <VersionPrefix>3.0.45</VersionPrefix>
     <UpdateBuildNumber>true</UpdateBuildNumber>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.Azure.WebJobs.Host/Hosting/OptionsFormatter/OptionsLoggingService.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Hosting/OptionsFormatter/OptionsLoggingService.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Azure.WebJobs.Hosting
         private readonly IOptionsLoggingSource _source;
         private readonly CancellationTokenSource _cts = new CancellationTokenSource();
         private Task _processingTask;
+        private bool _disposed;
 
         public OptionsLoggingService(IOptionsLoggingSource source, ILogger<OptionsLoggingService> logger)
         {
@@ -40,7 +41,11 @@ namespace Microsoft.Azure.WebJobs.Hosting
 
         public void Dispose()
         {
-            _cts.Dispose();
+            if (!_disposed)
+            {
+                _cts.Dispose();
+                _disposed = true;
+            }
         }
 
         private async Task ProcessLogs()

--- a/src/Microsoft.Azure.WebJobs.Host/Hosting/OptionsFormatter/OptionsLoggingService.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Hosting/OptionsFormatter/OptionsLoggingService.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.WebJobs.Hosting
     /// <summary>
     /// An <see cref="IHostedService"/> that streams logs from an <see cref="IOptionsLoggingSource"/> into an <see cref="ILogger"/>.
     /// </summary>
-    internal class OptionsLoggingService : IHostedService
+    internal sealed class OptionsLoggingService : IHostedService, IDisposable
     {
         private readonly ILogger<OptionsLoggingService> _logger;
         private readonly IOptionsLoggingSource _source;
@@ -38,6 +38,11 @@ namespace Microsoft.Azure.WebJobs.Hosting
             await _processingTask;
         }
 
+        public void Dispose()
+        {
+            _cts.Dispose();
+        }
+
         private async Task ProcessLogs()
         {
             ISourceBlock<string> source = _source.LogStream;
@@ -45,7 +50,7 @@ namespace Microsoft.Azure.WebJobs.Hosting
             {
                 while (await source.OutputAvailableAsync(_cts.Token))
                 {
-                    _logger.LogInformation(await source.ReceiveAsync());
+                    _logger.LogInformation(await source.ReceiveAsync(_cts.Token));
                 }
             }
             catch (OperationCanceledException)

--- a/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;

--- a/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsServiceCollectionExtensions.cs
@@ -224,7 +224,7 @@ namespace Microsoft.Azure.WebJobs
             // Must use AddTransient (not TryAdd) so the decorator is the last IOptionsFactory<> registration and wins.
             services.AddTransient(typeof(IOptionsFactory<>), typeof(WebJobsOptionsFactory<>));
             services.TryAddSingleton<IOptionsLoggingSource, OptionsLoggingSource>();
-            services.AddSingleton<IHostedService, OptionsLoggingService>();
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, OptionsLoggingService>());
 
             return services;
         }

--- a/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsServiceCollectionExtensions.cs
@@ -220,8 +220,10 @@ namespace Microsoft.Azure.WebJobs
             }
 
             services.TryAddTransient(typeof(OptionsFactory<>));
+
+            // Must use AddTransient (not TryAdd) so the decorator is the last IOptionsFactory<> registration and wins.
             services.AddTransient(typeof(IOptionsFactory<>), typeof(WebJobsOptionsFactory<>));
-            services.AddSingleton<IOptionsLoggingSource, OptionsLoggingSource>();
+            services.TryAddSingleton<IOptionsLoggingSource, OptionsLoggingSource>();
             services.AddSingleton<IHostedService, OptionsLoggingService>();
 
             return services;

--- a/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsServiceCollectionExtensions.cs
@@ -205,12 +205,31 @@ namespace Microsoft.Azure.WebJobs
             services.AddSingleton<IScaleMetricsRepository, InMemoryScaleMetricsRepository>();
         }
 
-        private static void AddOptionsLogging(this IServiceCollection services)
+        /// <summary>
+        /// Adds options logging infrastructure that automatically logs options when created,
+        /// if the options type implements <see cref="IOptionsFormatter"/> or has a registered
+        /// <see cref="IOptionsFormatter{TOptions}"/>.
+        /// </summary>
+        /// <param name="services">The service collection to which the options logging services will be added.</param>
+        /// <returns>The <see cref="IServiceCollection"/> for chaining.</returns>
+        public static IServiceCollection AddFormattableOptionsLogging(this IServiceCollection services)
         {
-            services.AddTransient(typeof(OptionsFactory<>));
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            services.TryAddTransient(typeof(OptionsFactory<>));
             services.AddTransient(typeof(IOptionsFactory<>), typeof(WebJobsOptionsFactory<>));
             services.AddSingleton<IOptionsLoggingSource, OptionsLoggingSource>();
             services.AddSingleton<IHostedService, OptionsLoggingService>();
+
+            return services;
+        }
+
+        private static void AddOptionsLogging(this IServiceCollection services)
+        {
+            services.AddFormattableOptionsLogging();
             services.AddSingleton<IOptionsFormatter<LoggerFilterOptions>, LoggerFilterOptionsFormatter>();
         }
 

--- a/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsServiceCollectionExtensions.cs
@@ -221,7 +221,7 @@ namespace Microsoft.Azure.WebJobs
 
             services.TryAddTransient(typeof(OptionsFactory<>));
 
-            // Must use AddTransient (not TryAdd) so the decorator is the last IOptionsFactory<> registration and wins.
+            // Must use AddTransient (not TryAddTransient) so the decorator overrides an IOptionsFactory<> already registered.
             services.AddTransient(typeof(IOptionsFactory<>), typeof(WebJobsOptionsFactory<>));
             services.TryAddSingleton<IOptionsLoggingSource, OptionsLoggingSource>();
             services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, OptionsLoggingService>());

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Hosting/AddFormattableOptionsLoggingTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Hosting/AddFormattableOptionsLoggingTests.cs
@@ -1,0 +1,177 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
+using Microsoft.Azure.WebJobs.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Host.UnitTests.Hosting
+{
+    public class AddFormattableOptionsLoggingTests
+    {
+        [Fact]
+        public void NullServices_Throws()
+        {
+            IServiceCollection services = null;
+
+            Assert.Throws<ArgumentNullException>("services", () => services.AddFormattableOptionsLogging());
+        }
+
+        [Fact]
+        public void ResolvedOptionsFactory_IsWebJobsOptionsFactory()
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddFormattableOptionsLogging();
+
+            using ServiceProvider provider = services.BuildServiceProvider();
+            var factory = provider.GetRequiredService<IOptionsFactory<TestOptions>>();
+
+            Assert.IsType<WebJobsOptionsFactory<TestOptions>>(factory);
+        }
+
+        [Fact]
+        public async Task FormattableOptions_AreLoggedViaSource()
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddFormattableOptionsLogging();
+
+            using ServiceProvider provider = services.BuildServiceProvider();
+
+            var source = provider.GetRequiredService<IOptionsLoggingSource>();
+            var factory = provider.GetRequiredService<IOptionsFactory<TestOptions>>();
+
+            factory.Create(Options.DefaultName);
+            source.LogStream.Complete();
+
+            IList<string> logs = new List<string>();
+            while (await source.LogStream.OutputAvailableAsync(CancellationToken.None))
+            {
+                logs.Add(await source.LogStream.ReceiveAsync());
+            }
+
+            string log = Assert.Single(logs);
+            Assert.StartsWith("TestOptions", log);
+            Assert.Contains("\"SomeValue\": \"abc123\"", log);
+        }
+
+        [Fact]
+        public async Task NonFormattableOptions_AreNotLogged()
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddFormattableOptionsLogging();
+
+            using ServiceProvider provider = services.BuildServiceProvider();
+
+            var source = provider.GetRequiredService<IOptionsLoggingSource>();
+            var factory = provider.GetRequiredService<IOptionsFactory<PlainOptions>>();
+
+            factory.Create(Options.DefaultName);
+            source.LogStream.Complete();
+
+            IList<string> logs = new List<string>();
+            while (await source.LogStream.OutputAvailableAsync(CancellationToken.None))
+            {
+                logs.Add(await source.LogStream.ReceiveAsync());
+            }
+
+            Assert.Empty(logs);
+        }
+
+        [Fact]
+        public async Task RegisteredOptionsFormatter_IsUsedForLogging()
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddFormattableOptionsLogging();
+            services.AddSingleton<IOptionsFormatter<PlainOptions>, PlainOptionsFormatter>();
+
+            using ServiceProvider provider = services.BuildServiceProvider();
+
+            var source = provider.GetRequiredService<IOptionsLoggingSource>();
+            var factory = provider.GetRequiredService<IOptionsFactory<PlainOptions>>();
+
+            factory.Create(Options.DefaultName);
+            source.LogStream.Complete();
+
+            IList<string> logs = new List<string>();
+            while (await source.LogStream.OutputAvailableAsync(CancellationToken.None))
+            {
+                logs.Add(await source.LogStream.ReceiveAsync());
+            }
+
+            string log = Assert.Single(logs);
+            Assert.StartsWith("PlainOptions", log);
+            Assert.Contains("\"Value\": \"default\"", log);
+        }
+
+        [Fact]
+        public async Task MultipleCallsDoNotCauseDuplicateLogs()
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddFormattableOptionsLogging();
+            services.AddFormattableOptionsLogging();
+
+            using ServiceProvider provider = services.BuildServiceProvider();
+
+            var source = provider.GetRequiredService<IOptionsLoggingSource>();
+            var factory = provider.GetRequiredService<IOptionsFactory<TestOptions>>();
+
+            factory.Create(Options.DefaultName);
+            source.LogStream.Complete();
+
+            IList<string> logs = new List<string>();
+            while (await source.LogStream.OutputAvailableAsync(CancellationToken.None))
+            {
+                logs.Add(await source.LogStream.ReceiveAsync());
+            }
+
+            string log = Assert.Single(logs);
+            Assert.StartsWith("TestOptions", log);
+        }
+
+        private class TestOptions : IOptionsFormatter
+        {
+            public string SomeValue { get; set; } = "abc123";
+
+            public string Format()
+            {
+                JObject options = new JObject
+                {
+                    { nameof(SomeValue), SomeValue }
+                };
+
+                return options.ToString(Formatting.Indented);
+            }
+        }
+
+        private class PlainOptions
+        {
+            public string Value { get; set; } = "default";
+        }
+
+        private class PlainOptionsFormatter : IOptionsFormatter<PlainOptions>
+        {
+            public string Format(PlainOptions options)
+            {
+                JObject obj = new JObject
+                {
+                    { nameof(options.Value), options.Value }
+                };
+
+                return obj.ToString(Formatting.Indented);
+            }
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Hosting/AddFormattableOptionsLoggingTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Hosting/AddFormattableOptionsLoggingTests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Hosting
             IList<string> logs = new List<string>();
             while (await source.LogStream.OutputAvailableAsync(CancellationToken.None))
             {
-                logs.Add(await source.LogStream.ReceiveAsync());
+                logs.Add(await source.LogStream.ReceiveAsync(CancellationToken.None));
             }
 
             string log = Assert.Single(logs);
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Hosting
             IList<string> logs = new List<string>();
             while (await source.LogStream.OutputAvailableAsync(CancellationToken.None))
             {
-                logs.Add(await source.LogStream.ReceiveAsync());
+                logs.Add(await source.LogStream.ReceiveAsync(CancellationToken.None));
             }
 
             Assert.Empty(logs);
@@ -109,7 +109,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Hosting
             IList<string> logs = new List<string>();
             while (await source.LogStream.OutputAvailableAsync(CancellationToken.None))
             {
-                logs.Add(await source.LogStream.ReceiveAsync());
+                logs.Add(await source.LogStream.ReceiveAsync(CancellationToken.None));
             }
 
             string log = Assert.Single(logs);
@@ -141,7 +141,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Hosting
             IList<string> logs = new List<string>();
             while (await source.LogStream.OutputAvailableAsync(CancellationToken.None))
             {
-                logs.Add(await source.LogStream.ReceiveAsync());
+                logs.Add(await source.LogStream.ReceiveAsync(CancellationToken.None));
             }
 
             string log = Assert.Single(logs);

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Hosting/AddFormattableOptionsLoggingTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Hosting/AddFormattableOptionsLoggingTests.cs
@@ -3,11 +3,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
 using Microsoft.Azure.WebJobs.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -122,6 +124,11 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Hosting
             services.AddLogging();
             services.AddFormattableOptionsLogging();
             services.AddFormattableOptionsLogging();
+
+            // Verify only one OptionsLoggingService is registered despite calling twice.
+            int hostedServiceCount = services
+                .Count(d => d.ServiceType == typeof(IHostedService) && d.ImplementationType == typeof(OptionsLoggingService));
+            Assert.Equal(1, hostedServiceCount);
 
             using ServiceProvider provider = services.BuildServiceProvider();
 


### PR DESCRIPTION
Currently, the existing `AddOptionsLogging` logs options that implement the `IOptionsFormatter` interface, but it is only called inside `AddWebJobs`. This means we only log options created at the ScriptHost level scope.

This PR exposes the options logging registration as a public `IServiceCollection` extension method so consumers like the Azure Functions host can register `IOptionsFormatter<TOptions>` implementations for their own options types and have them logged automatically. This will be useful on the host side to log WebHost-level options such as `LanguageWorkerOptions` and `WorkerConfigurationResolverOptions`.

### Changes

- **`WebJobsServiceCollectionExtensions.cs`**: Extracted core registrations into a new public `AddFormattableOptionsLogging` method.
- **`OptionsLoggingService.cs`**: Marked `sealed`, added `IDisposable` for CTS cleanup, passed cancellation token to `ReceiveAsync`.
- **`AddFormattableOptionsLoggingTests.cs`**: Added unit tests for the new public API.
- **`Directory.Version.props`**: Bumped version from `3.0.44` to `3.0.45`.