### PR TITLE
Fix SingletonListener lock leak when inner listener fails to start

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Singleton/SingletonListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Singleton/SingletonListener.cs
@@ -67,7 +67,15 @@ namespace Microsoft.Azure.WebJobs.Host.Listeners
                 return;
             }
 
-            await _innerListener.StartAsync(cancellationToken);
+            try
+            {
+                await _innerListener.StartAsync(cancellationToken);
+            }
+            catch
+            {
+                await ReleaseLockAsync(cancellationToken);
+                throw;
+            }
 
             _isListening = true;
         }
@@ -132,7 +140,15 @@ namespace Microsoft.Azure.WebJobs.Host.Listeners
                     LockTimer = null;
                 }
 
-                await _innerListener.StartAsync(CancellationToken.None);
+                try
+                {
+                    await _innerListener.StartAsync(CancellationToken.None);
+                }
+                catch
+                {
+                    await ReleaseLockAsync(CancellationToken.None);
+                    throw;
+                }
 
                 _isListening = true;
             }

--- a/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/Singleton/SingletonListenerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.FunctionalTests/Singleton/SingletonListenerTests.cs
@@ -101,6 +101,44 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Singleton
         }
 
         [Fact]
+        public async Task StartAsync_InnerListenerThrows_ReleasesLock()
+        {
+            CancellationToken cancellationToken = new CancellationToken();
+            var lockHandle = new RenewableLockHandle(new SingletonLockHandle(), null);
+            _mockSingletonManager.Setup(p => p.TryLockAsync(_lockId, null, _attribute, cancellationToken, false))
+                .ReturnsAsync(lockHandle);
+            _mockInnerListener.Setup(p => p.StartAsync(cancellationToken)).ThrowsAsync(new InvalidOperationException("Listener failed"));
+            _mockSingletonManager.Setup(p => p.ReleaseLockAsync(lockHandle, cancellationToken)).Returns(Task.FromResult(true));
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _listener.StartAsync(cancellationToken));
+
+            _mockSingletonManager.VerifyAll();
+            _mockInnerListener.VerifyAll();
+        }
+
+        [Fact]
+        public async Task TryAcquireLock_InnerListenerThrows_ReleasesLock()
+        {
+            _listener.LockTimer = new System.Timers.Timer
+            {
+                Interval = 30 * 1000
+            };
+            _listener.LockTimer.Start();
+
+            RenewableLockHandle lockHandle = new RenewableLockHandle(new SingletonLockHandle(), null);
+            _mockSingletonManager.Setup(p => p.TryLockAsync(_lockId, null, _attribute, CancellationToken.None, false))
+                .ReturnsAsync(lockHandle);
+            _mockInnerListener.Setup(p => p.StartAsync(CancellationToken.None)).ThrowsAsync(new InvalidOperationException("Listener failed"));
+            _mockSingletonManager.Setup(p => p.ReleaseLockAsync(lockHandle, CancellationToken.None)).Returns(Task.FromResult(true));
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _listener.TryAcquireLock());
+
+            Assert.Null(_listener.LockTimer);
+            _mockSingletonManager.VerifyAll();
+            _mockInnerListener.VerifyAll();
+        }
+
+        [Fact]
         public async Task TryAcquireLock_WhenLockAcquired_StopsLockTimerAndStartsListener()
         {
             _listener.LockTimer = new System.Timers.Timer


### PR DESCRIPTION
When _innerListener.StartAsync throws (e.g., storage error), the acquired blob lease was never released because _isListening was not set to true, so StopAsync/Dispose would skip the release.

Wrap _innerListener.StartAsync in try-catch in both StartAsync and TryAcquireLock to release the lock on failure, preventing the instance from holding the lease until recycled and blocking all other instances.