### PR TITLE
Strip _MS.AggregationIntervalMs from custom metrics when EnableMetricsCustomDimensionOptimization is enabled

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Constants/LoggingConstants.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Constants/LoggingConstants.cs
@@ -9,12 +9,6 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
         public const string Unknown = "[Unknown]";
         public const string ClientIpKey = "ClientIp";
         public const string HostInstanceIdKey = "HostInstanceId";
-
-        // Property added by the Application Insights SDK metric aggregation pipeline
-        // (e.g. when metrics are emitted via TelemetryClient.GetMetric(...).TrackValue(...)).
-        // This dimension is no longer published on custom metrics once migrated to the
-        // OpenTelemetry exporter, so it is stripped when EnableMetricsCustomDimensionOptimization
-        // is enabled to keep behavior consistent across exporters.
         public const string AggregationIntervalMsKey = "_MS.AggregationIntervalMs";
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Constants/LoggingConstants.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Constants/LoggingConstants.cs
@@ -9,5 +9,12 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
         public const string Unknown = "[Unknown]";
         public const string ClientIpKey = "ClientIp";
         public const string HostInstanceIdKey = "HostInstanceId";
+
+        // Property added by the Application Insights SDK metric aggregation pipeline
+        // (e.g. when metrics are emitted via TelemetryClient.GetMetric(...).TrackValue(...)).
+        // This dimension is no longer published on custom metrics once migrated to the
+        // OpenTelemetry exporter, so it is stripped when EnableMetricsCustomDimensionOptimization
+        // is enabled to keep behavior consistent across exporters.
+        public const string AggregationIntervalMsKey = "_MS.AggregationIntervalMs";
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/WebJobsTelemetryInitializer.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Initializers/WebJobsTelemetryInitializer.cs
@@ -58,6 +58,12 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
             {
                 // Remove the Host instance ID property, since it's not needed.
                 telemetryContext.Properties.Remove(LoggingConstants.HostInstanceIdKey);
+
+                // Remove the AggregationIntervalMs dimension. This dimension is added by the
+                // Application Insights SDK metric aggregation pipeline and is not published on
+                // custom metrics by the OpenTelemetry exporter, so we strip it for consistency
+                // when the custom dimension optimization is enabled.
+                telemetryContext.Properties.Remove(LoggingConstants.AggregationIntervalMsKey);
                 return;
             }
             else

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/WebJobsTelemetryInitializerTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/WebJobsTelemetryInitializerTests.cs
@@ -127,6 +127,53 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
         }
 
         [Fact]
+        public void Initializer_RemovesAggregationIntervalMs_OnMetricTelemetry_WhenOptimizationEnabled()
+        {
+            var metric = new MetricTelemetry("metric", 1.0);
+            metric.Properties["_MS.AggregationIntervalMs"] = "60000";
+            metric.Properties["HostInstanceId"] = Guid.NewGuid().ToString();
+            metric.Properties["custom"] = "value";
+
+            var options = new ApplicationInsightsLoggerOptions { EnableMetricsCustomDimensionOptimization = true };
+            var initializer = new WebJobsTelemetryInitializer(new WebJobsSdkVersionProvider(), new WebJobsRoleInstanceProvider(), Options.Create(options));
+
+            initializer.Initialize(metric);
+
+            Assert.False(metric.Properties.ContainsKey("_MS.AggregationIntervalMs"));
+            Assert.False(metric.Properties.ContainsKey("HostInstanceId"));
+            Assert.True(metric.Properties.ContainsKey("custom"));
+        }
+
+        [Fact]
+        public void Initializer_PreservesAggregationIntervalMs_OnMetricTelemetry_WhenOptimizationDisabled()
+        {
+            var metric = new MetricTelemetry("metric", 1.0);
+            metric.Properties["_MS.AggregationIntervalMs"] = "60000";
+
+            var options = new ApplicationInsightsLoggerOptions { EnableMetricsCustomDimensionOptimization = false };
+            var initializer = new WebJobsTelemetryInitializer(new WebJobsSdkVersionProvider(), new WebJobsRoleInstanceProvider(), Options.Create(options));
+
+            initializer.Initialize(metric);
+
+            Assert.True(metric.Properties.ContainsKey("_MS.AggregationIntervalMs"));
+            Assert.Equal("60000", metric.Properties["_MS.AggregationIntervalMs"]);
+        }
+
+        [Fact]
+        public void Initializer_DoesNotRemoveAggregationIntervalMs_OnNonMetricTelemetry()
+        {
+            var trace = new TraceTelemetry("hello");
+            trace.Properties["_MS.AggregationIntervalMs"] = "60000";
+
+            var options = new ApplicationInsightsLoggerOptions { EnableMetricsCustomDimensionOptimization = true };
+            var initializer = new WebJobsTelemetryInitializer(new WebJobsSdkVersionProvider(), new WebJobsRoleInstanceProvider(), Options.Create(options));
+
+            initializer.Initialize(trace);
+
+            Assert.True(trace.Properties.ContainsKey("_MS.AggregationIntervalMs"));
+        }
+
+        [Fact]
         public void Initializer_SetsRoleInstance()
         {
             var request = new RequestTelemetry { Name = "custom" };


### PR DESCRIPTION
## Summary

When `ApplicationInsightsLoggerOptions.EnableMetricsCustomDimensionOptimization` is `true`, the `WebJobsTelemetryInitializer` now also strips the `_MS.AggregationIntervalMs` custom dimension from `MetricTelemetry` items, in addition to the existing `HostInstanceId` removal.

`_MS.AggregationIntervalMs` is added by the Application Insights classic SDK's metric-aggregation pipeline (`MetricAggregateToApplicationInsightsPipelineConverterBase.ConvertAggregateToTelemetry` sets it before calling `TelemetryClient.Track`). The OpenTelemetry Azure Monitor exporter does not emit this dimension on custom metrics, so this change brings the classic SDK output into parity with the OTel exporter when the optimization flag is enabled (default-off).

## Why

`_MS.AggregationIntervalMs` provides no user-facing diagnostic value but is projected as a custom dimension onto every pre-aggregated custom metric, where it acts as a high-cardinality multiplier on every unique timeseries. Production telemetry from a Logic Apps Standard / Application Insights deployment shows the impact:

- The dimension takes **66 distinct values** per metric (varying aggregation intervals in ms), exploding timeseries counts via the cross-product.
- Across all classic-SDK workloads on a single Application Insights resource (24h sample): **64,559 unique timeseries** today vs. an estimated **9,122** without this dimension — an **85.9%** reduction.
- For Logic Apps Standard specifically: **30,752 → 1,738** unique timeseries (**94.3%** reduction); 96.5% of timeseries today carry this dimension.
- The resulting **6x–13x per-region multiplier** drives breaches of the Azure Monitor 50,000-active-timeseries-per-subscription-region custom metrics quota.

Independent confirmation that the dimension is purely a classic-SDK artifact:

- Inspection of the Azure Monitor OTel exporter source (`MetricHelper.cs`) shows it only copies `metricPoint.Tags` into properties and never sets `_MS.AggregationIntervalMs`.
- Workloads migrated from the classic SDK to the OTel exporter (AKS pods, Container Apps) showed **0 records** with `_MS.AggregationIntervalMs` across 100M+ datapoints/day; rolling OTel back caused the dimension to reappear at 42–48% of metrics within hours, and re-deploying OTel dropped it back to 0.

This change brings the classic SDK to parity for workloads that opt in via `EnableMetricsCustomDimensionOptimization`, dropping their active timeseries well within quota without losing any meaningful diagnostic information.

## Pipeline ordering

The Application Insights SDK pipeline runs `ITelemetryInitializer.Initialize` inside `TelemetryClient.Track`, before the processor chain and the channel:

```
SDK aggregator sets _MS.AggregationIntervalMs on MetricTelemetry
  → TelemetryClient.Track(item)
  → ITelemetryInitializer.Initialize  ← WebJobsTelemetryInitializer removes the dimension here
  → ITelemetryProcessor chain
  → ITelemetryChannel.Send             (serialized envelope, no _MS.AggregationIntervalMs)
```

## Changes

- `Constants/LoggingConstants.cs` — add `AggregationIntervalMsKey = "_MS.AggregationIntervalMs"`, matching the style of the existing `HostInstanceIdKey` constant.
- `Initializers/WebJobsTelemetryInitializer.cs` — when `EnableMetricsCustomDimensionOptimization` is enabled and the telemetry item is a `MetricTelemetry`, also remove `LoggingConstants.AggregationIntervalMsKey` from `Properties`.
- `test/.../Loggers/WebJobsTelemetryInitializerTests.cs` — three new unit tests covering: removal when optimization is enabled, preservation when disabled, and that non-metric telemetry (`TraceTelemetry`) is unaffected.

## Behavior

- Default (`EnableMetricsCustomDimensionOptimization = false`): unchanged.
- When opted in: `MetricTelemetry` items leaving the channel will not carry `_MS.AggregationIntervalMs` regardless of whether the dimension was added by `TelemetryClient.GetMetric(...).TrackValue(...)` aggregation or by `AutocollectedMetricsExtractor`. Other telemetry types are unaffected.

## Tests

- New unit tests pass; all 35 tests in `WebJobsTelemetryInitializerTests` and `ApplicationInsightsLoggerTests` pass.
- Build succeeds with no new warnings.