### PR TITLE
Remove duplicate target scaler vote log from ScaleManager

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Scale/ScaleManager.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Scale/ScaleManager.cs
@@ -190,7 +190,6 @@ namespace Microsoft.Azure.WebJobs.Host.Scale
                                 TargetWorkerCount = context.WorkerCount
                             };
                         }
-                        _logger.LogFunctionScaleVote(targetScaler.TargetScalerDescriptor.FunctionId, result.TargetWorkerCount);
                         targetScaleVotes.Add(targetScaler.TargetScalerDescriptor.FunctionId, result);
                     }
                     catch (Exception exc)

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Scale/ScaleManagerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Scale/ScaleManagerTests.cs
@@ -171,7 +171,6 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Scale
             {
                 Assert.Equal("1 target scalers to sample", logs[0].FormattedMessage);
                 Assert.Equal("Snapshot dynamic concurrency for target scaler 'func1' is '1'", logs[1].FormattedMessage);
-                Assert.Equal("Function 'func1' vote: TargetWorkerCount='2'.", logs[2].FormattedMessage);
                 Assert.Equal(ScaleVote.ScaleIn, status.Vote);
                 Assert.Equal(2, status.TargetWorkerCount);
             }
@@ -258,10 +257,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Scale
             var logs = _loggerProvider.GetAllLogMessages().ToArray();
             Assert.Equal("3 target scalers to sample", logs[0].FormattedMessage);
             Assert.Equal($"Snapshot dynamic concurrency for target scaler 'func1' is '1'", logs[1].FormattedMessage);
-            Assert.Equal("Function 'func1' vote: TargetWorkerCount='3'.", logs[2].FormattedMessage);
-            Assert.Equal("Function 'func2' error: Failed to get target scaler vote.", logs[3].FormattedMessage);
-            Assert.Same("test", logs[3].Exception.Message);
-            Assert.Equal("Function 'func3' vote: TargetWorkerCount='-3'.", logs[4].FormattedMessage);
+            Assert.Equal("Function 'func2' error: Failed to get target scaler vote.", logs[2].FormattedMessage);
+            Assert.Same("test", logs[2].Exception.Message);
 
             Assert.Equal(3, status.TargetWorkerCount);
             Assert.Equal(ScaleVote.None, status.Vote);


### PR DESCRIPTION
## Remove duplicate target scaler vote log from ScaleManager

### Problem

The ScaleManager logs 'Function X vote: TargetWorkerCount=N.' (EventId 8002) after each target scaler call. However, the individual extension target scalers already log the same information with more context:

- **EventHubs** [EventHubsTargetScaler.cs#L111](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubsTargetScaler.cs#L111): Target worker count for function X is N (EventHubName, EventCount, Concurrency, PartitionCount)
- **ServiceBus** [ServiceBusTargetScaler.cs#L111](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusTargetScaler.cs#L111): Target worker count for function X is N (EntityPath, MessageCount, Concurrency)

This produces duplicate log entries every polling cycle per function, adding noise to customer App Insights and platform Kusto telemetry.

### Changes

- **ScaleManager.cs**: Removed the redundant LogFunctionScaleVote call for target scalers (was at line 193). The extension-level logs provide strictly more information.
- **ScaleManagerTests.cs**: Updated test assertions that checked for the now-removed log line, adjusting log array indices.

### Testing

- All 24 ScaleManagerTests pass
- All 10 ScaleLoggerExtensionTests pass