### PR TITLE
Register ITargetScalerErrorRepository in AddCommonScaleServices and make public

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsServiceCollectionExtensions.cs
@@ -203,6 +203,7 @@ namespace Microsoft.Azure.WebJobs
                 });
             services.TryAddSingleton<IScaleMonitorManager, ScaleMonitorManager>();
             services.TryAddSingleton<ITargetScalerManager, TargetScalerManager>();
+            services.TryAddSingleton<ITargetScalerErrorRepository, NullTargetScalerErrorRepository>();
             services.TryAddSingleton<IScaleStatusProvider, ScaleManager>();
             services.AddHostedService<ScaleMonitorService>();
             services.AddSingleton<IScaleMetricsRepository, InMemoryScaleMetricsRepository>();

--- a/src/Microsoft.Azure.WebJobs.Host/Scale/ITargetScalerErrorRepository.cs
+++ b/src/Microsoft.Azure.WebJobs.Host/Scale/ITargetScalerErrorRepository.cs
@@ -8,11 +8,10 @@ using System.Threading.Tasks;
 namespace Microsoft.Azure.WebJobs.Host.Scale
 {
     /// <summary>
-    /// Provides functionality for persisting target scaler errors across multiple host instances.
-    /// When a target scaler throws <see cref="System.NotSupportedException"/>, the scaler identifier
-    /// is recorded so all instances can fall back to incremental scale monitoring.
+    /// Provides functionality for persisting target scaler errors.
+    /// Used by <see cref="IScaleMonitor"/> to track scalers that are in a faulted state.
     /// </summary>
-    internal interface ITargetScalerErrorRepository
+    public interface ITargetScalerErrorRepository
     {
         /// <summary>
         /// Adds a target scaler identifier to the set of scalers in error.

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/PublicSurfaceTests.cs
@@ -280,6 +280,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests
                 "SupportsRetryAttribute",
                 "AppServicesHostingUtility",
                 "ITargetScaler",
+                "ITargetScalerErrorRepository",
                 "ITargetScalerManager",
                 "ITargetScalerProvider",
                 "TargetScalerDescriptor",


### PR DESCRIPTION
## Summary

Fix missing DI registration in AddCommonScaleServices and make ITargetScalerErrorRepository public so external consumers can implement it directly.

## Problem

SDK 3.0.46 (PR #3191) introduced ITargetScalerErrorRepository as a required dependency of ScaleManager. However, the TryAddSingleton registration was only added in AddWebJobs(). Callers using ConfigureWebJobsScale (e.g. Scale Controller) go through AddWebJobsScale -> AddCommonScaleServices, which was missing this registration, causing:

    Unable to resolve service for type 'ITargetScalerErrorRepository'
    while attempting to activate 'ScaleManager'

Making the interface public allows Scale Controller to provide its own in-memory implementation that tracks errored target scalers within the process lifetime, so broken scalers fall back to incremental monitoring without retrying every cycle.

## Changes

- **AddCommonScaleServices**: Add TryAddSingleton for ITargetScalerErrorRepository so all scale host scenarios have a safe default
- **ITargetScalerErrorRepository**: Change from internal to public so external consumers can implement it directly
- **PublicSurfaceTests**: Add ITargetScalerErrorRepository to expected public types

## Testing

- All existing tests pass including PublicSurfaceTests
