### PR TITLE
Onboard azure-webjobs-sdk to Central Feed Service

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -2,7 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="AzureFunctionsTempStaging" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsTempStaging/nuget/v3/index.json" />
+    <add key="upstream-public" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/eng/ci/templates/steps/install-dotnet.yml
+++ b/eng/ci/templates/steps/install-dotnet.yml
@@ -11,3 +11,6 @@ steps:
   inputs:
     packageType: sdk
     useGlobalJson: true
+
+- task: NuGetAuthenticate@1
+  displayName: Authenticate NuGet feeds


### PR DESCRIPTION
## Summary
- route all repository NuGet restores through the Central Feed Service `upstream-public` proxy
- remove direct nuget.org and unused AzureFunctionsTempStaging sources
- authenticate NuGet feeds in the shared Azure Pipelines .NET bootstrap before explicit and implicit restores

## Validation
- `dotnet restore WebJobs.sln --configfile NuGet.Config --verbosity minimal`
- `dotnet nuget list source --configfile NuGet.Config`
- `git diff --check`

## Audit scope
- all committed NuGet configuration and .NET projects
- all repository-owned Azure Pipelines YAML/templates and restore-capable jobs
- npm and Python dependency surfaces (not used by this repository)