### PR TITLE
Don't shadow the Microsoft.Extensions.Logging namespace

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/LoggerExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/LoggerExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Loggers;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Logging
 {

--- a/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/LoggerExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Loggers/Logger/LoggerExtensions.cs
@@ -5,9 +5,8 @@ using System;
 using System.Collections.Generic;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Loggers;
-using Microsoft.Azure.WebJobs.Logging;
 
-namespace Microsoft.Extensions.Logging
+namespace Microsoft.Azure.WebJobs.Logging
 {
     /// <summary>
     /// Extension methods for use with <see cref="ILogger"/>.

--- a/src/Microsoft.Azure.WebJobs.Host/Scale/ConcurrencyStatus.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Scale/ConcurrencyStatus.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Diagnostics;
-using System.Threading;
+using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Host.Scale
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.WebJobs.Host.Scale
                 throw new ArgumentNullException(nameof(functionId));
             }
             FunctionId = functionId;
-            
+
             CurrentConcurrency = 1;
             OutstandingInvocations = 0;
             MaxConcurrentExecutionsSinceLastAdjustment = 0;

--- a/src/Microsoft.Azure.WebJobs.Host/Scale/DefaultHostProcessMonitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Scale/DefaultHostProcessMonitor.cs
@@ -1,12 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-// Some of the logic in this file was moved from https://github.com/Azure/azure-functions-host/blob/852eed9ceef6ef56b431428a8eb31f1bd9c97f3b/src/WebJobs.Script/Scale/HostPerformanceManager.cs 
+// Some of the logic in this file was moved from https://github.com/Azure/azure-functions-host/blob/852eed9ceef6ef56b431428a8eb31f1bd9c97f3b/src/WebJobs.Script/Scale/HostPerformanceManager.cs
 
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 

--- a/src/Microsoft.Azure.WebJobs.Host/Scale/ThreadPoolStarvationThrottleProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Scale/ThreadPoolStarvationThrottleProvider.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading;
+using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Host.Scale


### PR DESCRIPTION
Microsoft.Extensions.Logging.LoggerExtensions is a well-known class provided by Microsoft.Extensions.Logging.Abstractions.
The Webjobs SDK should not shadow it. While code continues to work fine in practice, it does end up breaking the builtin .NET analyzers that trigger on suboptimal logger usage.

Fixes #2995