### PR TITLE
Add configurable MaxTelemetryBufferDelay to ApplicationInsightsLoggerOptions

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
@@ -170,9 +170,16 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
         /// <summary>
         /// Gets or sets the maximum time telemetry is buffered by the <c>ServerTelemetryChannel</c> before it is sent
         /// to the ingestion endpoint. Lowering this value reduces the delay before telemetry becomes visible, at the
-        /// cost of more frequent network calls. The default value is 8 seconds and the minimum is 5 seconds.
+        /// cost of more frequent network calls. The default value is 8 seconds and the minimum is 5 seconds
+        /// (see <see cref="MinTelemetryBufferDelay"/>).
         /// </summary>
         public TimeSpan MaxTelemetryBufferDelay { get; set; } = TimeSpan.FromSeconds(8);
+
+        /// <summary>
+        /// The minimum allowed value for <see cref="MaxTelemetryBufferDelay"/>. This is the single source of truth
+        /// shared by the option's documentation and the validation performed when the channel is configured.
+        /// </summary>
+        internal static readonly TimeSpan MinTelemetryBufferDelay = TimeSpan.FromSeconds(5);
 
         public string Format()
         {

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
@@ -170,7 +170,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
         /// <summary>
         /// Gets or sets the maximum time telemetry is buffered by the <c>ServerTelemetryChannel</c> before it is sent
         /// to the ingestion endpoint. Lowering this value reduces the delay before telemetry becomes visible, at the
-        /// cost of more frequent network calls. The default value is 8 seconds.
+        /// cost of more frequent network calls. The default value is 8 seconds and the minimum is 5 seconds.
         /// </summary>
         public TimeSpan MaxTelemetryBufferDelay { get; set; } = TimeSpan.FromSeconds(8);
 

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/ApplicationInsightsLoggerOptions.cs
@@ -167,6 +167,13 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
         /// </summary>
         public TimeSpan AdaptiveSamplingInitializationDelay { get; set; } = TimeSpan.FromSeconds(15);
 
+        /// <summary>
+        /// Gets or sets the maximum time telemetry is buffered by the <c>ServerTelemetryChannel</c> before it is sent
+        /// to the ingestion endpoint. Lowering this value reduces the delay before telemetry becomes visible, at the
+        /// cost of more frequent network calls. The default value is 8 seconds.
+        /// </summary>
+        public TimeSpan MaxTelemetryBufferDelay { get; set; } = TimeSpan.FromSeconds(8);
+
         public string Format()
         {
             JObject sampling = null;
@@ -260,6 +267,7 @@ namespace Microsoft.Azure.WebJobs.Logging.ApplicationInsights
                 { nameof(EnableMetricsCustomDimensionOptimization), EnableMetricsCustomDimensionOptimization },
                 { nameof(EnableAdaptiveSamplingDelay), EnableAdaptiveSamplingDelay },
                 { nameof(AdaptiveSamplingInitializationDelay), AdaptiveSamplingInitializationDelay },
+                { nameof(MaxTelemetryBufferDelay), MaxTelemetryBufferDelay },
             };
 
             return options.ToString(Formatting.Indented);

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
@@ -334,7 +334,11 @@ namespace Microsoft.Extensions.DependencyInjection
                 }
             }
 
-            (channel as ServerTelemetryChannel)?.Initialize(configuration);
+            if (channel is ServerTelemetryChannel serverTelemetryChannel)
+            {
+                serverTelemetryChannel.MaxTelemetryBufferDelay = options.MaxTelemetryBufferDelay;
+                serverTelemetryChannel.Initialize(configuration);
+            }
 
             QuickPulseTelemetryModule quickPulseModule = null;
             foreach (ITelemetryModule module in telemetryModules)

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
@@ -336,6 +336,14 @@ namespace Microsoft.Extensions.DependencyInjection
 
             if (channel is ServerTelemetryChannel serverTelemetryChannel)
             {
+                if (options.MaxTelemetryBufferDelay <= TimeSpan.Zero)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        $"{nameof(ApplicationInsightsLoggerOptions)}.{nameof(ApplicationInsightsLoggerOptions.MaxTelemetryBufferDelay)}",
+                        options.MaxTelemetryBufferDelay,
+                        $"{nameof(ApplicationInsightsLoggerOptions.MaxTelemetryBufferDelay)} must be a positive TimeSpan.");
+                }
+
                 serverTelemetryChannel.MaxTelemetryBufferDelay = options.MaxTelemetryBufferDelay;
                 serverTelemetryChannel.Initialize(configuration);
             }

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
@@ -33,8 +33,6 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     internal static class ApplicationInsightsServiceCollectionExtensions
     {
-        private static readonly TimeSpan MinTelemetryBufferDelay = TimeSpan.FromSeconds(5);
-
         public static IServiceCollection AddApplicationInsights(this IServiceCollection services)
         {
             return services.AddApplicationInsights(_ => { }, _ => { });
@@ -337,12 +335,12 @@ namespace Microsoft.Extensions.DependencyInjection
 
             if (channel is ServerTelemetryChannel serverTelemetryChannel)
             {
-                if (options.MaxTelemetryBufferDelay < MinTelemetryBufferDelay)
+                if (options.MaxTelemetryBufferDelay < ApplicationInsightsLoggerOptions.MinTelemetryBufferDelay)
                 {
                     throw new ArgumentOutOfRangeException(
                         nameof(ApplicationInsightsLoggerOptions.MaxTelemetryBufferDelay),
                         options.MaxTelemetryBufferDelay,
-                        $"{nameof(ApplicationInsightsLoggerOptions.MaxTelemetryBufferDelay)} must be at least {MinTelemetryBufferDelay.TotalSeconds} seconds.");
+                        $"{nameof(ApplicationInsightsLoggerOptions.MaxTelemetryBufferDelay)} must be at least {ApplicationInsightsLoggerOptions.MinTelemetryBufferDelay.TotalSeconds} seconds.");
                 }
 
                 serverTelemetryChannel.MaxTelemetryBufferDelay = options.MaxTelemetryBufferDelay;

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
@@ -340,7 +340,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 if (options.MaxTelemetryBufferDelay < MinTelemetryBufferDelay)
                 {
                     throw new ArgumentOutOfRangeException(
-                        $"{nameof(ApplicationInsightsLoggerOptions)}.{nameof(ApplicationInsightsLoggerOptions.MaxTelemetryBufferDelay)}",
+                        nameof(ApplicationInsightsLoggerOptions.MaxTelemetryBufferDelay),
                         options.MaxTelemetryBufferDelay,
                         $"{nameof(ApplicationInsightsLoggerOptions.MaxTelemetryBufferDelay)} must be at least {MinTelemetryBufferDelay.TotalSeconds} seconds.");
                 }

--- a/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     internal static class ApplicationInsightsServiceCollectionExtensions
     {
+        private static readonly TimeSpan MinTelemetryBufferDelay = TimeSpan.FromSeconds(5);
 
         public static IServiceCollection AddApplicationInsights(this IServiceCollection services)
         {
@@ -336,12 +337,12 @@ namespace Microsoft.Extensions.DependencyInjection
 
             if (channel is ServerTelemetryChannel serverTelemetryChannel)
             {
-                if (options.MaxTelemetryBufferDelay <= TimeSpan.Zero)
+                if (options.MaxTelemetryBufferDelay < MinTelemetryBufferDelay)
                 {
                     throw new ArgumentOutOfRangeException(
                         $"{nameof(ApplicationInsightsLoggerOptions)}.{nameof(ApplicationInsightsLoggerOptions.MaxTelemetryBufferDelay)}",
                         options.MaxTelemetryBufferDelay,
-                        $"{nameof(ApplicationInsightsLoggerOptions.MaxTelemetryBufferDelay)} must be a positive TimeSpan.");
+                        $"{nameof(ApplicationInsightsLoggerOptions.MaxTelemetryBufferDelay)} must be at least {MinTelemetryBufferDelay.TotalSeconds} seconds.");
                 }
 
                 serverTelemetryChannel.MaxTelemetryBufferDelay = options.MaxTelemetryBufferDelay;

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
@@ -189,6 +189,30 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
         }
 
         [Fact]
+        public void DependencyInjectionConfiguration_MaxTelemetryBufferDelay_BindsFromConfiguration()
+        {
+            using (var host = CreateHost(
+                configureLogging: (c, b) =>
+                {
+                    // This is how logging config sections are registered by applications (e.g. host.json).
+                    b.AddConfiguration(c.Configuration.GetSection("Logging"));
+                },
+                configureConfiguration: b =>
+                {
+                    b.AddInMemoryCollection(new Dictionary<string, string>
+                    {
+                        { $"Logging:{ApplicationInsightsLoggerProvider.Alias}:{nameof(ApplicationInsightsLoggerOptions.MaxTelemetryBufferDelay)}", "00:00:10" }
+                    });
+                }))
+            {
+                var config = host.Services.GetService<TelemetryConfiguration>();
+
+                var channel = Assert.IsType<ServerTelemetryChannel>(config.TelemetryChannel);
+                Assert.Equal(TimeSpan.FromSeconds(10), channel.MaxTelemetryBufferDelay);
+            }
+        }
+
+        [Fact]
         public void DependencyInjectionConfiguration_Configures_With_ConnectionString()
         {
             var builder = new HostBuilder()

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
@@ -143,8 +143,10 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             }
         }
 
-        [Fact]
-        public void DependencyInjectionConfiguration_MaxTelemetryBufferDelay_CanBeOverridden()
+        [Theory]
+        [InlineData(5)]
+        [InlineData(20)]
+        public void DependencyInjectionConfiguration_MaxTelemetryBufferDelay_CanBeOverridden(int seconds)
         {
             var builder = new HostBuilder()
                 .ConfigureLogging(b =>
@@ -152,7 +154,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                     b.AddApplicationInsightsWebJobs(o =>
                     {
                         o.InstrumentationKey = "some key";
-                        o.MaxTelemetryBufferDelay = TimeSpan.FromSeconds(20);
+                        o.MaxTelemetryBufferDelay = TimeSpan.FromSeconds(seconds);
                     });
                 });
 
@@ -161,14 +163,16 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                 var config = host.Services.GetService<TelemetryConfiguration>();
 
                 var channel = Assert.IsType<ServerTelemetryChannel>(config.TelemetryChannel);
-                Assert.Equal(TimeSpan.FromSeconds(20), channel.MaxTelemetryBufferDelay);
+                Assert.Equal(TimeSpan.FromSeconds(seconds), channel.MaxTelemetryBufferDelay);
             }
         }
 
         [Theory]
         [InlineData(0)]
         [InlineData(-5)]
-        public void DependencyInjectionConfiguration_MaxTelemetryBufferDelay_ThrowsForNonPositiveValue(int seconds)
+        [InlineData(1)]
+        [InlineData(4)]
+        public void DependencyInjectionConfiguration_MaxTelemetryBufferDelay_ThrowsForValueBelowMinimum(int seconds)
         {
             var builder = new HostBuilder()
                 .ConfigureLogging(b =>

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
@@ -126,6 +126,46 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
         }
 
         [Fact]
+        public void DependencyInjectionConfiguration_MaxTelemetryBufferDelay_DefaultsTo8Seconds()
+        {
+            var builder = new HostBuilder()
+                .ConfigureLogging(b =>
+                {
+                    b.AddApplicationInsightsWebJobs(o => o.InstrumentationKey = "some key");
+                });
+
+            using (var host = builder.Build())
+            {
+                var config = host.Services.GetService<TelemetryConfiguration>();
+
+                var channel = Assert.IsType<ServerTelemetryChannel>(config.TelemetryChannel);
+                Assert.Equal(TimeSpan.FromSeconds(8), channel.MaxTelemetryBufferDelay);
+            }
+        }
+
+        [Fact]
+        public void DependencyInjectionConfiguration_MaxTelemetryBufferDelay_CanBeOverridden()
+        {
+            var builder = new HostBuilder()
+                .ConfigureLogging(b =>
+                {
+                    b.AddApplicationInsightsWebJobs(o =>
+                    {
+                        o.InstrumentationKey = "some key";
+                        o.MaxTelemetryBufferDelay = TimeSpan.FromSeconds(20);
+                    });
+                });
+
+            using (var host = builder.Build())
+            {
+                var config = host.Services.GetService<TelemetryConfiguration>();
+
+                var channel = Assert.IsType<ServerTelemetryChannel>(config.TelemetryChannel);
+                Assert.Equal(TimeSpan.FromSeconds(20), channel.MaxTelemetryBufferDelay);
+            }
+        }
+
+        [Fact]
         public void DependencyInjectionConfiguration_Configures_With_ConnectionString()
         {
             var builder = new HostBuilder()

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
@@ -184,7 +184,8 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
                     });
                 });
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => builder.Build());
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => builder.Build());
+            Assert.Equal(nameof(ApplicationInsightsLoggerOptions.MaxTelemetryBufferDelay), exception.ParamName);
         }
 
         [Fact]

--- a/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Host.UnitTests/Loggers/ApplicationInsightsConfigurationTests.cs
@@ -165,6 +165,24 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Loggers
             }
         }
 
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-5)]
+        public void DependencyInjectionConfiguration_MaxTelemetryBufferDelay_ThrowsForNonPositiveValue(int seconds)
+        {
+            var builder = new HostBuilder()
+                .ConfigureLogging(b =>
+                {
+                    b.AddApplicationInsightsWebJobs(o =>
+                    {
+                        o.InstrumentationKey = "some key";
+                        o.MaxTelemetryBufferDelay = TimeSpan.FromSeconds(seconds);
+                    });
+                });
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => builder.Build());
+        }
+
         [Fact]
         public void DependencyInjectionConfiguration_Configures_With_ConnectionString()
         {


### PR DESCRIPTION
Fixes #3209

Adds `MaxTelemetryBufferDelay` (`TimeSpan`, default 8s) to `ApplicationInsightsLoggerOptions`, applied to the `ServerTelemetryChannel` in `SetupTelemetryConfiguration`. Because the options class binds to host.json `logging:applicationInsights`, the flush interval is now configurable like `DiagnosticsEventListenerLogLevel`:

```json
{ "logging": { "applicationInsights": { "maxTelemetryBufferDelay": "00:00:08" } } }
```

### Changes
- New `MaxTelemetryBufferDelay` option (default 8s) on `ApplicationInsightsLoggerOptions`, included in `Format()`.
- Applied to the channel in `SetupTelemetryConfiguration`.
- Unit tests: default 8s + override.
